### PR TITLE
[BE] Notion 저장 모델 성능 실험 하네스 구현

### DIFF
--- a/backend/PERFORMANCE_EXPERIMENT.md
+++ b/backend/PERFORMANCE_EXPERIMENT.md
@@ -1,0 +1,93 @@
+# Notion 저장 모델 성능 실험
+
+## 목표
+
+Notion API 구조를 관계형 A안 DDL에 저장했을 때 발생하는 시드·조회·메모리 비용을 재현한다. 같은 논리 문서를 Batch 조회, Render Snapshot, Compact JSONB 모델로 읽어 개선 정도와 새 비용을 함께 비교한다.
+
+현재 백엔드에는 Notion Importer와 운영 Entity/Repository/API가 구현되어 있지 않다. 따라서 이 단계는 전체 A안 DDL을 생성하되 Page/Block/Rich Text/Mention/Snapshot 수직 슬라이스를 합성 SQL로 채우는 **DB 저장 모델 실험**이다. `SEED_LOAD`는 실제 Notion Import 처리량이나 앱 HTTP 응답 시간이 아니다. Importer와 조회 API가 생기면 같은 fixture를 서비스/API 경로로 통과시키는 2단계 측정을 추가한다.
+
+`baseline-a.sql`은 현재 v2.1 DDL을 복제한다. 원본에서 삭제 정책을 생략한 두 FK(`workspaces.created_by_user_id`, `notion_connections.connected_by_user_id`)만 프로젝트 DB 규칙에 따라 기본 `NO ACTION`과 이 실험의 조회·삽입 결과가 같은 `ON DELETE RESTRICT`를 명시했다.
+
+## 비교군
+
+| 이름 | 설명 |
+| --- | --- |
+| `N_PLUS_ONE` | Block 목록 조회 후 Block마다 Rich Text를 다시 조회한다. |
+| `BATCH` | 정규화된 A안 데이터를 set 기반 단일 조회로 조립한다. |
+| `SNAPSHOT_GENERATE` | Batch 결과를 `page_render_snapshots`에 생성한다. |
+| `SNAPSHOT_READ` | Render Snapshot 한 Row를 읽는다. |
+| `COMPACT` | JSONB payload와 `position_key`를 가진 비교 테이블을 읽는다. |
+| `INTEGER_REORDER` | 정수 순서를 범위 UPDATE한다. |
+| `POSITION_KEY_REORDER` | 이동 Block 한 Row의 문자열 순서 키만 변경한다. |
+
+모든 읽기 비교군은 SHA-256으로 같은 논리 JSON을 반환하는지 검증한다. Snapshot 생성은 조회 개선과 분리해 생성 시간·WAL·저장 크기를 측정한다.
+
+## 데이터와 자원 매트릭스
+
+- 논리 Block: `1,000`, `10,000`, `100,000`
+- PostgreSQL hard memory: `1,024MiB`, `512MiB`, `256MiB`
+- swap: 비활성화
+- PostgreSQL: 18.4
+- Rich Text: Block당 3 Segment, 10% Mention
+- Raw Snapshot: Page와 모든 Block에 한 건
+- 반복: 기본 3회, warm-up 1회
+- 동시 순서 변경: 10명, 50명
+
+실제 운영·고객 데이터는 사용하지 않는다. 데이터는 고정 seed와 결정적 SQL로 생성한다.
+
+## 실행
+
+빠른 검증:
+
+```bash
+./gradlew performanceTest \
+  -Dperformance.sizes=1000 \
+  -Dperformance.memoryMiB=512 \
+  -Dperformance.iterations=1 \
+  -Dperformance.warmups=0 \
+  -Dperformance.concurrency=10
+```
+
+전체 실험:
+
+```bash
+./gradlew performanceTest \
+  -Dperformance.sizes=1000,10000,100000 \
+  -Dperformance.memoryMiB=1024,512,256 \
+  -Dperformance.iterations=3 \
+  -Dperformance.warmups=1 \
+  -Dperformance.concurrency=10,50
+```
+
+결과는 `build/reports/performance/latest`에 생성된다.
+
+```text
+latest/
+├── environment.json
+├── metrics.csv
+├── metrics.json
+├── summary.md
+├── jvm.jfr
+└── query-plans/
+```
+
+## 판정 기준
+
+- 같은 dataset·seed·메모리 제한에서만 개선율을 계산한다.
+- 읽기 시간에는 JDBC 조회, JVM 객체 조립, JSON 생성을 포함한다. Spring/JPA/HTTP/커넥션 풀 비용은 포함하지 않는다.
+- `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)`으로 SQL 실행계획을 보존한다.
+- JVM heap peak와 PostgreSQL cgroup `memory.current`, `memory.peak`, `memory.events`를 기록한다.
+- OOM, timeout, deadlock은 숨기지 않고 결과 행의 관측 상태로 남긴다.
+- A안·Snapshot·Compact가 같은 DB에 공존하므로 cgroup OOM은 통합 비교 fixture의 한계다. 모델별 단독 용량 한계는 별도 컨테이너 실험이 필요하다.
+- Snapshot은 읽기 시간만이 아니라 생성 시간, 크기, WAL을 함께 평가한다.
+- Docker Desktop 결과는 운영 절대 성능이 아니라 같은 환경에서의 상대 비교 근거로 사용한다.
+
+## 2단계 앱·Importer 경로 실험 조건
+
+다음 구현물이 생기면 이 하네스의 합성 fixture를 그대로 재사용한다.
+
+1. Notion API payload를 Knot 저장 모델로 변환하는 Importer 경계
+2. 운영 Entity/Repository/Service와 페이지 조회 API
+3. 앱 컨테이너와 DB 커넥션 풀 설정
+
+이때 `Notion fixture → Importer → DB → Service/Repository → HTTP JSON`을 측정하고, 현재 JDBC 결과와 비교해 매핑·ORM·직렬화·네트워크 비용을 분리한다. 실제 익명화 fixture가 확보되기 전에는 “Notion DB 전체를 그대로 마이그레이션한 앱 성능”으로 일반화하지 않는다.

--- a/backend/PERFORMANCE_RESULTS.md
+++ b/backend/PERFORMANCE_RESULTS.md
@@ -1,0 +1,66 @@
+# Notion 저장 모델 성능 실험 결과
+
+## 결론
+
+현재 A안 DDL의 Page/Block/Rich Text/Mention/Snapshot 수직 슬라이스에서 N+1 조회와 정수 범위 재정렬은 데이터 증가에 따라 명확한 병목을 만들었다. 반면 set 기반 Batch 조회만으로 조회 병목 대부분이 해소되었으며, Render Snapshot과 Compact JSONB는 이 fixture에서 Batch보다 항상 빠르지 않았다.
+
+- N+1은 10만 Block에서 p50 `24.612초`, SQL `100,001회`였다.
+- Batch는 같은 논리 JSON을 p50 `0.274초`, SQL `1회`로 반환해 N+1 대비 `98.9%` 단축했다.
+- Snapshot Read는 10만 Block에서 p50 `0.292초`로 Batch보다 `6.6%` 느렸다. Snapshot 생성은 `0.863초`, SQL 2회, WAL 약 `2.50MB`가 추가됐다.
+- Compact JSONB는 10만 Block에서 p50 `0.276초`로 Batch와 사실상 비슷했고 `0.8%` 느렸다. 이 결과만으로 Rich Text 정규화 테이블 삭제를 정당화할 수 없다.
+- 정수 범위 재정렬은 10만 Block에서 50,000행과 WAL 약 `51.9MB`를 만들었다. 한 Row 순서 키 변경은 1행과 WAL 약 `475KB`였다.
+- 10만 Block 동시 정수 재정렬은 동시성 10에서 7/10, 동시성 50에서 48/50 요청이 5초 lock timeout 안에 실패했다. 순서 키 방식은 두 조건에서 모두 실패 0건이었다.
+- PostgreSQL 1GiB 제한에서는 10만 Block 통합 비교 실험을 완료했지만 `memory.events max=10,180`으로 한계 압박이 있었다. 512MiB와 256MiB에서는 A안·Snapshot·Compact를 함께 만드는 시드 중 `oom_kill=1`로 종료됐다. 이 결과는 컨테이너 제한 작동 증거지만 A안 단독 용량 한계는 아니다.
+
+## 대표 측정값
+
+아래 값은 PostgreSQL 1GiB, warm-up 1회, 본 측정 3회의 p50이다.
+
+| 논리 Block | N+1 | Batch | Snapshot Read | Compact JSONB | N+1 → Batch |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 227.866ms | 4.347ms | 5.782ms | 5.338ms | 98.1% 단축 |
+| 10,000 | 2,176.988ms | 31.606ms | 22.140ms | 33.653ms | 98.5% 단축 |
+| 100,000 | 24,611.515ms | 273.931ms | 291.989ms | 276.043ms | 98.9% 단축 |
+
+| 논리 Block | 정수 범위 재정렬 | 순서 키 한 Row | 변경 행 | WAL |
+| ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 14.475ms | 2.575ms | 500 → 1 | 469,568B → 5,192B |
+| 10,000 | 99.803ms | 24.475ms | 5,000 → 1 | 4,739,632B → 47,856B |
+| 100,000 | 1,010.721ms | 108.803ms | 50,000 → 1 | 51,933,584B → 474,560B |
+
+## 판정
+
+### 지금 해결해야 하는 것
+
+1. 서버가 Block마다 Rich Text를 재조회하는 N+1 구현을 금지한다.
+2. 정규화 모델을 유지하더라도 한 번의 set 기반 조회 또는 제한된 수의 Bulk 조회로 문서를 조립한다.
+3. Knot 편집기의 양방향 순서 변경을 고려해 정수 범위 갱신 대신 한 Row만 바꾸는 순서 키를 설계한다.
+4. 10만 Block 통합 비교 fixture는 PostgreSQL 1GiB에서도 메모리 압박이 크므로, 저장 모델별 독립 컨테이너와 실제 앱 경로에서 문서 크기 제한·페이지네이션·lazy fetch 경계를 재측정한다.
+
+### 이번 실험으로 확정할 수 없는 것
+
+1. A안의 모든 48개 테이블을 실제 Notion DB 분포대로 채운 결과가 아니다. 실험 스키마를 포함해 49개 테이블을 생성했지만 Page/Block/Rich Text/Mention/Snapshot 중심의 합성 수직 슬라이스만 채웠다. 원본에서 삭제 정책을 생략한 두 FK에는 프로젝트 규칙상 `ON DELETE RESTRICT`를 명시했으며 조회·삽입 실험에는 영향을 주지 않는다.
+2. `SEED_LOAD`는 합성 SQL 시드 비용이다. Notion API 호출, Importer 매핑, 재시도, 멱등 저장 성능이 아니다.
+3. Spring Entity/Repository/Service/API가 아직 없어 JPA, 커넥션 풀, HTTP 직렬화와 앱 컨테이너 메모리는 측정하지 않았다.
+4. 모든 Block이 한 Page의 직계 자식인 wide-tree fixture다. deep-tree lazy fetch 성능은 별도 fixture가 필요하다.
+5. 로컬 Docker Desktop 결과는 운영 환경의 절대 SLA가 아니라 같은 환경에서 대안을 비교하는 근거다.
+6. A안, Snapshot과 Compact 비교 데이터가 같은 DB에 공존한다. 512/256MiB OOM을 A안 단독 저장 용량 문제로 일반화할 수 없다.
+
+## 후속 실험
+
+운영 Importer와 조회 API가 구현되면 같은 결정적 fixture를 `Notion payload → Importer → PostgreSQL → Repository/Service → HTTP JSON` 경로로 통과시킨다. DB 하네스 수치와 비교해 Import 매핑, ORM, 커넥션 풀, 앱 객체 조립, 직렬화 비용을 분리하고 앱 컨테이너에도 256/512/1024MiB 제한을 적용한다. 실제 익명화 Notion fixture가 확보되면 block-heavy, property-heavy, relation-heavy, mixed workspace 프로필을 추가한다.
+
+## 재현
+
+실험 계획과 명령은 `PERFORMANCE_EXPERIMENT.md`에 있다. 원시 결과는 실행 후 `build/reports/performance/latest`의 `metrics.csv`, `metrics.json`, `jvm.jfr`, `query-plans/`에 생성된다.
+
+최종 실행 조건:
+
+```bash
+./gradlew performanceTest \
+  -Dperformance.sizes=1000,10000,100000 \
+  -Dperformance.memoryMiB=1024,512,256 \
+  -Dperformance.iterations=3 \
+  -Dperformance.warmups=1 \
+  -Dperformance.concurrency=10,50
+```

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,6 +48,22 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+sourceSets {
+	performanceTest {
+		java.setSrcDirs(['src/performanceTest/java'])
+		resources.setSrcDirs(['src/performanceTest/resources'])
+		compileClasspath += sourceSets.main.output + configurations.compileClasspath + configurations.testCompileClasspath
+		runtimeClasspath += output + compileClasspath + configurations.runtimeClasspath + configurations.testRuntimeClasspath
+	}
+}
+
+configurations {
+	performanceTestImplementation.extendsFrom implementation
+	performanceTestImplementation.extendsFrom testImplementation
+	performanceTestRuntimeOnly.extendsFrom runtimeOnly
+	performanceTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 spotless {
 	java {
 		googleJavaFormat().aosp()
@@ -89,6 +105,38 @@ tasks.register('acceptanceTest', Test) {
 	}
 
 	shouldRunAfter integrationTest
+}
+
+tasks.register('performanceTest', Test) {
+	group = 'verification'
+	description = 'Runs the isolated Notion storage performance experiment.'
+
+	testClassesDirs = sourceSets.performanceTest.output.classesDirs
+	classpath = sourceSets.performanceTest.runtimeClasspath
+
+	useJUnitPlatform {
+		includeTags 'performance'
+	}
+
+	outputs.upToDateWhen { false }
+
+	System.properties.findAll { key, ignored -> key.toString().startsWith('performance.') }
+			.each { key, value -> systemProperty key, value }
+
+	String performanceOutputDirectory = layout.buildDirectory
+			.dir('reports/performance/latest')
+			.get()
+			.asFile
+			.absolutePath
+	systemProperty 'performance.outputDir', performanceOutputDirectory
+	maxHeapSize = System.getProperty('performance.heap', '2g')
+	jvmArgs "-XX:StartFlightRecording=filename=${performanceOutputDirectory}/jvm.jfr,settings=profile,dumponexit=true"
+
+	doFirst {
+		mkdir performanceOutputDirectory
+	}
+
+	shouldRunAfter acceptanceTest
 }
 
 tasks.named('check') {

--- a/backend/src/performanceTest/java/com/knot/backend/performance/NotionStoragePerformanceTest.java
+++ b/backend/src/performanceTest/java/com/knot/backend/performance/NotionStoragePerformanceTest.java
@@ -1,0 +1,2083 @@
+package com.knot.backend.performance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.HostConfig;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+@Tag("performance")
+class NotionStoragePerformanceTest {
+    private static final DockerImageName POSTGRES_IMAGE = DockerImageName.parse("postgres:18.4");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final int RICH_TEXT_SEGMENTS_PER_BLOCK = 3;
+    private static final int DEFAULT_PAGE_OBJECT_ID = 1;
+    private static final long DATASET_SEED = 20260812L;
+    private static final String BASELINE_SQL = "performance/baseline-a.sql";
+    private static final String EXPERIMENT_SQL = "performance/experiment-schema.sql";
+    private static final String POSITION_KEY_REORDER_SQL =
+            "UPDATE experiment_compact_blocks SET position_key = ? WHERE source_block_object_id = "
+                    + "(SELECT source_block_object_id FROM experiment_compact_blocks "
+                    + "WHERE page_object_id = ? ORDER BY position_key OFFSET ? LIMIT 1)";
+    private final Path outputDirectory;
+
+    NotionStoragePerformanceTest() {
+        outputDirectory =
+                Path.of(
+                        System.getProperty(
+                                "performance.outputDir", "build/reports/performance/latest"));
+    }
+
+    @Test
+    void notion_ddl_storage_models_are_measured_under_memory_limits() throws Exception {
+        // given
+        PerformanceProperties properties = PerformanceProperties.fromSystemProperties();
+        ReportWriter reportWriter = new ReportWriter(outputDirectory);
+
+        // when
+        PerformanceReport report = runExperimentMatrix(properties);
+
+        // then
+        reportWriter.write(report);
+        assertEquals(0, report.failedLogicalEquivalenceCount());
+        assertEquals(0, report.invalidMatrixCount());
+    }
+
+    private PerformanceReport runExperimentMatrix(PerformanceProperties properties)
+            throws Exception {
+        PerformanceReport report = new PerformanceReport(properties);
+        for (int memoryMiB : properties.memoryMiB()) {
+            for (int blockCount : properties.sizes()) {
+                runDatasetExperiment(properties, report, memoryMiB, blockCount);
+            }
+        }
+        return report;
+    }
+
+    private void runDatasetExperiment(
+            PerformanceProperties properties,
+            PerformanceReport report,
+            int memoryMiB,
+            int blockCount)
+            throws Exception {
+        PostgreSQLContainer<?> container = createContainer(memoryMiB);
+        try {
+            container.start();
+            ActiveDatabase.connect(
+                    container.getJdbcUrl(), container.getUsername(), container.getPassword());
+            try (Connection connection = openConnection(container)) {
+                configureSession(connection);
+                applySchema(connection);
+                report.add(
+                        environmentMetric(
+                                "RESOURCE_AFTER_START", memoryMiB, blockCount, container));
+                DatasetContext datasetContext = loadDataset(connection, blockCount);
+                report.add(datasetContext.metric(memoryMiB));
+                report.add(
+                        resourceMetric(
+                                "RESOURCE_AFTER_SEED",
+                                memoryMiB,
+                                blockCount,
+                                container,
+                                connection));
+                runReadMeasurements(properties, report, connection, memoryMiB, blockCount);
+                report.add(
+                        resourceMetric(
+                                "RESOURCE_AFTER_READS",
+                                memoryMiB,
+                                blockCount,
+                                container,
+                                connection));
+                runReorderMeasurements(properties, report, connection, memoryMiB, blockCount);
+                report.add(
+                        resourceMetric(
+                                "RESOURCE_AFTER_MATRIX",
+                                memoryMiB,
+                                blockCount,
+                                container,
+                                connection));
+            }
+        } catch (Exception exception) {
+            if (isOomKilled(container)) {
+                report.add(Metric.resourceLimit(memoryMiB, blockCount, "MATRIX", exception));
+            } else {
+                report.add(Metric.failure(memoryMiB, blockCount, "MATRIX", exception));
+            }
+        } finally {
+            report.add(
+                    containerStateMetric(
+                            "RESOURCE_BEFORE_CONTAINER_STOP", memoryMiB, blockCount, container));
+            container.stop();
+        }
+    }
+
+    private PostgreSQLContainer<?> createContainer(int memoryMiB) {
+        long memoryBytes = memoryMiB * 1024L * 1024L;
+        int sharedBuffersMiB = Math.max(32, memoryMiB / 4);
+        return new PostgreSQLContainer<>(POSTGRES_IMAGE)
+                .withDatabaseName("knot_performance")
+                .withUsername("knot")
+                .withPassword("knot")
+                .withStartupTimeout(Duration.ofSeconds(60))
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(60)))
+                .withCommand(
+                        "postgres",
+                        "-c",
+                        "shared_buffers=" + sharedBuffersMiB + "MB",
+                        "-c",
+                        "work_mem=2MB",
+                        "-c",
+                        "max_connections=64",
+                        "-c",
+                        "track_io_timing=on")
+                .withCreateContainerCmdModifier(
+                        command -> {
+                            HostConfig hostConfig = command.getHostConfig();
+                            if (hostConfig == null) {
+                                hostConfig = new HostConfig();
+                            }
+                            command.withHostConfig(
+                                    hostConfig.withMemory(memoryBytes).withMemorySwap(memoryBytes));
+                        });
+    }
+
+    private Connection openConnection(PostgreSQLContainer<?> container) throws SQLException {
+        return DriverManager.getConnection(
+                container.getJdbcUrl(), container.getUsername(), container.getPassword());
+    }
+
+    private void configureSession(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET lock_timeout = '5s'");
+            statement.execute("SET statement_timeout = '60s'");
+        }
+    }
+
+    private void applySchema(Connection connection) throws SQLException {
+        executeSqlResource(connection, BASELINE_SQL);
+        executeSqlResource(connection, EXPERIMENT_SQL);
+    }
+
+    private void executeSqlResource(Connection connection, String resourceName)
+            throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(readResource(resourceName));
+        }
+    }
+
+    private DatasetContext loadDataset(Connection connection, int blockCount) throws Exception {
+        Instant startedAt = Instant.now();
+        SqlCounter sqlCounter = new SqlCounter();
+        String walStart = currentWalLsn(connection);
+        connection.setAutoCommit(false);
+        try {
+            long userId =
+                    insertReturningId(
+                            connection,
+                            "INSERT INTO users (email, name) VALUES (?, ?) RETURNING id",
+                            "performance-" + blockCount + "@example.test",
+                            "Performance User");
+            sqlCounter.increment();
+            long workspaceId =
+                    insertReturningId(
+                            connection,
+                            "INSERT INTO workspaces (name, created_by_user_id) VALUES (?, ?) RETURNING id",
+                            "Performance Workspace",
+                            userId);
+            sqlCounter.increment();
+            insert(
+                    connection,
+                    "INSERT INTO workspace_members (workspace_id, user_id, member_role) VALUES (?, ?, ?)",
+                    workspaceId,
+                    userId,
+                    "OWNER");
+            sqlCounter.increment();
+            long connectionId =
+                    insertReturningId(
+                            connection,
+                            "INSERT INTO notion_connections "
+                                    + "(workspace_id, connected_by_user_id, bot_id, notion_workspace_id, "
+                                    + "notion_workspace_name, encrypted_access_token) "
+                                    + "VALUES (?, ?, ?, ?, ?, ?) RETURNING id",
+                            workspaceId,
+                            userId,
+                            "bot-" + blockCount,
+                            "workspace-" + blockCount,
+                            "Workspace",
+                            "[REDACTED]");
+            sqlCounter.increment();
+            long notionUserId =
+                    insertReturningId(
+                            connection,
+                            "INSERT INTO notion_users (notion_connection_id, notion_user_id, user_type, name) "
+                                    + "VALUES (?, ?, ?, ?) RETURNING id",
+                            connectionId,
+                            "notion-user-" + blockCount,
+                            "PERSON",
+                            "Writer");
+            sqlCounter.increment();
+            long titleRichTextId =
+                    insertReturningId(
+                            connection,
+                            "INSERT INTO rich_text_contents DEFAULT VALUES RETURNING id");
+            sqlCounter.increment();
+            long pageObjectId =
+                    insertObject(
+                            connection,
+                            workspaceId,
+                            connectionId,
+                            null,
+                            "page-" + blockCount,
+                            "PAGE",
+                            0,
+                            notionUserId);
+            sqlCounter.increment();
+            insert(
+                    connection,
+                    "INSERT INTO pages (object_id, title_rich_text_id, plain_title) VALUES (?, ?, ?)",
+                    pageObjectId,
+                    titleRichTextId,
+                    "Performance Page " + blockCount);
+            sqlCounter.increment();
+            insertPageSnapshot(connection, connectionId, blockCount);
+            sqlCounter.increment();
+            insertBlockRichTextContents(connection, blockCount);
+            sqlCounter.increment();
+            insertBlockObjects(
+                    connection, blockCount, workspaceId, connectionId, pageObjectId, notionUserId);
+            sqlCounter.increment();
+            insertBlockRows(connection);
+            sqlCounter.increment();
+            insertBlockRichTextFields(connection);
+            sqlCounter.increment();
+            insertRichTextSegments(connection);
+            sqlCounter.increment();
+            insertRichTextMentions(connection, pageObjectId);
+            sqlCounter.increment();
+            insertBlockSnapshots(connection, blockCount, connectionId);
+            sqlCounter.increment();
+            JsonNode documentJson = assembleDocumentBatch(connection, pageObjectId).json();
+            insert(
+                    connection,
+                    "INSERT INTO page_render_snapshots "
+                            + "(page_object_id, document_json, source_updated_at) VALUES (?, ?::jsonb, now())",
+                    pageObjectId,
+                    documentJson.toString());
+            sqlCounter.increment();
+            insertCompactBlocks(connection, pageObjectId);
+            sqlCounter.increment();
+            connection.commit();
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("ANALYZE");
+            }
+            long elapsedMillis = Duration.between(startedAt, Instant.now()).toMillis();
+            long walBytes = walBytesBetween(connection, walStart, currentWalLsn(connection));
+            long estimatedPhysicalRows =
+                    queryLong(
+                            connection,
+                            "SELECT COALESCE(SUM(reltuples), 0)::bigint FROM pg_class "
+                                    + "WHERE relnamespace = 'public'::regnamespace AND relkind = 'r'");
+            long schemaTableCount =
+                    queryLong(
+                            connection,
+                            "SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public'");
+            return new DatasetContext(
+                    pageObjectId,
+                    connectionId,
+                    blockCount,
+                    elapsedMillis,
+                    sqlCounter.count(),
+                    walBytes,
+                    estimatedPhysicalRows,
+                    schemaTableCount);
+        } catch (Exception exception) {
+            connection.rollback();
+            throw exception;
+        } finally {
+            connection.setAutoCommit(true);
+        }
+    }
+
+    private long insertObject(
+            Connection connection,
+            long workspaceId,
+            long connectionId,
+            Long parentObjectId,
+            String notionObjectId,
+            String objectType,
+            int positionIndex,
+            long notionUserId)
+            throws SQLException {
+        return insertReturningId(
+                connection,
+                "INSERT INTO objects "
+                        + "(workspace_id, notion_connection_id, parent_object_id, external_parent_type, "
+                        + "external_parent_notion_id, parent_payload, notion_object_id, object_type, "
+                        + "source_type, position_index, created_by_notion_user_id, updated_by_notion_user_id, "
+                        + "notion_created_at, notion_updated_at) "
+                        + "VALUES (?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?, ?, now(), now()) RETURNING id",
+                workspaceId,
+                connectionId,
+                parentObjectId,
+                parentObjectId == null ? "workspace" : "page_id",
+                parentObjectId == null ? null : "page-parent",
+                "{\"type\":\"synthetic\"}",
+                notionObjectId,
+                objectType,
+                "NOTION",
+                positionIndex,
+                notionUserId,
+                notionUserId);
+    }
+
+    private void insertSnapshot(
+            Connection connection,
+            long connectionId,
+            String notionObjectId,
+            String objectType,
+            String payload)
+            throws SQLException {
+        insert(
+                connection,
+                "INSERT INTO notion_object_snapshots "
+                        + "(notion_connection_id, notion_object_id, object_type, api_version, raw_payload) "
+                        + "VALUES (?, ?, ?, ?, ?::jsonb)",
+                connectionId,
+                notionObjectId,
+                objectType,
+                "2025-09-03",
+                payload);
+    }
+
+    private void insertPageSnapshot(Connection connection, long connectionId, int blockCount)
+            throws SQLException {
+        insertSnapshot(
+                connection, connectionId, "page-" + blockCount, "PAGE", pagePayload(blockCount));
+    }
+
+    private void insertBlockRichTextContents(Connection connection, int blockCount)
+            throws SQLException {
+        execute(
+                connection,
+                "INSERT INTO rich_text_contents SELECT FROM generate_series(0, ? - 1)",
+                blockCount);
+    }
+
+    private void insertBlockObjects(
+            Connection connection,
+            int blockCount,
+            long workspaceId,
+            long connectionId,
+            long pageObjectId,
+            long notionUserId)
+            throws SQLException {
+        execute(
+                connection,
+                """
+                        INSERT INTO objects (
+                            workspace_id,
+                            notion_connection_id,
+                            parent_object_id,
+                            external_parent_type,
+                            external_parent_notion_id,
+                            parent_payload,
+                            notion_object_id,
+                            object_type,
+                            source_type,
+                            position_index,
+                            created_by_notion_user_id,
+                            updated_by_notion_user_id,
+                            notion_created_at,
+                            notion_updated_at
+                        )
+                        SELECT
+                            ?,
+                            ?,
+                            ?,
+                            'page_id',
+                            'page-parent',
+                            '{"type":"synthetic"}'::jsonb,
+                            'block-' || ? || '-' || index,
+                            'BLOCK',
+                            'NOTION',
+                            index,
+                            ?,
+                            ?,
+                            now(),
+                            now()
+                        FROM generate_series(0, ? - 1) AS generated(index)
+                        ORDER BY index
+                        """,
+                workspaceId,
+                connectionId,
+                pageObjectId,
+                blockCount,
+                notionUserId,
+                notionUserId,
+                blockCount);
+    }
+
+    private void insertBlockRows(Connection connection) throws SQLException {
+        execute(
+                connection,
+                """
+                        INSERT INTO blocks (object_id, block_type, has_children, block_payload)
+                        SELECT
+                            id,
+                            CASE
+                                WHEN position_index % 17 = 0 THEN 'heading_2'
+                                WHEN position_index % 11 = 0 THEN 'to_do'
+                                WHEN position_index % 7 = 0 THEN 'image'
+                                ELSE 'paragraph'
+                            END,
+                            position_index % 100 = 0,
+                            jsonb_build_object(
+                                'type',
+                                CASE
+                                    WHEN position_index % 17 = 0 THEN 'heading_2'
+                                    WHEN position_index % 11 = 0 THEN 'to_do'
+                                    WHEN position_index % 7 = 0 THEN 'image'
+                                    ELSE 'paragraph'
+                                END,
+                                'position',
+                                position_index,
+                                'seed',
+                                ?
+                            )
+                        FROM objects
+                        WHERE object_type = 'BLOCK'
+                        ORDER BY position_index
+                        """,
+                DATASET_SEED);
+    }
+
+    private void insertBlockRichTextFields(Connection connection) throws SQLException {
+        execute(
+                connection,
+                """
+                        INSERT INTO block_rich_text_fields (block_object_id, field_name, rich_text_content_id)
+                        SELECT id, 'rich_text', id
+                        FROM objects
+                        WHERE object_type = 'BLOCK'
+                        ORDER BY position_index
+                        """);
+    }
+
+    private void insertRichTextSegments(Connection connection) throws SQLException {
+        execute(
+                connection,
+                """
+                        INSERT INTO rich_text_segments (
+                            rich_text_content_id,
+                            position_index,
+                            segment_type,
+                            plain_text,
+                            text_content,
+                            annotations,
+                            segment_payload
+                        )
+                        SELECT
+                            o.id,
+                            segment_index,
+                            CASE WHEN o.position_index % 10 = 0 AND segment_index = 0 THEN 'mention' ELSE 'text' END,
+                            'block-' || o.position_index || '-segment-' || segment_index,
+                            'block-' || o.position_index || '-segment-' || segment_index,
+                            '{"bold":false,"italic":false}'::jsonb,
+                            '{"source":"synthetic"}'::jsonb
+                        FROM objects o
+                        CROSS JOIN generate_series(0, ? - 1) AS segment(segment_index)
+                        WHERE o.object_type = 'BLOCK'
+                        ORDER BY o.position_index, segment_index
+                        """,
+                RICH_TEXT_SEGMENTS_PER_BLOCK);
+    }
+
+    private void insertRichTextMentions(Connection connection, long pageObjectId)
+            throws SQLException {
+        execute(
+                connection,
+                """
+                        INSERT INTO rich_text_mentions (
+                            rich_text_segment_id,
+                            mention_type,
+                            target_page_object_id,
+                            mention_payload
+                        )
+                        SELECT rts.id, 'PAGE', ?, '{"synthetic":true}'::jsonb
+                        FROM rich_text_segments rts
+                        JOIN objects o ON o.id = rts.rich_text_content_id
+                        WHERE o.position_index % 10 = 0 AND rts.position_index = 0
+                        """,
+                pageObjectId);
+    }
+
+    private void insertBlockSnapshots(Connection connection, int blockCount, long connectionId)
+            throws SQLException {
+        execute(
+                connection,
+                """
+                        INSERT INTO notion_object_snapshots (
+                            notion_connection_id,
+                            notion_object_id,
+                            object_type,
+                            api_version,
+                            raw_payload
+                        )
+                        SELECT
+                            ?,
+                            'block-' || ? || '-' || position_index,
+                            'BLOCK',
+                            '2025-09-03',
+                            block_payload
+                        FROM objects o
+                        JOIN blocks b ON b.object_id = o.id
+                        WHERE o.object_type = 'BLOCK'
+                        ORDER BY o.position_index
+                        """,
+                connectionId,
+                blockCount);
+    }
+
+    private void insertCompactBlocks(Connection connection, long pageObjectId) throws SQLException {
+        execute(
+                connection,
+                """
+                INSERT INTO experiment_compact_blocks (
+                    page_object_id,
+                    source_block_object_id,
+                    parent_block_object_id,
+                    position_key,
+                    block_type,
+                    payload
+                )
+                WITH rich_text_by_block AS (
+                    SELECT
+                        brtf.block_object_id,
+                        jsonb_agg(
+                            jsonb_strip_nulls(
+                                jsonb_build_object(
+                                    'position', rts.position_index,
+                                    'plainText', rts.plain_text,
+                                    'mentionType', rtm.mention_type
+                                )
+                            )
+                            ORDER BY rts.position_index
+                        ) AS rich_text
+                    FROM block_rich_text_fields brtf
+                    JOIN rich_text_segments rts
+                        ON rts.rich_text_content_id = brtf.rich_text_content_id
+                    LEFT JOIN rich_text_mentions rtm
+                        ON rtm.rich_text_segment_id = rts.id
+                    GROUP BY brtf.block_object_id
+                )
+                SELECT
+                    ?,
+                    o.id,
+                    COALESCE(o.parent_object_id, ?),
+                    lpad((o.position_index * 1024)::text, 12, '0'),
+                    b.block_type,
+                    jsonb_build_object(
+                        'position',
+                        o.position_index,
+                        'richText',
+                        COALESCE(rich_text_by_block.rich_text, '[]'::jsonb)
+                    )
+                FROM objects o
+                JOIN blocks b ON b.object_id = o.id
+                LEFT JOIN rich_text_by_block ON rich_text_by_block.block_object_id = o.id
+                WHERE o.object_type = 'BLOCK'
+                ORDER BY o.position_index
+                """,
+                pageObjectId,
+                pageObjectId);
+    }
+
+    private void runReadMeasurements(
+            PerformanceProperties properties,
+            PerformanceReport report,
+            Connection connection,
+            int memoryMiB,
+            int blockCount)
+            throws Exception {
+        DocumentResult reference = assembleDocumentBatch(connection, DEFAULT_PAGE_OBJECT_ID);
+        String referenceHash = sha256(canonicalJson(reference.json()));
+        report.add(measureSnapshotGenerate(connection, memoryMiB, blockCount));
+        for (ReadModel readModel : ReadModel.values()) {
+            captureExplain(connection, report, memoryMiB, blockCount, readModel);
+            List<Measurement> measurements = new ArrayList<>();
+            for (int iteration = -properties.warmups();
+                    iteration < properties.iterations();
+                    iteration++) {
+                Measurement measurement =
+                        measureRead(connection, readModel, DEFAULT_PAGE_OBJECT_ID);
+                if (iteration >= 0) {
+                    measurements.add(measurement);
+                    if (!referenceHash.equals(measurement.responseHash())) {
+                        report.add(
+                                Metric.logicalMismatch(
+                                        memoryMiB,
+                                        blockCount,
+                                        readModel.name(),
+                                        referenceHash,
+                                        measurement));
+                    }
+                }
+            }
+            report.add(
+                    Metric.fromMeasurements(memoryMiB, blockCount, readModel.name(), measurements));
+        }
+    }
+
+    private Measurement measureRead(Connection connection, ReadModel readModel, long pageObjectId)
+            throws Exception {
+        MemorySample.resetPeaks();
+        MemorySample before = MemorySample.capture();
+        SqlCounter sqlCounter = new SqlCounter();
+        Instant startedAt = Instant.now();
+        DocumentResult result =
+                switch (readModel) {
+                    case N_PLUS_ONE ->
+                            assembleDocumentNPlusOne(connection, pageObjectId, sqlCounter);
+                    case BATCH -> assembleDocumentBatch(connection, pageObjectId, sqlCounter);
+                    case SNAPSHOT_READ -> readSnapshot(connection, pageObjectId, sqlCounter);
+                    case COMPACT -> readCompact(connection, pageObjectId, sqlCounter);
+                };
+        long elapsedNanos = Duration.between(startedAt, Instant.now()).toNanos();
+        MemorySample after = MemorySample.capture();
+        return new Measurement(
+                elapsedNanos,
+                sqlCounter.count(),
+                result.json().toString().getBytes(StandardCharsets.UTF_8).length,
+                sha256(canonicalJson(result.json())),
+                before.heapUsedBytes(),
+                after.heapUsedBytes(),
+                after.heapPeakBytes());
+    }
+
+    private DocumentResult assembleDocumentBatch(Connection connection, long pageObjectId)
+            throws Exception {
+        return assembleDocumentBatch(connection, pageObjectId, new SqlCounter());
+    }
+
+    private DocumentResult assembleDocumentBatch(
+            Connection connection, long pageObjectId, SqlCounter sqlCounter) throws Exception {
+        ObjectNode document = documentRoot(pageObjectId);
+        ArrayNode blocks = document.putArray("blocks");
+        String sql =
+                """
+                SELECT o.id, o.position_index, b.block_type,
+                    rts.position_index AS segment_index, rts.plain_text, rtm.mention_type
+                FROM objects o
+                JOIN blocks b ON b.object_id = o.id
+                JOIN block_rich_text_fields brtf ON brtf.block_object_id = b.object_id
+                JOIN rich_text_segments rts ON rts.rich_text_content_id = brtf.rich_text_content_id
+                LEFT JOIN rich_text_mentions rtm ON rtm.rich_text_segment_id = rts.id
+                WHERE o.parent_object_id = ?
+                ORDER BY o.position_index, rts.position_index
+                """;
+        Map<Long, ObjectNode> blockById = new LinkedHashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, pageObjectId);
+            sqlCounter.increment();
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    long blockObjectId = resultSet.getLong("id");
+                    ObjectNode block =
+                            blockById.computeIfAbsent(
+                                    blockObjectId,
+                                    id -> {
+                                        ObjectNode node = blocks.addObject();
+                                        node.put("id", id);
+                                        node.put("type", uncheckedString(resultSet, "block_type"));
+                                        node.put(
+                                                "position",
+                                                uncheckedInt(resultSet, "position_index"));
+                                        node.putArray("richText");
+                                        return node;
+                                    });
+                    ObjectNode segment = ((ArrayNode) block.get("richText")).addObject();
+                    segment.put("position", resultSet.getInt("segment_index"));
+                    segment.put("plainText", resultSet.getString("plain_text"));
+                    putMentionType(segment, resultSet.getString("mention_type"));
+                }
+            }
+        }
+        sortBlocks(blocks);
+        return new DocumentResult(document);
+    }
+
+    private Metric measureSnapshotGenerate(Connection connection, int memoryMiB, int blockCount)
+            throws Exception {
+        String walStart = currentWalLsn(connection);
+        MemorySample.resetPeaks();
+        MemorySample before = MemorySample.capture();
+        Instant startedAt = Instant.now();
+        SqlCounter sqlCounter = new SqlCounter();
+        DocumentResult documentResult =
+                assembleDocumentBatch(connection, DEFAULT_PAGE_OBJECT_ID, sqlCounter);
+        int rows;
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        "UPDATE page_render_snapshots SET version = version + 1, "
+                                + "document_json = ?::jsonb, generated_at = now() "
+                                + "WHERE page_object_id = ?")) {
+            statement.setString(1, documentResult.json().toString());
+            statement.setLong(2, DEFAULT_PAGE_OBJECT_ID);
+            rows = statement.executeUpdate();
+            sqlCounter.increment();
+        }
+        long elapsedNanos = Duration.between(startedAt, Instant.now()).toNanos();
+        MemorySample after = MemorySample.capture();
+        long walBytes = walBytesBetween(connection, walStart, currentWalLsn(connection));
+        return Metric.write(
+                memoryMiB,
+                blockCount,
+                "SNAPSHOT_GENERATE",
+                elapsedNanos,
+                sqlCounter.count(),
+                documentResult.json().toString().getBytes(StandardCharsets.UTF_8).length,
+                after.heapUsedBytes() - before.heapUsedBytes(),
+                after.heapPeakBytes(),
+                rows,
+                walBytes,
+                "batch assembly + snapshot upsert");
+    }
+
+    private DocumentResult assembleDocumentNPlusOne(
+            Connection connection, long pageObjectId, SqlCounter sqlCounter) throws Exception {
+        ObjectNode document = documentRoot(pageObjectId);
+        ArrayNode blocks = document.putArray("blocks");
+        List<BlockRow> blockRows = new ArrayList<>();
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        "SELECT o.id, o.position_index, b.block_type FROM objects o "
+                                + "JOIN blocks b ON b.object_id = o.id "
+                                + "WHERE o.parent_object_id = ? ORDER BY o.position_index")) {
+            statement.setLong(1, pageObjectId);
+            sqlCounter.increment();
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    blockRows.add(
+                            new BlockRow(
+                                    resultSet.getLong("id"),
+                                    resultSet.getInt("position_index"),
+                                    resultSet.getString("block_type")));
+                }
+            }
+        }
+        for (BlockRow blockRow : blockRows) {
+            ObjectNode block = blocks.addObject();
+            block.put("id", blockRow.id());
+            block.put("type", blockRow.blockType());
+            block.put("position", blockRow.positionIndex());
+            ArrayNode richText = block.putArray("richText");
+            try (PreparedStatement statement =
+                    connection.prepareStatement(
+                            "SELECT rts.position_index, rts.plain_text, rtm.mention_type "
+                                    + "FROM block_rich_text_fields brtf "
+                                    + "JOIN rich_text_segments rts "
+                                    + "ON rts.rich_text_content_id = brtf.rich_text_content_id "
+                                    + "LEFT JOIN rich_text_mentions rtm "
+                                    + "ON rtm.rich_text_segment_id = rts.id "
+                                    + "WHERE brtf.block_object_id = ? ORDER BY rts.position_index")) {
+                statement.setLong(1, blockRow.id());
+                sqlCounter.increment();
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    while (resultSet.next()) {
+                        ObjectNode segment = richText.addObject();
+                        segment.put("position", resultSet.getInt("position_index"));
+                        segment.put("plainText", resultSet.getString("plain_text"));
+                        putMentionType(segment, resultSet.getString("mention_type"));
+                    }
+                }
+            }
+        }
+        return new DocumentResult(document);
+    }
+
+    private DocumentResult readSnapshot(
+            Connection connection, long pageObjectId, SqlCounter sqlCounter) throws Exception {
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        "SELECT document_json::text FROM page_render_snapshots WHERE page_object_id = ?")) {
+            statement.setLong(1, pageObjectId);
+            sqlCounter.increment();
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    throw new IllegalStateException("snapshot not found");
+                }
+                return new DocumentResult(OBJECT_MAPPER.readTree(resultSet.getString(1)));
+            }
+        }
+    }
+
+    private DocumentResult readCompact(
+            Connection connection, long pageObjectId, SqlCounter sqlCounter) throws Exception {
+        ObjectNode document = documentRoot(pageObjectId);
+        ArrayNode blocks = document.putArray("blocks");
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        "SELECT source_block_object_id, block_type, payload::text FROM experiment_compact_blocks "
+                                + "WHERE page_object_id = ? AND parent_block_object_id = ? ORDER BY position_key")) {
+            statement.setLong(1, pageObjectId);
+            statement.setLong(2, pageObjectId);
+            sqlCounter.increment();
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    JsonNode payload = OBJECT_MAPPER.readTree(resultSet.getString("payload"));
+                    ObjectNode block = blocks.addObject();
+                    block.put("id", resultSet.getLong("source_block_object_id"));
+                    block.put("type", resultSet.getString("block_type"));
+                    block.put("position", payload.get("position").asInt());
+                    block.set("richText", payload.get("richText"));
+                }
+            }
+        }
+        sortBlocks(blocks);
+        return new DocumentResult(document);
+    }
+
+    private void captureExplain(
+            Connection connection,
+            PerformanceReport report,
+            int memoryMiB,
+            int blockCount,
+            ReadModel readModel)
+            throws Exception {
+        if (readModel == ReadModel.N_PLUS_ONE) {
+            String parentPlan =
+                    explain(
+                            connection,
+                            "SELECT o.id, o.position_index, b.block_type FROM objects o "
+                                    + "JOIN blocks b ON b.object_id = o.id "
+                                    + "WHERE o.parent_object_id = "
+                                    + DEFAULT_PAGE_OBJECT_ID
+                                    + " ORDER BY o.position_index");
+            String childPlan =
+                    explain(
+                            connection,
+                            "SELECT rts.position_index, rts.plain_text, rtm.mention_type "
+                                    + "FROM block_rich_text_fields brtf "
+                                    + "JOIN rich_text_segments rts "
+                                    + "ON rts.rich_text_content_id = brtf.rich_text_content_id "
+                                    + "LEFT JOIN rich_text_mentions rtm "
+                                    + "ON rtm.rich_text_segment_id = rts.id "
+                                    + "WHERE brtf.block_object_id = "
+                                    + firstBlockObjectId(connection)
+                                    + " ORDER BY rts.position_index");
+            report.addPlan(memoryMiB, blockCount, "N_PLUS_ONE_PARENT", parentPlan);
+            report.addPlan(memoryMiB, blockCount, "N_PLUS_ONE_CHILD_REPRESENTATIVE", childPlan);
+            return;
+        }
+        String sql =
+                switch (readModel) {
+                    case BATCH ->
+                            """
+                    SELECT o.id, o.position_index, b.block_type,
+                        rts.position_index AS segment_index, rts.plain_text, rtm.mention_type
+                    FROM objects o
+                    JOIN blocks b ON b.object_id = o.id
+                    JOIN block_rich_text_fields brtf ON brtf.block_object_id = b.object_id
+                    JOIN rich_text_segments rts ON rts.rich_text_content_id = brtf.rich_text_content_id
+                    LEFT JOIN rich_text_mentions rtm ON rtm.rich_text_segment_id = rts.id
+                    WHERE o.parent_object_id = %d
+                    ORDER BY o.position_index, rts.position_index
+                    """
+                                    .formatted(DEFAULT_PAGE_OBJECT_ID);
+                    case SNAPSHOT_READ ->
+                            "SELECT document_json::text FROM page_render_snapshots WHERE page_object_id = "
+                                    + DEFAULT_PAGE_OBJECT_ID;
+                    case COMPACT ->
+                            "SELECT source_block_object_id, block_type, payload::text FROM experiment_compact_blocks "
+                                    + "WHERE page_object_id = "
+                                    + DEFAULT_PAGE_OBJECT_ID
+                                    + " AND parent_block_object_id = "
+                                    + DEFAULT_PAGE_OBJECT_ID
+                                    + " ORDER BY position_key";
+                    case N_PLUS_ONE -> throw new IllegalStateException("handled above");
+                };
+        String plan = explain(connection, sql);
+        report.addPlan(memoryMiB, blockCount, readModel.name(), plan);
+    }
+
+    private long firstBlockObjectId(Connection connection) throws SQLException {
+        return queryLong(
+                connection,
+                "SELECT id FROM objects WHERE object_type = 'BLOCK' ORDER BY position_index LIMIT 1");
+    }
+
+    private String explain(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet =
+                        statement.executeQuery(
+                                "EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON) " + sql)) {
+            resultSet.next();
+            return resultSet.getString(1);
+        }
+    }
+
+    private void runReorderMeasurements(
+            PerformanceProperties properties,
+            PerformanceReport report,
+            Connection connection,
+            int memoryMiB,
+            int blockCount)
+            throws Exception {
+        resetIntegerOrder(connection);
+        report.add(measureIntegerReorder(connection, memoryMiB, blockCount));
+        resetPositionKeys(connection);
+        report.add(measurePositionKeyReorder(connection, memoryMiB, blockCount));
+        for (int concurrency : properties.concurrency()) {
+            resetIntegerOrder(connection);
+            report.add(
+                    measureConcurrentReorder(
+                            connection,
+                            memoryMiB,
+                            blockCount,
+                            concurrency,
+                            "INTEGER_REORDER",
+                            this::integerReorderAttempt));
+            resetPositionKeys(connection);
+            report.add(
+                    measureConcurrentReorder(
+                            connection,
+                            memoryMiB,
+                            blockCount,
+                            concurrency,
+                            "POSITION_KEY_REORDER",
+                            this::positionKeyReorderAttempt));
+        }
+    }
+
+    private Metric measureIntegerReorder(Connection connection, int memoryMiB, int blockCount)
+            throws SQLException {
+        String walStart = currentWalLsn(connection);
+        Instant startedAt = Instant.now();
+        int rows;
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        "UPDATE objects SET position_index = position_index + 1 WHERE parent_object_id = ? "
+                                + "AND position_index >= ?")) {
+            statement.setLong(1, DEFAULT_PAGE_OBJECT_ID);
+            statement.setInt(2, Math.max(0, blockCount / 2));
+            rows = statement.executeUpdate();
+        }
+        long elapsedNanos = Duration.between(startedAt, Instant.now()).toNanos();
+        long walBytes = walBytesBetween(connection, walStart, currentWalLsn(connection));
+        return Metric.write(
+                memoryMiB,
+                blockCount,
+                "INTEGER_REORDER",
+                elapsedNanos,
+                1,
+                0,
+                0,
+                0,
+                rows,
+                walBytes,
+                "range update from midpoint");
+    }
+
+    private Metric measurePositionKeyReorder(Connection connection, int memoryMiB, int blockCount)
+            throws SQLException {
+        String walStart = currentWalLsn(connection);
+        Instant startedAt = Instant.now();
+        int rows;
+        try (PreparedStatement statement = connection.prepareStatement(POSITION_KEY_REORDER_SQL)) {
+            statement.setString(1, midpointPositionKey(0, 1024));
+            statement.setLong(2, DEFAULT_PAGE_OBJECT_ID);
+            statement.setInt(3, Math.max(0, blockCount - 1));
+            rows = statement.executeUpdate();
+        }
+        long elapsedNanos = Duration.between(startedAt, Instant.now()).toNanos();
+        long walBytes = walBytesBetween(connection, walStart, currentWalLsn(connection));
+        return Metric.write(
+                memoryMiB,
+                blockCount,
+                "POSITION_KEY_REORDER",
+                elapsedNanos,
+                1,
+                0,
+                0,
+                0,
+                rows,
+                walBytes,
+                "one row moved between adjacent rank keys");
+    }
+
+    private Metric measureConcurrentReorder(
+            Connection connection,
+            int memoryMiB,
+            int blockCount,
+            int concurrency,
+            String scenario,
+            ReorderAttempt reorderAttempt)
+            throws Exception {
+        String walStart = currentWalLsn(connection);
+        ExecutorService executorService = Executors.newFixedThreadPool(concurrency);
+        CountDownLatch startSignal = new CountDownLatch(1);
+        List<Future<AttemptResult>> futures = new ArrayList<>();
+        Instant startedAt = Instant.now();
+        try {
+            for (int index = 0; index < concurrency; index++) {
+                int attemptIndex = index;
+                futures.add(
+                        executorService.submit(
+                                () ->
+                                        reorderAttempt.attempt(
+                                                startSignal, attemptIndex, blockCount)));
+            }
+            startSignal.countDown();
+            List<AttemptResult> results = new ArrayList<>();
+            for (Future<AttemptResult> future : futures) {
+                results.add(future.get());
+            }
+            long elapsedNanos = Duration.between(startedAt, Instant.now()).toNanos();
+            long walBytes = walBytesBetween(connection, walStart, currentWalLsn(connection));
+            return Metric.concurrent(
+                    memoryMiB,
+                    blockCount,
+                    scenario + "_CONCURRENT_" + concurrency,
+                    elapsedNanos,
+                    walBytes,
+                    results);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private AttemptResult integerReorderAttempt(
+            CountDownLatch startSignal, int attemptIndex, int blockCount) {
+        return runAttempt(
+                startSignal,
+                "INTEGER_REORDER",
+                connection -> {
+                    try (PreparedStatement statement =
+                            connection.prepareStatement(
+                                    "UPDATE objects SET position_index = position_index + 1 WHERE parent_object_id = ? "
+                                            + "AND position_index >= ?")) {
+                        statement.setLong(1, DEFAULT_PAGE_OBJECT_ID);
+                        statement.setInt(
+                                2,
+                                Math.max(0, (attemptIndex + blockCount) % Math.max(1, blockCount)));
+                        return statement.executeUpdate();
+                    }
+                });
+    }
+
+    private AttemptResult positionKeyReorderAttempt(
+            CountDownLatch startSignal, int attemptIndex, int blockCount) {
+        return runAttempt(
+                startSignal,
+                "POSITION_KEY_REORDER",
+                connection -> {
+                    try (PreparedStatement statement =
+                            connection.prepareStatement(POSITION_KEY_REORDER_SQL)) {
+                        statement.setString(1, positionKey(attemptIndex + 1));
+                        statement.setLong(2, DEFAULT_PAGE_OBJECT_ID);
+                        statement.setInt(3, Math.max(0, blockCount - 1 - attemptIndex));
+                        return statement.executeUpdate();
+                    }
+                });
+    }
+
+    private void resetIntegerOrder(Connection connection) throws SQLException {
+        execute(
+                connection,
+                "UPDATE objects SET position_index = split_part(notion_object_id, '-', 3)::integer "
+                        + "WHERE object_type = 'BLOCK'");
+    }
+
+    private void resetPositionKeys(Connection connection) throws SQLException {
+        execute(
+                connection,
+                "UPDATE experiment_compact_blocks compact SET position_key = "
+                        + "lpad((split_part(source.notion_object_id, '-', 3)::integer * 1024)::text, 12, '0') "
+                        + "FROM objects source WHERE source.id = compact.source_block_object_id");
+    }
+
+    private AttemptResult runAttempt(
+            CountDownLatch startSignal, String name, SqlAttempt sqlAttempt) {
+        Instant startedAt = Instant.now();
+        try (Connection connection =
+                DriverManager.getConnection(
+                        ActiveDatabase.jdbcUrl(),
+                        ActiveDatabase.username(),
+                        ActiveDatabase.password())) {
+            configureSession(connection);
+            startSignal.await();
+            int rows = sqlAttempt.execute(connection);
+            return AttemptResult.success(
+                    name, Duration.between(startedAt, Instant.now()).toNanos(), rows);
+        } catch (Exception exception) {
+            return AttemptResult.failure(
+                    name, Duration.between(startedAt, Instant.now()).toNanos(), exception);
+        }
+    }
+
+    private Metric environmentMetric(
+            String scenario, int memoryMiB, int blockCount, PostgreSQLContainer<?> container)
+            throws Exception {
+        InspectContainerResponse response =
+                container.getDockerClient().inspectContainerCmd(container.getContainerId()).exec();
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("containerId", container.getContainerId());
+        details.put("image", POSTGRES_IMAGE.asCanonicalNameString());
+        details.put("memoryMaxBytes", cgroupValue(container, "/sys/fs/cgroup/memory.max"));
+        details.put("memorySwapMaxBytes", cgroupValue(container, "/sys/fs/cgroup/memory.swap.max"));
+        details.put("memoryCurrentBytes", cgroupValue(container, "/sys/fs/cgroup/memory.current"));
+        details.put("memoryPeakBytes", cgroupValue(container, "/sys/fs/cgroup/memory.peak"));
+        details.put(
+                "memoryEvents",
+                cgroupValue(container, "/sys/fs/cgroup/memory.events").replace('\n', '|'));
+        details.put("sharedBuffersMiB", String.valueOf(Math.max(32, memoryMiB / 4)));
+        details.put("workMem", "2MB");
+        details.put("maxConnections", "64");
+        details.put("oomKilled", String.valueOf(response.getState().getOOMKilled()));
+        return Metric.observation(memoryMiB, blockCount, scenario, details);
+    }
+
+    private Metric resourceMetric(
+            String scenario,
+            int memoryMiB,
+            int blockCount,
+            PostgreSQLContainer<?> container,
+            Connection connection)
+            throws Exception {
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put(
+                "dbSizeBytes",
+                String.valueOf(
+                        queryLong(connection, "SELECT pg_database_size(current_database())")));
+        details.put("memoryCurrentBytes", cgroupValue(container, "/sys/fs/cgroup/memory.current"));
+        details.put("memoryPeakBytes", cgroupValue(container, "/sys/fs/cgroup/memory.peak"));
+        details.put("memoryMaxBytes", cgroupValue(container, "/sys/fs/cgroup/memory.max"));
+        details.put("memorySwapMaxBytes", cgroupValue(container, "/sys/fs/cgroup/memory.swap.max"));
+        details.put(
+                "memoryEvents",
+                cgroupValue(container, "/sys/fs/cgroup/memory.events").replace('\n', '|'));
+        InspectContainerResponse response =
+                container.getDockerClient().inspectContainerCmd(container.getContainerId()).exec();
+        details.put("oomKilled", String.valueOf(response.getState().getOOMKilled()));
+        return Metric.observation(memoryMiB, blockCount, scenario, details);
+    }
+
+    private Metric containerStateMetric(
+            String scenario, int memoryMiB, int blockCount, PostgreSQLContainer<?> container) {
+        if (!container.isCreated()) {
+            return Metric.observation(
+                    memoryMiB, blockCount, scenario, Map.of("state", "not_created"));
+        }
+        InspectContainerResponse response =
+                container.getDockerClient().inspectContainerCmd(container.getContainerId()).exec();
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("running", String.valueOf(response.getState().getRunning()));
+        details.put("oomKilled", String.valueOf(response.getState().getOOMKilled()));
+        details.put("memoryMaxBytes", safeCgroupValue(container, "/sys/fs/cgroup/memory.max"));
+        details.put(
+                "memorySwapMaxBytes", safeCgroupValue(container, "/sys/fs/cgroup/memory.swap.max"));
+        details.put(
+                "memoryCurrentBytes", safeCgroupValue(container, "/sys/fs/cgroup/memory.current"));
+        details.put("memoryPeakBytes", safeCgroupValue(container, "/sys/fs/cgroup/memory.peak"));
+        details.put(
+                "memoryEvents",
+                safeCgroupValue(container, "/sys/fs/cgroup/memory.events").replace('\n', '|'));
+        return Metric.observation(memoryMiB, blockCount, scenario, details);
+    }
+
+    private boolean isOomKilled(PostgreSQLContainer<?> container) {
+        if (!container.isCreated()) {
+            return false;
+        }
+        InspectContainerResponse response =
+                container.getDockerClient().inspectContainerCmd(container.getContainerId()).exec();
+        return Boolean.TRUE.equals(response.getState().getOOMKilled());
+    }
+
+    private String cgroupValue(PostgreSQLContainer<?> container, String path)
+            throws IOException, InterruptedException {
+        org.testcontainers.containers.Container.ExecResult result =
+                container.execInContainer(
+                        "sh", "-c", "test -f " + path + " && cat " + path + " || true");
+        return result.getStdout().strip();
+    }
+
+    private String safeCgroupValue(PostgreSQLContainer<?> container, String path) {
+        try {
+            return cgroupValue(container, path);
+        } catch (Exception exception) {
+            return "unavailable:" + exception.getClass().getSimpleName();
+        }
+    }
+
+    private String currentWalLsn(Connection connection) throws SQLException {
+        return queryString(connection, "SELECT pg_current_wal_lsn()::text");
+    }
+
+    private long walBytesBetween(Connection connection, String startLsn, String endLsn)
+            throws SQLException {
+        try (PreparedStatement statement =
+                connection.prepareStatement(
+                        "SELECT pg_wal_lsn_diff(?::pg_lsn, ?::pg_lsn)::bigint")) {
+            statement.setString(1, endLsn);
+            statement.setString(2, startLsn);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getLong(1);
+            }
+        }
+    }
+
+    private String queryString(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getString(1);
+        }
+    }
+
+    private long queryLong(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getLong(1);
+        }
+    }
+
+    private long insertReturningId(Connection connection, String sql, Object... parameters)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            bind(statement, parameters);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getLong(1);
+            }
+        }
+    }
+
+    private void insert(Connection connection, String sql, Object... parameters)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            bind(statement, parameters);
+            statement.executeUpdate();
+        }
+    }
+
+    private void execute(Connection connection, String sql, Object... parameters)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            bind(statement, parameters);
+            statement.executeUpdate();
+        }
+    }
+
+    private void bind(PreparedStatement statement, Object... parameters) throws SQLException {
+        for (int index = 0; index < parameters.length; index++) {
+            statement.setObject(index + 1, parameters[index]);
+        }
+    }
+
+    private ObjectNode documentRoot(long pageObjectId) {
+        ObjectNode document = OBJECT_MAPPER.createObjectNode();
+        document.put("pageId", pageObjectId);
+        document.put("title", "Performance Page");
+        return document;
+    }
+
+    private void sortBlocks(ArrayNode blocks) {
+        List<JsonNode> sorted = new ArrayList<>();
+        blocks.forEach(sorted::add);
+        sorted.sort(Comparator.comparingInt(node -> node.get("position").asInt()));
+        blocks.removeAll();
+        sorted.forEach(blocks::add);
+    }
+
+    private void putMentionType(ObjectNode segment, String mentionType) {
+        if (mentionType != null) {
+            segment.put("mentionType", mentionType);
+        }
+    }
+
+    private String readResource(String resourceName) {
+        try (InputStream inputStream =
+                getClass().getClassLoader().getResourceAsStream(resourceName)) {
+            if (inputStream == null) {
+                throw new IllegalStateException("classpath resource not found: " + resourceName);
+            }
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
+        }
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte item : hash) {
+                builder.append(String.format("%02x", item));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private String canonicalJson(JsonNode jsonNode) {
+        if (jsonNode.isObject()) {
+            List<String> propertyNames = new ArrayList<>(jsonNode.propertyNames());
+            Collections.sort(propertyNames);
+            StringJoiner joiner = new StringJoiner(",", "{", "}");
+            for (String propertyName : propertyNames) {
+                joiner.add(
+                        quoteJson(propertyName) + ":" + canonicalJson(jsonNode.get(propertyName)));
+            }
+            return joiner.toString();
+        }
+        if (jsonNode.isArray()) {
+            StringJoiner joiner = new StringJoiner(",", "[", "]");
+            for (JsonNode item : jsonNode) {
+                joiner.add(canonicalJson(item));
+            }
+            return joiner.toString();
+        }
+        return jsonNode.toString();
+    }
+
+    private String quoteJson(String value) {
+        return OBJECT_MAPPER.writeValueAsString(value);
+    }
+
+    private String pagePayload(int blockCount) {
+        return "{\"type\":\"page\",\"blockCount\":"
+                + blockCount
+                + ",\"seed\":"
+                + DATASET_SEED
+                + "}";
+    }
+
+    private String blockPayload(int index) {
+        return "{\"type\":\""
+                + blockType(index)
+                + "\",\"position\":"
+                + index
+                + ",\"seed\":"
+                + DATASET_SEED
+                + "}";
+    }
+
+    private String compactPayload(int index) {
+        StringJoiner segments = new StringJoiner(",", "[", "]");
+        for (int segmentIndex = 0; segmentIndex < RICH_TEXT_SEGMENTS_PER_BLOCK; segmentIndex++) {
+            segments.add(
+                    "{\"position\":"
+                            + segmentIndex
+                            + ",\"plainText\":\""
+                            + segmentText(index, segmentIndex)
+                            + "\"}");
+        }
+        return "{\"position\":" + index + ",\"richText\":" + segments + "}";
+    }
+
+    private String blockType(int index) {
+        if (index % 17 == 0) {
+            return "heading_2";
+        }
+        if (index % 11 == 0) {
+            return "to_do";
+        }
+        if (index % 7 == 0) {
+            return "image";
+        }
+        return "paragraph";
+    }
+
+    private String segmentType(int blockIndex, int segmentIndex) {
+        if (blockIndex % 10 == 0 && segmentIndex == 0) {
+            return "mention";
+        }
+        return "text";
+    }
+
+    private String segmentText(int blockIndex, int segmentIndex) {
+        return "block-" + blockIndex + "-segment-" + segmentIndex;
+    }
+
+    private String uncheckedString(ResultSet resultSet, String columnName) {
+        try {
+            return resultSet.getString(columnName);
+        } catch (SQLException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private int uncheckedInt(ResultSet resultSet, String columnName) {
+        try {
+            return resultSet.getInt(columnName);
+        } catch (SQLException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private String positionKey(int index) {
+        return String.format("%012d", index);
+    }
+
+    private String midpointPositionKey(int lower, int upper) {
+        return positionKey(lower + ((upper - lower) / 2));
+    }
+
+    private enum ReadModel {
+        N_PLUS_ONE,
+        BATCH,
+        SNAPSHOT_READ,
+        COMPACT
+    }
+
+    private interface ReorderAttempt {
+
+        AttemptResult attempt(CountDownLatch startSignal, int attemptIndex, int blockCount);
+    }
+
+    private interface SqlAttempt {
+
+        int execute(Connection connection) throws Exception;
+    }
+
+    private record PerformanceProperties(
+            List<Integer> sizes,
+            List<Integer> memoryMiB,
+            int iterations,
+            int warmups,
+            List<Integer> concurrency) {
+
+        static PerformanceProperties fromSystemProperties() {
+            return new PerformanceProperties(
+                    parseInts("performance.sizes", "1000,10000,100000"),
+                    parseInts("performance.memoryMiB", "1024,512,256"),
+                    Integer.getInteger("performance.iterations", 3),
+                    Integer.getInteger("performance.warmups", 1),
+                    parseInts("performance.concurrency", "10,50"));
+        }
+
+        private static List<Integer> parseInts(String propertyName, String defaultValue) {
+            String rawValue = System.getProperty(propertyName, defaultValue);
+            List<Integer> values = new ArrayList<>();
+            for (String part : rawValue.split(",")) {
+                String trimmed = part.trim();
+                if (!trimmed.isEmpty()) {
+                    values.add(Integer.parseInt(trimmed));
+                }
+            }
+            return Collections.unmodifiableList(values);
+        }
+    }
+
+    private record DatasetContext(
+            long pageObjectId,
+            long connectionId,
+            int blockCount,
+            long loadMillis,
+            long sqlCount,
+            long walBytes,
+            long estimatedPhysicalRows,
+            long schemaTableCount) {
+
+        Metric metric(int memoryMiB) {
+            return Metric.observation(
+                    memoryMiB,
+                    blockCount,
+                    "SEED_LOAD",
+                    Map.of(
+                            "pageObjectId", String.valueOf(pageObjectId),
+                            "notionConnectionId", String.valueOf(connectionId),
+                            "loadMillis", String.valueOf(loadMillis),
+                            "sqlCount", String.valueOf(sqlCount),
+                            "logicalBlocks", String.valueOf(blockCount),
+                            "walBytes", String.valueOf(walBytes),
+                            "estimatedPhysicalRows", String.valueOf(estimatedPhysicalRows),
+                            "schemaTableCount", String.valueOf(schemaTableCount)));
+        }
+    }
+
+    private record BlockRow(long id, int positionIndex, String blockType) {}
+
+    private record DocumentResult(JsonNode json) {}
+
+    private record Measurement(
+            long elapsedNanos,
+            long sqlCount,
+            int responseBytes,
+            String responseHash,
+            long heapBeforeBytes,
+            long heapAfterBytes,
+            long heapPeakBytes) {}
+
+    private record MemorySample(long heapUsedBytes, long heapPeakBytes) {
+
+        static void resetPeaks() {
+            for (MemoryPoolMXBean memoryPoolMXBean : ManagementFactory.getMemoryPoolMXBeans()) {
+                if (memoryPoolMXBean.getType() == MemoryType.HEAP) {
+                    memoryPoolMXBean.resetPeakUsage();
+                }
+            }
+        }
+
+        static MemorySample capture() {
+            MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+            MemoryUsage heapMemoryUsage = memoryMXBean.getHeapMemoryUsage();
+            long heapPeakBytes = 0;
+            for (MemoryPoolMXBean memoryPoolMXBean : ManagementFactory.getMemoryPoolMXBeans()) {
+                if (memoryPoolMXBean.getType() == MemoryType.HEAP) {
+                    MemoryUsage peakUsage = memoryPoolMXBean.getPeakUsage();
+                    if (peakUsage != null) {
+                        heapPeakBytes += peakUsage.getUsed();
+                    }
+                }
+            }
+            return new MemorySample(heapMemoryUsage.getUsed(), heapPeakBytes);
+        }
+    }
+
+    private record AttemptResult(
+            String scenario,
+            long elapsedNanos,
+            int changedRows,
+            String status,
+            String observation) {
+
+        static AttemptResult success(String scenario, long elapsedNanos, int changedRows) {
+            return new AttemptResult(scenario, elapsedNanos, changedRows, "OK", "");
+        }
+
+        static AttemptResult failure(String scenario, long elapsedNanos, Exception exception) {
+            return new AttemptResult(
+                    scenario,
+                    elapsedNanos,
+                    0,
+                    "OBSERVED_FAILURE",
+                    exception.getClass().getSimpleName());
+        }
+    }
+
+    private static final class SqlCounter {
+        private long count;
+
+        void increment() {
+            count++;
+        }
+
+        long count() {
+            return count;
+        }
+    }
+
+    private record Metric(
+            int memoryMiB,
+            int blockCount,
+            String scenario,
+            String status,
+            long p50Nanos,
+            long p95Nanos,
+            long p99Nanos,
+            long sqlCount,
+            int responseBytes,
+            long heapDeltaBytes,
+            long heapPeakBytes,
+            int changedRows,
+            long walBytes,
+            String observation) {
+
+        static Metric fromMeasurements(
+                int memoryMiB, int blockCount, String scenario, List<Measurement> measurements) {
+            if (measurements.isEmpty()) {
+                return observation(
+                        memoryMiB, blockCount, scenario, Map.of("status", "NO_MEASUREMENTS"));
+            }
+            List<Long> elapsed =
+                    measurements.stream().map(Measurement::elapsedNanos).sorted().toList();
+            Measurement last = measurements.get(measurements.size() - 1);
+            long sqlCount =
+                    Math.round(
+                            measurements.stream()
+                                    .mapToLong(Measurement::sqlCount)
+                                    .average()
+                                    .orElse(0));
+            long heapDelta =
+                    measurements.stream()
+                            .mapToLong(
+                                    measurement ->
+                                            measurement.heapAfterBytes()
+                                                    - measurement.heapBeforeBytes())
+                            .max()
+                            .orElse(0);
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    "OK",
+                    percentile(elapsed, 50),
+                    percentile(elapsed, 95),
+                    percentile(elapsed, 99),
+                    sqlCount,
+                    last.responseBytes(),
+                    heapDelta,
+                    measurements.stream().mapToLong(Measurement::heapPeakBytes).max().orElse(0),
+                    0,
+                    0,
+                    "responseHash=" + last.responseHash());
+        }
+
+        static Metric write(
+                int memoryMiB,
+                int blockCount,
+                String scenario,
+                long elapsedNanos,
+                long sqlCount,
+                int responseBytes,
+                long heapDeltaBytes,
+                long heapPeakBytes,
+                int changedRows,
+                long walBytes,
+                String observation) {
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    "OK",
+                    elapsedNanos,
+                    elapsedNanos,
+                    elapsedNanos,
+                    sqlCount,
+                    responseBytes,
+                    heapDeltaBytes,
+                    heapPeakBytes,
+                    changedRows,
+                    walBytes,
+                    observation);
+        }
+
+        static Metric concurrent(
+                int memoryMiB,
+                int blockCount,
+                String scenario,
+                long wallNanos,
+                long walBytes,
+                List<AttemptResult> results) {
+            long failures =
+                    results.stream().filter(result -> !"OK".equals(result.status())).count();
+            int changedRows = results.stream().mapToInt(AttemptResult::changedRows).sum();
+            List<Long> elapsed =
+                    results.stream().map(AttemptResult::elapsedNanos).sorted().toList();
+            String observation =
+                    "attempts="
+                            + results.size()
+                            + ";failures="
+                            + failures
+                            + ";wallNanos="
+                            + wallNanos;
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    failures == 0 ? "OK" : "OBSERVED_FAILURE",
+                    percentile(elapsed, 50),
+                    percentile(elapsed, 95),
+                    percentile(elapsed, 99),
+                    results.size(),
+                    0,
+                    0,
+                    0,
+                    changedRows,
+                    walBytes,
+                    observation);
+        }
+
+        static Metric observation(
+                int memoryMiB, int blockCount, String scenario, Map<String, String> details) {
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    "OBSERVED",
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    details.toString());
+        }
+
+        static Metric logicalMismatch(
+                int memoryMiB,
+                int blockCount,
+                String scenario,
+                String expectedHash,
+                Measurement measurement) {
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    "LOGICAL_MISMATCH",
+                    measurement.elapsedNanos(),
+                    measurement.elapsedNanos(),
+                    measurement.elapsedNanos(),
+                    measurement.sqlCount(),
+                    measurement.responseBytes(),
+                    measurement.heapAfterBytes() - measurement.heapBeforeBytes(),
+                    measurement.heapPeakBytes(),
+                    0,
+                    0,
+                    "expected=" + expectedHash + ";actual=" + measurement.responseHash());
+        }
+
+        static Metric failure(int memoryMiB, int blockCount, String scenario, Exception exception) {
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    "OBSERVED_FAILURE",
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    exception.getClass().getSimpleName()
+                            + ":"
+                            + Objects.toString(exception.getMessage(), ""));
+        }
+
+        static Metric resourceLimit(
+                int memoryMiB, int blockCount, String scenario, Exception exception) {
+            return new Metric(
+                    memoryMiB,
+                    blockCount,
+                    scenario,
+                    "RESOURCE_LIMIT_OOM",
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    exception.getClass().getSimpleName()
+                            + ":"
+                            + Objects.toString(exception.getMessage(), ""));
+        }
+
+        String toCsvRow() {
+            return "%d,%d,%s,%s,%d,%d,%d,%d,%d,%d,%d,%d,%d,%s%n"
+                    .formatted(
+                            memoryMiB,
+                            blockCount,
+                            scenario,
+                            status,
+                            p50Nanos,
+                            p95Nanos,
+                            p99Nanos,
+                            sqlCount,
+                            responseBytes,
+                            heapDeltaBytes,
+                            heapPeakBytes,
+                            changedRows,
+                            walBytes,
+                            observation.replace(',', ';').replace('\n', '|'));
+        }
+
+        private static long percentile(List<Long> sortedValues, int percentile) {
+            int index = (int) Math.ceil((percentile / 100.0d) * sortedValues.size()) - 1;
+            return sortedValues.get(Math.max(0, Math.min(index, sortedValues.size() - 1)));
+        }
+    }
+
+    private static final class PerformanceReport {
+        private final PerformanceProperties properties;
+        private final List<Metric> metrics = new ArrayList<>();
+        private final Map<String, String> plans = new LinkedHashMap<>();
+
+        PerformanceReport(PerformanceProperties properties) {
+            this.properties = properties;
+        }
+
+        void add(Metric metric) {
+            metrics.add(metric);
+        }
+
+        void addPlan(int memoryMiB, int blockCount, String scenario, String plan) {
+            plans.put(memoryMiB + "MiB-" + blockCount + "-" + scenario + ".json", plan);
+        }
+
+        int failedLogicalEquivalenceCount() {
+            return (int)
+                    metrics.stream()
+                            .filter(metric -> "LOGICAL_MISMATCH".equals(metric.status()))
+                            .count();
+        }
+
+        int invalidMatrixCount() {
+            int invalid = 0;
+            for (int memoryMiB : properties.memoryMiB()) {
+                for (int blockCount : properties.sizes()) {
+                    boolean completed =
+                            metrics.stream()
+                                    .anyMatch(
+                                            metric ->
+                                                    metric.memoryMiB() == memoryMiB
+                                                            && metric.blockCount() == blockCount
+                                                            && "RESOURCE_AFTER_MATRIX"
+                                                                    .equals(metric.scenario()));
+                    boolean classifiedResourceLimit =
+                            metrics.stream()
+                                    .anyMatch(
+                                            metric ->
+                                                    metric.memoryMiB() == memoryMiB
+                                                            && metric.blockCount() == blockCount
+                                                            && "RESOURCE_LIMIT_OOM"
+                                                                    .equals(metric.status()));
+                    if (!completed && !classifiedResourceLimit) {
+                        invalid++;
+                    }
+                }
+            }
+            return invalid;
+        }
+    }
+
+    private static final class ReportWriter {
+        private final Path outputDirectory;
+
+        ReportWriter(Path outputDirectory) {
+            this.outputDirectory = outputDirectory;
+        }
+
+        void write(PerformanceReport report) throws IOException {
+            Path planDirectory = outputDirectory.resolve("query-plans");
+            Files.createDirectories(planDirectory);
+            cleanPlanDirectory(planDirectory);
+            writeEnvironment(report);
+            writeMetrics(report);
+            writeMetricsJson(report);
+            writePlans(report, planDirectory);
+            writeSummary(report);
+        }
+
+        private void cleanPlanDirectory(Path planDirectory) throws IOException {
+            try (java.util.stream.Stream<Path> paths = Files.list(planDirectory)) {
+                for (Path path : paths.toList()) {
+                    Files.deleteIfExists(path);
+                }
+            }
+        }
+
+        private void writeEnvironment(PerformanceReport report) throws IOException {
+            ObjectNode environment = OBJECT_MAPPER.createObjectNode();
+            environment.put("javaVersion", System.getProperty("java.version"));
+            environment.put("availableProcessors", Runtime.getRuntime().availableProcessors());
+            environment.put("postgresImage", POSTGRES_IMAGE.asCanonicalNameString());
+            ArrayNode sizes = environment.putArray("sizes");
+            report.properties.sizes().forEach(sizes::add);
+            ArrayNode memoryMiB = environment.putArray("memoryMiB");
+            report.properties.memoryMiB().forEach(memoryMiB::add);
+            environment.put("iterations", report.properties.iterations());
+            environment.put("warmups", report.properties.warmups());
+            ArrayNode concurrency = environment.putArray("concurrency");
+            report.properties.concurrency().forEach(concurrency::add);
+            environment.put("sharedBuffersRatio", "25% with 32MiB minimum");
+            environment.put("workMem", "2MB");
+            environment.put("maxConnections", 64);
+            environment.put(
+                    "datasetProfile", "block-rich-text-mention-heavy synthetic vertical slice");
+            environment.put(
+                    "measurementBoundary", "raw JDBC + app-side JSON assembly; not HTTP/JPA");
+            Files.writeString(
+                    outputDirectory.resolve("environment.json"),
+                    OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(environment),
+                    StandardCharsets.UTF_8);
+        }
+
+        private void writeMetrics(PerformanceReport report) throws IOException {
+            StringBuilder builder = new StringBuilder();
+            builder.append(
+                    "memory_mib,block_count,scenario,status,p50_nanos,p95_nanos,p99_nanos,sql_count,"
+                            + "response_bytes,heap_delta_bytes,heap_peak_bytes,changed_rows,wal_bytes,observation\n");
+            for (Metric metric : report.metrics) {
+                builder.append(metric.toCsvRow());
+            }
+            Files.writeString(
+                    outputDirectory.resolve("metrics.csv"),
+                    builder.toString(),
+                    StandardCharsets.UTF_8);
+        }
+
+        private void writeMetricsJson(PerformanceReport report) throws IOException {
+            Files.writeString(
+                    outputDirectory.resolve("metrics.json"),
+                    OBJECT_MAPPER
+                            .writerWithDefaultPrettyPrinter()
+                            .writeValueAsString(report.metrics),
+                    StandardCharsets.UTF_8);
+        }
+
+        private void writePlans(PerformanceReport report, Path planDirectory) throws IOException {
+            for (Map.Entry<String, String> entry : report.plans.entrySet()) {
+                Files.writeString(
+                        planDirectory.resolve(entry.getKey()),
+                        entry.getValue(),
+                        StandardCharsets.UTF_8);
+            }
+        }
+
+        private void writeSummary(PerformanceReport report) throws IOException {
+            long failures =
+                    report.metrics.stream()
+                            .filter(metric -> metric.status().contains("FAILURE"))
+                            .count();
+            long resourceLimits =
+                    report.metrics.stream()
+                            .filter(metric -> "RESOURCE_LIMIT_OOM".equals(metric.status()))
+                            .count();
+            StringBuilder builder = new StringBuilder();
+            builder.append("# Notion 저장 모델 성능 실험 결과\n\n");
+            builder.append("- 측정 행: ").append(report.metrics.size()).append("\n");
+            builder.append("- 실패 관측 행: ").append(failures).append("\n");
+            builder.append("- cgroup OOM 한계 행: ").append(resourceLimits).append("\n");
+            builder.append("- 논리 JSON 불일치: ")
+                    .append(report.failedLogicalEquivalenceCount())
+                    .append("\n");
+            builder.append("- 미완료 매트릭스: ").append(report.invalidMatrixCount()).append("\n");
+            builder.append("- 쿼리 계획 파일: ").append(report.plans.size()).append("\n\n");
+            builder.append("## 핵심 비교\n\n");
+            builder.append("| DB 메모리 | Block | 비교 | 기준 p50(ms) | 개선 p50(ms) | 개선율 |\n");
+            builder.append("| ---: | ---: | --- | ---: | ---: | ---: |\n");
+            appendComparisonRows(builder, report, "N_PLUS_ONE", "BATCH");
+            appendComparisonRows(builder, report, "BATCH", "SNAPSHOT_READ");
+            appendComparisonRows(builder, report, "BATCH", "COMPACT");
+            appendComparisonRows(builder, report, "INTEGER_REORDER", "POSITION_KEY_REORDER");
+            builder.append("\n상세 수치는 `metrics.csv`, `metrics.json`, `query-plans/`를 확인한다.\n");
+            builder.append(
+                    "이 실험은 전체 A DDL을 생성하지만 Page/Block/Rich Text/Mention/Snapshot 수직 슬라이스만 "
+                            + "채운다. Spring HTTP/JPA와 실제 Notion Importer 경로는 별도 2단계 실험 대상이다.\n");
+            Files.writeString(
+                    outputDirectory.resolve("summary.md"),
+                    builder.toString(),
+                    StandardCharsets.UTF_8);
+        }
+
+        private void appendComparisonRows(
+                StringBuilder builder,
+                PerformanceReport report,
+                String baselineScenario,
+                String improvedScenario) {
+            for (int memoryMiB : report.properties.memoryMiB()) {
+                for (int blockCount : report.properties.sizes()) {
+                    Metric baseline = findMetric(report, memoryMiB, blockCount, baselineScenario);
+                    Metric improved = findMetric(report, memoryMiB, blockCount, improvedScenario);
+                    if (baseline == null || improved == null || baseline.p50Nanos() == 0) {
+                        continue;
+                    }
+                    double improvement =
+                            (1.0d - ((double) improved.p50Nanos() / baseline.p50Nanos())) * 100.0d;
+                    builder.append(
+                            "| %dMiB | %,d | %s → %s | %.3f | %.3f | %.1f%% |%n"
+                                    .formatted(
+                                            memoryMiB,
+                                            blockCount,
+                                            baselineScenario,
+                                            improvedScenario,
+                                            baseline.p50Nanos() / 1_000_000.0d,
+                                            improved.p50Nanos() / 1_000_000.0d,
+                                            improvement));
+                }
+            }
+        }
+
+        private Metric findMetric(
+                PerformanceReport report, int memoryMiB, int blockCount, String scenario) {
+            return report.metrics.stream()
+                    .filter(
+                            metric ->
+                                    metric.memoryMiB() == memoryMiB
+                                            && metric.blockCount() == blockCount
+                                            && scenario.equals(metric.scenario()))
+                    .findFirst()
+                    .orElse(null);
+        }
+    }
+
+    private static final class ActiveDatabase {
+        private static String jdbcUrl;
+        private static String username;
+        private static String password;
+
+        static void connect(String jdbcUrl, String username, String password) {
+            ActiveDatabase.jdbcUrl = jdbcUrl;
+            ActiveDatabase.username = username;
+            ActiveDatabase.password = password;
+        }
+
+        static String jdbcUrl() {
+            return jdbcUrl;
+        }
+
+        static String username() {
+            return username;
+        }
+
+        static String password() {
+            return password;
+        }
+    }
+}

--- a/backend/src/performanceTest/resources/performance/baseline-a.sql
+++ b/backend/src/performanceTest/resources/performance/baseline-a.sql
@@ -1,0 +1,1406 @@
+-- =========================================================
+-- Knot Notion Import ERD v2.1
+-- PostgreSQL 15+
+-- ERDCloud import용
+-- 상태: A안 TARGET DDL (2026-08-10, ADR-001 / D-014)
+-- 구현 전 보완 항목은 docs/02-architecture/notion-import-architecture.md의
+-- "v2.1 DDL 보완 목록"과 docs/05-roadmap/notion-import-roadmap.md를 따른다.
+--
+-- 설계 원칙
+-- 1. Knot 사용자/워크스페이스와 Notion 사용자/연결을 분리한다.
+-- 2. Notion 원본은 snapshots에 보존한다.
+-- 3. objects가 Page/Database/Data Source/Block 계층의 Source of Truth다.
+-- 4. page_links, page_render_snapshots는 재생성 가능한 Projection이다.
+-- 5. Property의 단일 값은 page_property_values에 통합하고,
+--    다중 값만 연결 테이블로 분리한다.
+-- =========================================================
+
+
+-- =========================================================
+-- 1. Knot 서비스 사용자 / 워크스페이스
+-- =========================================================
+
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    email VARCHAR(320) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    profile_image_url VARCHAR(2048),
+    status VARCHAR(30) NOT NULL DEFAULT 'ACTIVE',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_users_email UNIQUE (email)
+);
+
+CREATE TABLE workspaces (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    created_by_user_id BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_workspaces_created_by
+        FOREIGN KEY (created_by_user_id)
+        REFERENCES users (id)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE workspace_members (
+    workspace_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    member_role VARCHAR(30) NOT NULL,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT pk_workspace_members
+        PRIMARY KEY (workspace_id, user_id),
+
+    CONSTRAINT fk_workspace_members_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_workspace_members_user
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 2. Notion OAuth / Connection
+-- =========================================================
+
+CREATE TABLE notion_oauth_states (
+    state VARCHAR(255) PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    workspace_id BIGINT,
+    redirect_path VARCHAR(1000),
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_notion_oauth_states_user
+        FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_notion_oauth_states_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE notion_connections (
+    id BIGSERIAL PRIMARY KEY,
+    workspace_id BIGINT NOT NULL,
+    connected_by_user_id BIGINT NOT NULL,
+
+    bot_id VARCHAR(100) NOT NULL,
+    notion_workspace_id VARCHAR(100) NOT NULL,
+    notion_workspace_name VARCHAR(255),
+    notion_workspace_icon VARCHAR(2048),
+    notion_owner_user_id VARCHAR(100),
+
+    encrypted_access_token TEXT NOT NULL,
+    encrypted_refresh_token TEXT,
+    access_token_expires_at TIMESTAMPTZ,
+
+    connection_status VARCHAR(30) NOT NULL DEFAULT 'CONNECTED',
+    connected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_refreshed_at TIMESTAMPTZ,
+    disconnected_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_notion_connections_bot_id
+        UNIQUE (bot_id),
+
+    CONSTRAINT fk_notion_connections_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_notion_connections_connected_by
+        FOREIGN KEY (connected_by_user_id)
+        REFERENCES users (id)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE notion_users (
+    id BIGSERIAL PRIMARY KEY,
+    notion_connection_id BIGINT NOT NULL,
+    notion_user_id VARCHAR(100) NOT NULL,
+    user_type VARCHAR(30) NOT NULL,
+    name VARCHAR(255),
+    email VARCHAR(320),
+    avatar_url VARCHAR(2048),
+    raw_payload JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_notion_users_connection_user
+        UNIQUE (notion_connection_id, notion_user_id),
+
+    CONSTRAINT fk_notion_users_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 3. Rich Text 공통 모델
+-- =========================================================
+
+CREATE TABLE rich_text_contents (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+
+-- =========================================================
+-- 4. Notion 공통 Object / 하위 타입
+-- =========================================================
+
+CREATE TABLE objects (
+    id BIGSERIAL PRIMARY KEY,
+    workspace_id BIGINT NOT NULL,
+    notion_connection_id BIGINT NOT NULL,
+
+    -- Knot DB에서 연결된 실제 부모 Object.
+    -- 부모가 아직 저장되지 않았거나 workspace/agent라면 NULL일 수 있다.
+    parent_object_id BIGINT,
+
+    -- Notion API parent 원본 정보.
+    -- 지원 타입: page_id, block_id, database_id, data_source_id, workspace, agent_id
+    external_parent_type VARCHAR(30),
+    external_parent_notion_id VARCHAR(100),
+
+    -- data_source_id parent 응답에 함께 포함되는 database_id 편의 값.
+    -- 계층의 Source of Truth는 parent_object_id이며, 이 컬럼은 원본 보존/조회 편의용이다.
+    parent_database_notion_id VARCHAR(100),
+
+    -- Notion API가 반환한 parent 객체 전체를 보존한다.
+    parent_payload JSONB,
+
+    notion_object_id VARCHAR(100),
+    object_type VARCHAR(30) NOT NULL,
+    source_type VARCHAR(20) NOT NULL DEFAULT 'NOTION',
+    position_index INTEGER,
+
+    created_by_notion_user_id BIGINT,
+    updated_by_notion_user_id BIGINT,
+
+    notion_created_at TIMESTAMPTZ,
+    notion_updated_at TIMESTAMPTZ,
+    is_in_trash BOOLEAN NOT NULL DEFAULT FALSE,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_objects_connection_notion
+        UNIQUE (notion_connection_id, notion_object_id),
+
+    CONSTRAINT ck_objects_external_parent_type
+        CHECK (
+            external_parent_type IS NULL
+            OR external_parent_type IN (
+                'page_id',
+                'block_id',
+                'database_id',
+                'data_source_id',
+                'workspace',
+                'agent_id'
+            )
+        ),
+
+    CONSTRAINT fk_objects_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_objects_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_objects_parent
+        FOREIGN KEY (parent_object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_objects_created_by
+        FOREIGN KEY (created_by_notion_user_id)
+        REFERENCES notion_users (id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_objects_updated_by
+        FOREIGN KEY (updated_by_notion_user_id)
+        REFERENCES notion_users (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE pages (
+    object_id BIGINT PRIMARY KEY,
+    title_rich_text_id BIGINT,
+    plain_title VARCHAR(1000),
+
+    page_kind VARCHAR(30) NOT NULL DEFAULT 'NORMAL',
+    url VARCHAR(2048),
+    public_url VARCHAR(2048),
+
+    icon_payload JSONB,
+    cover_payload JSONB,
+
+    is_locked BOOLEAN NOT NULL DEFAULT FALSE,
+
+    CONSTRAINT fk_pages_object
+        FOREIGN KEY (object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_pages_title
+        FOREIGN KEY (title_rich_text_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE databases (
+    object_id BIGINT PRIMARY KEY,
+    title_rich_text_id BIGINT,
+    description_rich_text_id BIGINT,
+
+    plain_title VARCHAR(1000),
+    plain_description TEXT,
+    is_inline BOOLEAN NOT NULL DEFAULT FALSE,
+
+    icon_payload JSONB,
+    cover_payload JSONB,
+
+    CONSTRAINT fk_databases_object
+        FOREIGN KEY (object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_databases_title
+        FOREIGN KEY (title_rich_text_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_databases_description
+        FOREIGN KEY (description_rich_text_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE data_sources (
+    object_id BIGINT PRIMARY KEY,
+    title_rich_text_id BIGINT,
+    description_rich_text_id BIGINT,
+
+    plain_title VARCHAR(1000),
+    plain_description TEXT,
+
+    CONSTRAINT fk_data_sources_object
+        FOREIGN KEY (object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_data_sources_title
+        FOREIGN KEY (title_rich_text_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_data_sources_description
+        FOREIGN KEY (description_rich_text_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE blocks (
+    object_id BIGINT PRIMARY KEY,
+    synced_from_block_object_id BIGINT,
+
+    block_type VARCHAR(50) NOT NULL,
+    has_children BOOLEAN NOT NULL DEFAULT FALSE,
+
+    -- Rich Text 자체가 아니라 타입별 설정과 fallback 원본
+    block_payload JSONB,
+
+    CONSTRAINT fk_blocks_object
+        FOREIGN KEY (object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_blocks_synced_from
+        FOREIGN KEY (synced_from_block_object_id)
+        REFERENCES blocks (object_id)
+        ON DELETE SET NULL
+);
+
+
+-- =========================================================
+-- 5. Rich Text Segment / Mention / Block 연결
+-- =========================================================
+
+CREATE TABLE rich_text_segments (
+    id BIGSERIAL PRIMARY KEY,
+    rich_text_content_id BIGINT NOT NULL,
+    position_index INTEGER NOT NULL,
+
+    segment_type VARCHAR(30) NOT NULL,
+    plain_text TEXT,
+    href VARCHAR(2048),
+
+    text_content TEXT,
+    link_url VARCHAR(2048),
+    equation_expression TEXT,
+
+    annotations JSONB,
+    segment_payload JSONB,
+
+    CONSTRAINT uk_rich_text_segments_position
+        UNIQUE (rich_text_content_id, position_index),
+
+    CONSTRAINT fk_rich_text_segments_content
+        FOREIGN KEY (rich_text_content_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE rich_text_mentions (
+    rich_text_segment_id BIGINT PRIMARY KEY,
+    mention_type VARCHAR(30) NOT NULL,
+
+    target_notion_user_id BIGINT,
+    target_page_object_id BIGINT,
+    target_database_object_id BIGINT,
+    target_data_source_object_id BIGINT,
+
+    mention_date_start TIMESTAMPTZ,
+    mention_date_end TIMESTAMPTZ,
+    mention_timezone VARCHAR(100),
+    link_preview_url VARCHAR(2048),
+
+    mention_payload JSONB,
+
+    CONSTRAINT fk_rich_text_mentions_segment
+        FOREIGN KEY (rich_text_segment_id)
+        REFERENCES rich_text_segments (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_rich_text_mentions_user
+        FOREIGN KEY (target_notion_user_id)
+        REFERENCES notion_users (id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_rich_text_mentions_page
+        FOREIGN KEY (target_page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_rich_text_mentions_database
+        FOREIGN KEY (target_database_object_id)
+        REFERENCES databases (object_id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_rich_text_mentions_data_source
+        FOREIGN KEY (target_data_source_object_id)
+        REFERENCES data_sources (object_id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE block_rich_text_fields (
+    block_object_id BIGINT NOT NULL,
+    field_name VARCHAR(50) NOT NULL,
+    rich_text_content_id BIGINT NOT NULL,
+
+    CONSTRAINT pk_block_rich_text_fields
+        PRIMARY KEY (block_object_id, field_name),
+
+    CONSTRAINT fk_block_rich_text_fields_block
+        FOREIGN KEY (block_object_id)
+        REFERENCES blocks (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_block_rich_text_fields_content
+        FOREIGN KEY (rich_text_content_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 6. Asset / 파일 영구 보존
+-- =========================================================
+
+CREATE TABLE assets (
+    id BIGSERIAL PRIMARY KEY,
+    workspace_id BIGINT NOT NULL,
+    notion_connection_id BIGINT NOT NULL,
+
+    notion_file_id VARCHAR(100),
+    asset_type VARCHAR(30) NOT NULL,
+    source_type VARCHAR(30) NOT NULL,
+
+    original_name VARCHAR(500),
+    mime_type VARCHAR(255),
+    file_size BIGINT,
+
+    storage_key VARCHAR(2048),
+    external_url VARCHAR(2048),
+    expires_at TIMESTAMPTZ,
+
+    download_status VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+    checksum VARCHAR(128),
+    downloaded_at TIMESTAMPTZ,
+    download_error TEXT,
+
+    raw_payload JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_assets_connection_file
+        UNIQUE (notion_connection_id, notion_file_id),
+
+    CONSTRAINT fk_assets_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_assets_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE page_assets (
+    page_object_id BIGINT NOT NULL,
+    asset_id BIGINT NOT NULL,
+    asset_role VARCHAR(30) NOT NULL,
+
+    CONSTRAINT pk_page_assets
+        PRIMARY KEY (page_object_id, asset_id, asset_role),
+
+    CONSTRAINT fk_page_assets_page
+        FOREIGN KEY (page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_assets_asset
+        FOREIGN KEY (asset_id)
+        REFERENCES assets (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE block_assets (
+    block_object_id BIGINT NOT NULL,
+    asset_id BIGINT NOT NULL,
+    asset_role VARCHAR(30) NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+    caption_rich_text_id BIGINT,
+
+    CONSTRAINT pk_block_assets
+        PRIMARY KEY (
+            block_object_id,
+            asset_id,
+            asset_role,
+            position_index
+        ),
+
+    CONSTRAINT fk_block_assets_block
+        FOREIGN KEY (block_object_id)
+        REFERENCES blocks (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_block_assets_asset
+        FOREIGN KEY (asset_id)
+        REFERENCES assets (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_block_assets_caption
+        FOREIGN KEY (caption_rich_text_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL
+);
+
+
+-- =========================================================
+-- 7. Data Source Property Schema
+-- =========================================================
+
+CREATE TABLE property_definitions (
+    id BIGSERIAL PRIMARY KEY,
+    data_source_object_id BIGINT NOT NULL,
+
+    notion_property_id VARCHAR(100) NOT NULL,
+    property_name VARCHAR(255) NOT NULL,
+    property_type VARCHAR(50) NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    configuration JSONB,
+    raw_payload JSONB,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_property_definitions_notion_id
+        UNIQUE (data_source_object_id, notion_property_id),
+
+    CONSTRAINT uk_property_definitions_name
+        UNIQUE (data_source_object_id, property_name),
+
+    CONSTRAINT fk_property_definitions_data_source
+        FOREIGN KEY (data_source_object_id)
+        REFERENCES data_sources (object_id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE property_option_groups (
+    id BIGSERIAL PRIMARY KEY,
+    property_definition_id BIGINT NOT NULL,
+
+    notion_group_id VARCHAR(100),
+    group_name VARCHAR(255) NOT NULL,
+    group_color VARCHAR(30) NOT NULL DEFAULT 'default',
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT uk_property_option_groups_notion_id
+        UNIQUE (property_definition_id, notion_group_id),
+
+    CONSTRAINT fk_property_option_groups_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE property_select_options (
+    id BIGSERIAL PRIMARY KEY,
+    property_definition_id BIGINT NOT NULL,
+    option_group_id BIGINT,
+
+    notion_option_id VARCHAR(100) NOT NULL,
+    option_name VARCHAR(255) NOT NULL,
+    option_color VARCHAR(30) NOT NULL DEFAULT 'default',
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT uk_property_select_options_notion_id
+        UNIQUE (property_definition_id, notion_option_id),
+
+    CONSTRAINT fk_property_select_options_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_property_select_options_group
+        FOREIGN KEY (option_group_id)
+        REFERENCES property_option_groups (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE relation_property_configs (
+    property_definition_id BIGINT PRIMARY KEY,
+
+    target_data_source_object_id BIGINT,
+    target_data_source_notion_id VARCHAR(100) NOT NULL,
+
+    synced_property_definition_id BIGINT,
+    synced_property_notion_id VARCHAR(100),
+
+    relation_type VARCHAR(30) NOT NULL,
+    raw_payload JSONB,
+
+    CONSTRAINT fk_relation_configs_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_relation_configs_target_source
+        FOREIGN KEY (target_data_source_object_id)
+        REFERENCES data_sources (object_id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_relation_configs_synced_property
+        FOREIGN KEY (synced_property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE formula_property_configs (
+    property_definition_id BIGINT PRIMARY KEY,
+    formula_expression TEXT,
+    result_type VARCHAR(30),
+    raw_payload JSONB,
+
+    CONSTRAINT fk_formula_configs_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE rollup_property_configs (
+    property_definition_id BIGINT PRIMARY KEY,
+
+    relation_property_definition_id BIGINT,
+    relation_property_notion_id VARCHAR(100),
+
+    target_property_definition_id BIGINT,
+    target_property_notion_id VARCHAR(100),
+
+    aggregation_function VARCHAR(50) NOT NULL,
+    result_type VARCHAR(30),
+    raw_payload JSONB,
+
+    CONSTRAINT fk_rollup_configs_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_rollup_configs_relation
+        FOREIGN KEY (relation_property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_rollup_configs_target
+        FOREIGN KEY (target_property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE SET NULL
+);
+
+
+-- =========================================================
+-- 8. Page Property Value
+-- 단일 값은 공통 테이블, 다중 값은 연결 테이블
+-- =========================================================
+
+CREATE TABLE page_property_values (
+    id BIGSERIAL PRIMARY KEY,
+    page_object_id BIGINT NOT NULL,
+    property_definition_id BIGINT NOT NULL,
+
+    notion_value_id VARCHAR(100),
+    value_type VARCHAR(50) NOT NULL,
+    raw_value JSONB,
+
+    -- 검색/정렬용 추출 컬럼
+    rich_text_content_id BIGINT,
+    text_value TEXT,
+    number_value NUMERIC(38, 10),
+    boolean_value BOOLEAN,
+
+    date_start DATE,
+    date_end DATE,
+    datetime_start TIMESTAMPTZ,
+    datetime_end TIMESTAMPTZ,
+    time_zone VARCHAR(100),
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_page_property_values
+        UNIQUE (page_object_id, property_definition_id),
+
+    CONSTRAINT fk_page_property_values_page
+        FOREIGN KEY (page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_property_values_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_property_values_rich_text
+        FOREIGN KEY (rich_text_content_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE property_value_options (
+    property_value_id BIGINT NOT NULL,
+    option_id BIGINT NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT pk_property_value_options
+        PRIMARY KEY (property_value_id, option_id),
+
+    CONSTRAINT fk_property_value_options_value
+        FOREIGN KEY (property_value_id)
+        REFERENCES page_property_values (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_property_value_options_option
+        FOREIGN KEY (option_id)
+        REFERENCES property_select_options (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE property_value_users (
+    property_value_id BIGINT NOT NULL,
+    notion_user_id BIGINT NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT pk_property_value_users
+        PRIMARY KEY (property_value_id, notion_user_id),
+
+    CONSTRAINT fk_property_value_users_value
+        FOREIGN KEY (property_value_id)
+        REFERENCES page_property_values (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_property_value_users_user
+        FOREIGN KEY (notion_user_id)
+        REFERENCES notion_users (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE property_value_relations (
+    property_value_id BIGINT NOT NULL,
+
+    target_page_object_id BIGINT,
+    target_notion_page_id VARCHAR(100) NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT pk_property_value_relations
+        PRIMARY KEY (property_value_id, target_notion_page_id),
+
+    CONSTRAINT fk_property_value_relations_value
+        FOREIGN KEY (property_value_id)
+        REFERENCES page_property_values (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_property_value_relations_target
+        FOREIGN KEY (target_page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE property_value_files (
+    property_value_id BIGINT NOT NULL,
+    asset_id BIGINT NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+    display_name VARCHAR(500),
+
+    CONSTRAINT pk_property_value_files
+        PRIMARY KEY (property_value_id, asset_id),
+
+    CONSTRAINT fk_property_value_files_value
+        FOREIGN KEY (property_value_id)
+        REFERENCES page_property_values (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_property_value_files_asset
+        FOREIGN KEY (asset_id)
+        REFERENCES assets (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 9. Data Source Template / View
+-- =========================================================
+
+CREATE TABLE data_source_templates (
+    id BIGSERIAL PRIMARY KEY,
+    data_source_object_id BIGINT NOT NULL,
+
+    notion_template_id VARCHAR(100) NOT NULL,
+    template_page_object_id BIGINT,
+
+    template_name VARCHAR(255) NOT NULL,
+    description TEXT,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    raw_payload JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_data_source_templates_notion_id
+        UNIQUE (data_source_object_id, notion_template_id),
+
+    CONSTRAINT fk_data_source_templates_source
+        FOREIGN KEY (data_source_object_id)
+        REFERENCES data_sources (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_data_source_templates_page
+        FOREIGN KEY (template_page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE data_source_views (
+    id BIGSERIAL PRIMARY KEY,
+
+    notion_view_id VARCHAR(100) NOT NULL,
+    database_object_id BIGINT NOT NULL,
+    data_source_object_id BIGINT,
+
+    view_name VARCHAR(255) NOT NULL,
+    view_type VARCHAR(30) NOT NULL,
+    position_index INTEGER NOT NULL DEFAULT 0,
+
+    layout_configuration JSONB,
+    raw_payload JSONB,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_data_source_views_notion_id
+        UNIQUE (notion_view_id),
+
+    CONSTRAINT fk_data_source_views_database
+        FOREIGN KEY (database_object_id)
+        REFERENCES databases (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_data_source_views_data_source
+        FOREIGN KEY (data_source_object_id)
+        REFERENCES data_sources (object_id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE data_source_view_properties (
+    view_id BIGINT NOT NULL,
+    property_definition_id BIGINT NOT NULL,
+
+    position_index INTEGER NOT NULL DEFAULT 0,
+    is_visible BOOLEAN NOT NULL DEFAULT TRUE,
+    width INTEGER,
+
+    CONSTRAINT pk_data_source_view_properties
+        PRIMARY KEY (view_id, property_definition_id),
+
+    CONSTRAINT fk_data_source_view_properties_view
+        FOREIGN KEY (view_id)
+        REFERENCES data_source_views (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_data_source_view_properties_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE data_source_view_sorts (
+    id BIGSERIAL PRIMARY KEY,
+    view_id BIGINT NOT NULL,
+    property_definition_id BIGINT NOT NULL,
+
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    direction VARCHAR(10) NOT NULL,
+    nulls_order VARCHAR(10) NOT NULL DEFAULT 'LAST',
+
+    CONSTRAINT fk_data_source_view_sorts_view
+        FOREIGN KEY (view_id)
+        REFERENCES data_source_views (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_data_source_view_sorts_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE data_source_view_groups (
+    id BIGSERIAL PRIMARY KEY,
+    view_id BIGINT NOT NULL,
+    property_definition_id BIGINT NOT NULL,
+
+    position_index INTEGER NOT NULL DEFAULT 0,
+    direction VARCHAR(10) NOT NULL DEFAULT 'ASC',
+    hide_empty_groups BOOLEAN NOT NULL DEFAULT FALSE,
+
+    CONSTRAINT fk_data_source_view_groups_view
+        FOREIGN KEY (view_id)
+        REFERENCES data_source_views (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_data_source_view_groups_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE data_source_view_filter_nodes (
+    id BIGSERIAL PRIMARY KEY,
+    view_id BIGINT NOT NULL,
+    parent_filter_node_id BIGINT,
+
+    node_type VARCHAR(20) NOT NULL,
+    logical_operator VARCHAR(10),
+
+    property_definition_id BIGINT,
+    filter_operator VARCHAR(40),
+    value_type VARCHAR(30),
+
+    string_value TEXT,
+    number_value NUMERIC(38, 10),
+    boolean_value BOOLEAN,
+
+    date_value DATE,
+    datetime_value TIMESTAMPTZ,
+    time_zone VARCHAR(100),
+
+    position_index INTEGER NOT NULL DEFAULT 0,
+    raw_payload JSONB,
+
+    CONSTRAINT fk_filter_nodes_view
+        FOREIGN KEY (view_id)
+        REFERENCES data_source_views (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_filter_nodes_parent
+        FOREIGN KEY (parent_filter_node_id)
+        REFERENCES data_source_view_filter_nodes (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_filter_nodes_definition
+        FOREIGN KEY (property_definition_id)
+        REFERENCES property_definitions (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE data_source_view_filter_options (
+    filter_node_id BIGINT NOT NULL,
+    option_id BIGINT NOT NULL,
+
+    CONSTRAINT pk_data_source_view_filter_options
+        PRIMARY KEY (filter_node_id, option_id),
+
+    CONSTRAINT fk_filter_options_node
+        FOREIGN KEY (filter_node_id)
+        REFERENCES data_source_view_filter_nodes (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_filter_options_option
+        FOREIGN KEY (option_id)
+        REFERENCES property_select_options (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE data_source_view_filter_users (
+    filter_node_id BIGINT NOT NULL,
+    notion_user_id BIGINT NOT NULL,
+
+    CONSTRAINT pk_data_source_view_filter_users
+        PRIMARY KEY (filter_node_id, notion_user_id),
+
+    CONSTRAINT fk_filter_users_node
+        FOREIGN KEY (filter_node_id)
+        REFERENCES data_source_view_filter_nodes (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_filter_users_user
+        FOREIGN KEY (notion_user_id)
+        REFERENCES notion_users (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE data_source_view_filter_pages (
+    filter_node_id BIGINT NOT NULL,
+
+    page_object_id BIGINT,
+    notion_page_id VARCHAR(100) NOT NULL,
+
+    CONSTRAINT pk_data_source_view_filter_pages
+        PRIMARY KEY (filter_node_id, notion_page_id),
+
+    CONSTRAINT fk_filter_pages_node
+        FOREIGN KEY (filter_node_id)
+        REFERENCES data_source_view_filter_nodes (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_filter_pages_page
+        FOREIGN KEY (page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE SET NULL
+);
+
+
+-- =========================================================
+-- 10. Comment
+-- =========================================================
+
+CREATE TABLE comments (
+    id BIGSERIAL PRIMARY KEY,
+    notion_connection_id BIGINT NOT NULL,
+
+    notion_comment_id VARCHAR(100) NOT NULL,
+    parent_object_id BIGINT NOT NULL,
+    discussion_id VARCHAR(255),
+
+    created_by_notion_user_id BIGINT,
+    rich_text_content_id BIGINT NOT NULL,
+
+    notion_created_at TIMESTAMPTZ,
+    notion_updated_at TIMESTAMPTZ,
+    is_resolved BOOLEAN NOT NULL DEFAULT FALSE,
+
+    raw_payload JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_comments_connection_comment
+        UNIQUE (notion_connection_id, notion_comment_id),
+
+    CONSTRAINT fk_comments_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_comments_parent_object
+        FOREIGN KEY (parent_object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_comments_created_by
+        FOREIGN KEY (created_by_notion_user_id)
+        REFERENCES notion_users (id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_comments_rich_text
+        FOREIGN KEY (rich_text_content_id)
+        REFERENCES rich_text_contents (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 11. Page Link Projection
+-- Rich Text Mention / Relation에서 재생성 가능
+-- =========================================================
+
+CREATE TABLE page_links (
+    id BIGSERIAL PRIMARY KEY,
+    workspace_id BIGINT NOT NULL,
+    notion_connection_id BIGINT NOT NULL,
+
+    source_page_object_id BIGINT NOT NULL,
+    target_page_object_id BIGINT,
+    target_notion_page_id VARCHAR(100) NOT NULL,
+
+    source_block_object_id BIGINT,
+    source_segment_id BIGINT,
+
+    link_type VARCHAR(30) NOT NULL,
+    generated_from VARCHAR(30) NOT NULL,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_page_links_workspace
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_links_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_links_source_page
+        FOREIGN KEY (source_page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_links_target_page
+        FOREIGN KEY (target_page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE SET NULL,
+
+    CONSTRAINT fk_page_links_source_block
+        FOREIGN KEY (source_block_object_id)
+        REFERENCES blocks (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_page_links_source_segment
+        FOREIGN KEY (source_segment_id)
+        REFERENCES rich_text_segments (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 12. Import / Sync / Webhook 운영
+-- =========================================================
+
+CREATE TABLE notion_sync_roots (
+    id BIGSERIAL PRIMARY KEY,
+    notion_connection_id BIGINT NOT NULL,
+
+    notion_object_id VARCHAR(100) NOT NULL,
+    object_type VARCHAR(30) NOT NULL,
+    local_object_id BIGINT,
+
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_notion_sync_roots
+        UNIQUE (notion_connection_id, notion_object_id),
+
+    CONSTRAINT fk_notion_sync_roots_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_notion_sync_roots_object
+        FOREIGN KEY (local_object_id)
+        REFERENCES objects (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE sync_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    notion_connection_id BIGINT NOT NULL,
+
+    sync_type VARCHAR(30) NOT NULL,
+    sync_status VARCHAR(30) NOT NULL,
+
+    total_count INTEGER NOT NULL DEFAULT 0,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    error_message TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_sync_jobs_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE sync_job_items (
+    id BIGSERIAL PRIMARY KEY,
+    sync_job_id BIGINT NOT NULL,
+
+    notion_object_id VARCHAR(100) NOT NULL,
+    object_type VARCHAR(30) NOT NULL,
+    local_object_id BIGINT,
+
+    sync_status VARCHAR(30) NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    error_message TEXT,
+
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+
+    CONSTRAINT uk_sync_job_items
+        UNIQUE (sync_job_id, notion_object_id),
+
+    CONSTRAINT fk_sync_job_items_job
+        FOREIGN KEY (sync_job_id)
+        REFERENCES sync_jobs (id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_sync_job_items_object
+        FOREIGN KEY (local_object_id)
+        REFERENCES objects (id)
+        ON DELETE SET NULL
+);
+
+CREATE TABLE object_sync_states (
+    object_id BIGINT PRIMARY KEY,
+
+    notion_last_edited_at TIMESTAMPTZ,
+    last_synced_at TIMESTAMPTZ,
+
+    content_hash VARCHAR(128),
+    sync_status VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_error_message TEXT,
+    access_lost_at TIMESTAMPTZ,
+
+    CONSTRAINT fk_object_sync_states_object
+        FOREIGN KEY (object_id)
+        REFERENCES objects (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE notion_object_snapshots (
+    id BIGSERIAL PRIMARY KEY,
+    notion_connection_id BIGINT NOT NULL,
+
+    notion_object_id VARCHAR(100) NOT NULL,
+    object_type VARCHAR(30) NOT NULL,
+    api_version VARCHAR(30) NOT NULL,
+
+    raw_payload JSONB NOT NULL,
+    fetched_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_snapshots_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE webhook_subscriptions (
+    id BIGSERIAL PRIMARY KEY,
+    notion_connection_id BIGINT NOT NULL,
+
+    notion_subscription_id VARCHAR(100),
+    callback_url VARCHAR(2048) NOT NULL,
+    encrypted_verification_token TEXT,
+
+    subscription_status VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+    verified_at TIMESTAMPTZ,
+    disabled_at TIMESTAMPTZ,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT uk_webhook_subscriptions_notion_id
+        UNIQUE (notion_subscription_id),
+
+    CONSTRAINT fk_webhook_subscriptions_connection
+        FOREIGN KEY (notion_connection_id)
+        REFERENCES notion_connections (id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE webhook_events (
+    id BIGSERIAL PRIMARY KEY,
+    webhook_subscription_id BIGINT NOT NULL,
+
+    notion_event_id VARCHAR(100) NOT NULL,
+    event_type VARCHAR(100) NOT NULL,
+
+    entity_type VARCHAR(30),
+    entity_notion_id VARCHAR(100),
+
+    attempt_number INTEGER NOT NULL DEFAULT 1,
+    payload JSONB NOT NULL,
+
+    processing_status VARCHAR(30) NOT NULL DEFAULT 'RECEIVED',
+    received_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    processed_at TIMESTAMPTZ,
+    error_message TEXT,
+
+    CONSTRAINT uk_webhook_events_notion_id
+        UNIQUE (notion_event_id),
+
+    CONSTRAINT fk_webhook_events_subscription
+        FOREIGN KEY (webhook_subscription_id)
+        REFERENCES webhook_subscriptions (id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 13. 프론트 조회용 Projection
+-- =========================================================
+
+CREATE TABLE page_render_snapshots (
+    page_object_id BIGINT PRIMARY KEY,
+
+    version BIGINT NOT NULL DEFAULT 1,
+    document_json JSONB NOT NULL,
+
+    source_updated_at TIMESTAMPTZ NOT NULL,
+    generated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_page_render_snapshots_page
+        FOREIGN KEY (page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================================================
+-- 14. 주요 인덱스
+-- =========================================================
+
+CREATE INDEX idx_workspace_members_user
+    ON workspace_members (user_id);
+
+CREATE INDEX idx_notion_connections_workspace
+    ON notion_connections (workspace_id);
+
+CREATE INDEX idx_notion_users_connection
+    ON notion_users (notion_connection_id);
+
+CREATE INDEX idx_objects_workspace_type
+    ON objects (workspace_id, object_type);
+
+CREATE INDEX idx_objects_connection_type
+    ON objects (notion_connection_id, object_type);
+
+CREATE INDEX idx_objects_parent_position
+    ON objects (parent_object_id, position_index);
+
+CREATE INDEX idx_objects_external_parent
+    ON objects (
+        notion_connection_id,
+        external_parent_type,
+        external_parent_notion_id
+    );
+
+CREATE INDEX idx_objects_parent_database_notion
+    ON objects (notion_connection_id, parent_database_notion_id);
+
+CREATE INDEX idx_objects_notion_updated_at
+    ON objects (notion_connection_id, notion_updated_at);
+
+CREATE INDEX idx_pages_plain_title
+    ON pages (plain_title);
+
+CREATE INDEX idx_blocks_block_type
+    ON blocks (block_type);
+
+CREATE INDEX idx_rich_text_segments_content_position
+    ON rich_text_segments (rich_text_content_id, position_index);
+
+CREATE INDEX idx_assets_download_status
+    ON assets (download_status);
+
+CREATE INDEX idx_property_definitions_source_position
+    ON property_definitions (data_source_object_id, position_index);
+
+CREATE INDEX idx_page_property_values_page
+    ON page_property_values (page_object_id);
+
+CREATE INDEX idx_page_property_values_definition
+    ON page_property_values (property_definition_id);
+
+CREATE INDEX idx_page_property_values_text
+    ON page_property_values (text_value);
+
+CREATE INDEX idx_page_property_values_number
+    ON page_property_values (number_value);
+
+CREATE INDEX idx_page_property_values_date
+    ON page_property_values (date_start);
+
+CREATE INDEX idx_page_property_values_datetime
+    ON page_property_values (datetime_start);
+
+CREATE INDEX idx_property_value_relations_target
+    ON property_value_relations (target_notion_page_id);
+
+CREATE INDEX idx_data_source_views_database
+    ON data_source_views (database_object_id);
+
+CREATE INDEX idx_page_links_source
+    ON page_links (source_page_object_id);
+
+CREATE INDEX idx_page_links_target
+    ON page_links (target_notion_page_id);
+
+CREATE INDEX idx_sync_jobs_connection_status
+    ON sync_jobs (notion_connection_id, sync_status);
+
+CREATE INDEX idx_snapshots_object_fetched
+    ON notion_object_snapshots (
+        notion_connection_id,
+        notion_object_id,
+        fetched_at
+    );
+
+CREATE INDEX idx_webhook_events_status
+    ON webhook_events (processing_status, received_at);

--- a/backend/src/performanceTest/resources/performance/experiment-schema.sql
+++ b/backend/src/performanceTest/resources/performance/experiment-schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE experiment_compact_blocks (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    page_object_id BIGINT NOT NULL,
+    source_block_object_id BIGINT NOT NULL,
+    parent_block_object_id BIGINT,
+    position_key TEXT NOT NULL,
+    block_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    archived_at TIMESTAMPTZ,
+
+    CONSTRAINT uk_experiment_compact_blocks_source
+        UNIQUE (source_block_object_id),
+
+    CONSTRAINT uk_experiment_compact_blocks_position
+        UNIQUE NULLS NOT DISTINCT (page_object_id, parent_block_object_id, position_key),
+
+    CONSTRAINT fk_experiment_compact_blocks_page
+        FOREIGN KEY (page_object_id)
+        REFERENCES pages (object_id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_experiment_compact_blocks_source
+        FOREIGN KEY (source_block_object_id)
+        REFERENCES blocks (object_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_experiment_compact_blocks_page_parent_position
+    ON experiment_compact_blocks (page_object_id, parent_block_object_id, position_key);

--- a/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
+++ b/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
@@ -12,5 +12,11 @@ import org.springframework.context.annotation.Import;
 class KnotApplicationTests {
 
     @Test
-    void contextLoads() {}
+    void contextLoads() {
+        // given
+
+        // when
+
+        // then
+    }
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #158

## 작업 내용

- 현재 Notion v2.1 A안 DDL을 재현하는 격리된 `performanceTest` source set을 추가했습니다.
- 1천/1만/10만 Block과 PostgreSQL 1024/512/256MiB 조합에서 N+1, set 기반 Batch, Render Snapshot, Compact JSONB를 같은 논리 JSON으로 비교합니다.
- 정수 범위 재정렬과 한 Row 문자열 순서 키를 동시성 10/50에서 비교하고 WAL, 변경 행, lock timeout을 기록합니다.
- cgroup memory/max/swap/events, DB 크기, JVM heap/JFR, EXPLAIN ANALYZE 계획을 결과로 남깁니다.
- 실행 계획과 최종 결과를 `PERFORMANCE_EXPERIMENT.md`, `PERFORMANCE_RESULTS.md`에 정리했습니다.

## 검증

- 전체 성능 매트릭스 성공: 5분 12초, 측정 행 125개, 논리 JSON 불일치 0개, 미완료 조합 0개
- 전체 백엔드 검증 성공: `spotlessCheck`, `test`, `integrationTest`, `acceptanceTest`, `bootJar`
- 컨벤션 원문 hash gate와 전체 파일 검사 성공
- 독립 코드 리뷰 승인

### 참고 사항

- 현재 하네스는 JDBC + JVM JSON 조립 경로입니다. 실제 Notion Importer, Spring/JPA/HTTP 경로는 구현 후 2단계 실험이 필요합니다.
- 512/256MiB OOM은 A안, Snapshot, Compact가 함께 존재하는 통합 비교 fixture 결과이며 A안 단독 용량 한계가 아닙니다.
- 10만 Block에서 N+1은 p50 24.612초/100,001 SQL, Batch는 0.274초/1 SQL이었습니다.
- Snapshot과 Compact는 Batch보다 일관되게 빠르지 않았으므로 테이블 통폐합 근거로 해석하지 않습니다.
