### PR TITLE
[BE] Java formatter와 강제 줄바꿈 규칙 통합

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
 spotless {
 	java {
-		googleJavaFormat().aosp()
+		eclipse('4.39').configFile('config/spotless/eclipse-formatter.xml')
 		removeUnusedImports()
 		trimTrailingWhitespace()
 		endWithNewline()

--- a/backend/config/spotless/eclipse-formatter.xml
+++ b/backend/config/spotless/eclipse-formatter.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="23">
+    <profile kind="CodeFormatterProfile" name="Knot" version="23">
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_if_empty"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="do not insert"/>
+
+        <!-- 49 = force split + one item per line + default continuation indentation. -->
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+
+        <!-- 81 = force split + wrap the next selector on each line. -->
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="81"/>
+
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="separate_lines_if_wrapped"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="separate_lines_if_wrapped"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="separate_lines_if_wrapped"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="separate_lines_if_wrapped"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="separate_lines_if_wrapped"/>
+    </profile>
+</profiles>

--- a/backend/src/main/java/com/knot/backend/KnotApplication.java
+++ b/backend/src/main/java/com/knot/backend/KnotApplication.java
@@ -7,6 +7,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class KnotApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(KnotApplication.class, args);
+        SpringApplication.run(
+                KnotApplication.class,
+                args
+        );
     }
 }

--- a/backend/src/main/java/com/knot/backend/global/exception/CommonErrorCode.java
+++ b/backend/src/main/java/com/knot/backend/global/exception/CommonErrorCode.java
@@ -1,23 +1,45 @@
 package com.knot.backend.global.exception;
 
 public enum CommonErrorCode implements ErrorCode {
-    VALIDATION_ERROR(ErrorCategory.INVALID_INPUT, "VALIDATION_ERROR", "입력값이 올바르지 않습니다"),
+    VALIDATION_ERROR(
+            ErrorCategory.INVALID_INPUT,
+            "VALIDATION_ERROR",
+            "입력값이 올바르지 않습니다"
+    ),
 
     INVALID_REQUEST_BODY(
-            ErrorCategory.INVALID_INPUT, "INVALID_REQUEST_BODY", "요청 본문 형식이 올바르지 않습니다"),
+            ErrorCategory.INVALID_INPUT,
+            "INVALID_REQUEST_BODY",
+            "요청 본문 형식이 올바르지 않습니다"
+    ),
 
-    INVALID_PARAMETER(ErrorCategory.INVALID_INPUT, "INVALID_PARAMETER", "요청 파라미터 형식이 올바르지 않습니다"),
+    INVALID_PARAMETER(
+            ErrorCategory.INVALID_INPUT,
+            "INVALID_PARAMETER",
+            "요청 파라미터 형식이 올바르지 않습니다"
+    ),
 
-    MISSING_PARAMETER(ErrorCategory.INVALID_INPUT, "MISSING_PARAMETER", "필수 요청 파라미터가 누락되었습니다"),
+    MISSING_PARAMETER(
+            ErrorCategory.INVALID_INPUT,
+            "MISSING_PARAMETER",
+            "필수 요청 파라미터가 누락되었습니다"
+    ),
 
     INTERNAL_SERVER_ERROR(
-            ErrorCategory.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다");
+            ErrorCategory.INTERNAL_SERVER_ERROR,
+            "INTERNAL_SERVER_ERROR",
+            "서버 오류가 발생했습니다"
+    );
 
     private final ErrorCategory category;
     private final String code;
     private final String message;
 
-    CommonErrorCode(ErrorCategory category, String code, String message) {
+    CommonErrorCode(
+            ErrorCategory category,
+            String code,
+            String message
+    ) {
         this.category = category;
         this.code = code;
         this.message = message;

--- a/backend/src/main/java/com/knot/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/knot/backend/global/exception/GlobalExceptionHandler.java
@@ -27,55 +27,76 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(
-            MethodArgumentNotValidException exception) {
-        List<FieldErrorResponse> fieldErrors =
-                exception.getBindingResult().getFieldErrors().stream()
-                        .map(
-                                error ->
-                                        new FieldErrorResponse(
-                                                error.getField(), error.getDefaultMessage()))
-                        .toList();
+            MethodArgumentNotValidException exception
+    ) {
+        List<FieldErrorResponse> fieldErrors = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(
+                        error -> new FieldErrorResponse(
+                                error.getField(),
+                                error.getDefaultMessage()
+                        )
+                )
+                .toList();
 
-        return respond(CommonErrorCode.VALIDATION_ERROR, fieldErrors);
+        return respond(
+                CommonErrorCode.VALIDATION_ERROR,
+                fieldErrors
+        );
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraintViolationException(
-            ConstraintViolationException exception) {
-        List<FieldErrorResponse> fieldErrors =
-                exception.getConstraintViolations().stream()
-                        .map(this::toFieldErrorResponse)
-                        .toList();
+            ConstraintViolationException exception
+    ) {
+        List<FieldErrorResponse> fieldErrors = exception.getConstraintViolations()
+                .stream()
+                .map(this::toFieldErrorResponse)
+                .toList();
 
-        return respond(CommonErrorCode.VALIDATION_ERROR, fieldErrors);
+        return respond(
+                CommonErrorCode.VALIDATION_ERROR,
+                fieldErrors
+        );
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleUnreadableMessage(
-            HttpMessageNotReadableException ignored) {
+            HttpMessageNotReadableException ignored
+    ) {
         return respond(CommonErrorCode.INVALID_REQUEST_BODY);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(
-            MethodArgumentTypeMismatchException exception) {
-        FieldErrorResponse fieldError =
-                new FieldErrorResponse(
-                        exception.getName(), CommonErrorCode.INVALID_PARAMETER.getMessage());
+            MethodArgumentTypeMismatchException exception
+    ) {
+        FieldErrorResponse fieldError = new FieldErrorResponse(
+                exception.getName(),
+                CommonErrorCode.INVALID_PARAMETER.getMessage()
+        );
 
-        return respond(CommonErrorCode.INVALID_PARAMETER, List.of(fieldError));
+        return respond(
+                CommonErrorCode.INVALID_PARAMETER,
+                List.of(fieldError)
+        );
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingParameter(
-            MissingServletRequestParameterException exception) {
+            MissingServletRequestParameterException exception
+    ) {
 
-        FieldErrorResponse fieldError =
-                new FieldErrorResponse(
-                        exception.getParameterName(),
-                        CommonErrorCode.MISSING_PARAMETER.getMessage());
+        FieldErrorResponse fieldError = new FieldErrorResponse(
+                exception.getParameterName(),
+                CommonErrorCode.MISSING_PARAMETER.getMessage()
+        );
 
-        return respond(CommonErrorCode.MISSING_PARAMETER, List.of(fieldError));
+        return respond(
+                CommonErrorCode.MISSING_PARAMETER,
+                List.of(fieldError)
+        );
     }
 
     @ExceptionHandler(Exception.class)
@@ -85,15 +106,25 @@ public class GlobalExceptionHandler {
 
     private FieldErrorResponse toFieldErrorResponse(ConstraintViolation<?> violation) {
         return new FieldErrorResponse(
-                extractFieldName(violation.getPropertyPath()), violation.getMessage());
+                extractFieldName(violation.getPropertyPath()),
+                violation.getMessage()
+        );
     }
 
     private String extractFieldName(Path path) {
-        return StreamSupport.stream(path.spliterator(), false)
+        return StreamSupport.stream(
+                path.spliterator(),
+                false
+        )
                 .filter(this::isFieldNode)
                 .map(Path.Node::getName)
                 .filter(this::isUsableFieldName)
-                .reduce((first, second) -> second)
+                .reduce(
+                        (
+                                first,
+                                second
+                        ) -> second
+                )
                 .orElse("request");
     }
 
@@ -106,13 +137,23 @@ public class GlobalExceptionHandler {
     }
 
     private ResponseEntity<ErrorResponse> respond(ErrorCode errorCode) {
-        return respond(errorCode, List.of());
+        return respond(
+                errorCode,
+                List.of()
+        );
     }
 
     private ResponseEntity<ErrorResponse> respond(
-            ErrorCode errorCode, List<FieldErrorResponse> fieldErrors) {
+            ErrorCode errorCode,
+            List<FieldErrorResponse> fieldErrors
+    ) {
         return ResponseEntity.status(toHttpStatus(errorCode.getCategory()))
-                .body(new ErrorResponse(errorCode, fieldErrors));
+                .body(
+                        new ErrorResponse(
+                                errorCode,
+                                fieldErrors
+                        )
+                );
     }
 
     private HttpStatus toHttpStatus(ErrorCategory category) {

--- a/backend/src/main/java/com/knot/backend/global/exception/ProjectException.java
+++ b/backend/src/main/java/com/knot/backend/global/exception/ProjectException.java
@@ -6,21 +6,31 @@ import lombok.Getter;
 
 @Getter
 public abstract class ProjectException extends RuntimeException {
-
     @Serial private static final long serialVersionUID = 1L;
-
     private final ErrorCode errorCode;
 
     protected ProjectException(ErrorCode errorCode) {
-        this(errorCode, null);
+        this(
+                errorCode,
+                null
+        );
     }
 
-    protected ProjectException(ErrorCode errorCode, Throwable cause) {
-        super(requireErrorCode(errorCode).getMessage(), cause);
+    protected ProjectException(
+            ErrorCode errorCode,
+            Throwable cause
+    ) {
+        super(
+                requireErrorCode(errorCode).getMessage(),
+                cause
+        );
         this.errorCode = errorCode;
     }
 
     private static ErrorCode requireErrorCode(ErrorCode errorCode) {
-        return Objects.requireNonNull(errorCode, "errorCode");
+        return Objects.requireNonNull(
+                errorCode,
+                "errorCode"
+        );
     }
 }

--- a/backend/src/main/java/com/knot/backend/global/response/ErrorResponse.java
+++ b/backend/src/main/java/com/knot/backend/global/response/ErrorResponse.java
@@ -6,26 +6,44 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ErrorResponse(String code, String message, List<FieldErrorResponse> fieldErrors) {
+public record ErrorResponse(
+        String code,
+        String message,
+        List<FieldErrorResponse> fieldErrors
+) {
 
-    public ErrorResponse(String code, String message, List<FieldErrorResponse> fieldErrors) {
+    public ErrorResponse(
+            String code,
+            String message,
+            List<FieldErrorResponse> fieldErrors
+    ) {
         this.code = code;
         this.message = message;
         this.fieldErrors = fieldErrors;
     }
 
     public ErrorResponse(ErrorCode errorCode) {
-        this(errorCode, List.of());
+        this(
+                errorCode,
+                List.of()
+        );
     }
 
-    public ErrorResponse(ErrorCode errorCode, List<FieldErrorResponse> fieldErrors) {
+    public ErrorResponse(
+            ErrorCode errorCode,
+            List<FieldErrorResponse> fieldErrors
+    ) {
         this(
                 requireErrorCode(errorCode).getCode(),
                 requireErrorCode(errorCode).getMessage(),
-                fieldErrors);
+                fieldErrors
+        );
     }
 
     private static ErrorCode requireErrorCode(ErrorCode errorCode) {
-        return Objects.requireNonNull(errorCode, "errorCode");
+        return Objects.requireNonNull(
+                errorCode,
+                "errorCode"
+        );
     }
 }

--- a/backend/src/main/java/com/knot/backend/global/response/FieldErrorResponse.java
+++ b/backend/src/main/java/com/knot/backend/global/response/FieldErrorResponse.java
@@ -2,10 +2,19 @@ package com.knot.backend.global.response;
 
 import java.util.Objects;
 
-public record FieldErrorResponse(String field, String reason) {
+public record FieldErrorResponse(
+        String field,
+        String reason
+) {
 
     public FieldErrorResponse {
-        Objects.requireNonNull(field, "field");
-        Objects.requireNonNull(reason, "reason");
+        Objects.requireNonNull(
+                field,
+                "field"
+        );
+        Objects.requireNonNull(
+                reason,
+                "reason"
+        );
     }
 }

--- a/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
+++ b/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
@@ -1,16 +1,30 @@
 package com.knot.backend;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.knot.backend.testsupport.TestcontainersConfiguration;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
 
 @Tag("acceptance")
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class KnotApplicationTests {
+    @Autowired private ConfigurableApplicationContext applicationContext;
 
     @Test
-    void contextLoads() {}
+    void contextLoads() {
+        // given
+        ConfigurableApplicationContext context = applicationContext;
+
+        // when
+        boolean active = context.isActive();
+
+        // then
+        assertTrue(active);
+    }
 }

--- a/backend/src/test/java/com/knot/backend/testsupport/FormatterConventionFixture.java
+++ b/backend/src/test/java/com/knot/backend/testsupport/FormatterConventionFixture.java
@@ -1,0 +1,102 @@
+package com.knot.backend.testsupport;
+
+import java.util.function.BiFunction;
+
+final class FormatterConventionFixture extends FormatterConventionParent {
+
+    FormatterConventionFixture(String name) {
+        this(
+                name,
+                1
+        );
+    }
+
+    FormatterConventionFixture(
+            String name,
+            int count
+    ) {
+        super(
+                name,
+                count
+        );
+    }
+
+    static FormatterConventionRecord create(String name) {
+        return new FormatterConventionRecord(
+                name,
+                1
+        );
+    }
+
+    static FormatterSingleRecord createSingle(String name) {
+        return new FormatterSingleRecord(name);
+    }
+
+    static void invokeZero() {
+        consumeZero();
+    }
+
+    static FormatterConventionRecord create(
+            String name,
+            int count
+    ) {
+        return new FormatterConventionRecord(
+                name,
+                count
+        );
+    }
+
+    static void invokeNested() {
+        BiFunction<String, String, String> merger = (
+                first,
+                second
+        ) -> first + second;
+
+        consume(
+                create(
+                        "workspace",
+                        1
+                ),
+                merger
+        );
+    }
+
+    private static void consume(
+            FormatterConventionRecord record,
+            BiFunction<String, String, String> merger
+    ) {}
+
+    private static void consumeZero() {}
+}
+
+class FormatterConventionParent {
+
+    FormatterConventionParent(
+            String name,
+            int count
+    ) {}
+}
+
+record FormatterConventionRecord(
+        String name,
+        int count
+) {
+}
+
+record FormatterSingleRecord(String name) {
+}
+
+enum FormatterConventionEnum {
+    SINGLE("single"),
+    MULTIPLE(
+            "multiple",
+            2
+    );
+
+    FormatterConventionEnum(String name) {}
+
+    FormatterConventionEnum(
+            String name,
+            int count
+    ) {}
+}

--- a/backend/src/test/java/com/knot/backend/testsupport/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/knot/backend/testsupport/TestcontainersConfiguration.java
@@ -11,8 +11,7 @@ public class TestcontainersConfiguration {
     @Bean
     @ServiceConnection
     PostgreSQLContainer postgresContainer() {
-        return new PostgreSQLContainer("postgres:18.4")
-                .withDatabaseName("knot_test")
+        return new PostgreSQLContainer("postgres:18.4").withDatabaseName("knot_test")
                 .withUsername("knot")
                 .withPassword("knot");
     }


### PR DESCRIPTION
## 관련 이슈

- Closes #172

## 작업 내용

- Spotless Java formatter를 `google-java-format AOSP`에서 버전 고정 Eclipse JDT 4.39로 교체했습니다.
- 저장소의 Eclipse formatter profile로 메서드·생성자 선언과 호출에서 파라미터·인자가 2개 이상이면 괄호와 항목을 각각 줄바꿈하도록 설정했습니다.
- 0~1개 목록, 중첩 호출, `this`·`super`, lambda, record, enum 사례를 컴파일되는 formatter 회귀 fixture로 추가했습니다.
- 전체 백엔드 Java 소스에 새 formatter를 적용하고 필드 공백 및 Given–When–Then 규칙도 함께 맞췄습니다.

### 검증

- `spotlessApply` 2회 적용 결과 무변경
- `./gradlew spotlessCheck test integrationTest acceptanceTest bootJar` 성공
- 전체 18개 관련 파일 컨벤션 검사 성공

### 참고 사항

- 제품 동작과 공개 API 변경은 없습니다.
- 로컬 팀 컨벤션 원문 디렉터리가 없어 source hash gate만 실행할 수 없었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized backend Java formatting with a consistent Eclipse-based style.
  * Reformatted application, exception handling, and response code without changing behavior or public APIs.

* **Tests**
  * Strengthened application startup testing by verifying the application context is active.
  * Added formatter convention coverage for common Java syntax patterns.
  * Updated test database configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->