### PR TITLE
[FE] Spacing 레이아웃 공통 컴포넌트 구현

### DIFF
--- a/frontend/src/shared/components/primitives/layout/Spacing/index.tsx
+++ b/frontend/src/shared/components/primitives/layout/Spacing/index.tsx
@@ -1,0 +1,39 @@
+import styled from "@emotion/styled";
+
+interface SpacingProps {
+  /** 자식을 받지 않습니다. 간격을 벌릴 형제 요소 사이에 놓아 쓰세요. */
+  children?: never;
+  /**
+   * 간격을 벌릴 방향.
+   * `vertical`은 위아래, `horizontal`은 좌우로 벌립니다.
+   * @default "vertical"
+   */
+  direction?: "vertical" | "horizontal";
+  /**
+   * 벌릴 간격.
+   * 숫자를 넘기면 `px`로 붙고, 문자열은 `1rem`, `8%`처럼 단위까지 그대적용돼요.
+   */
+  size: string | number;
+}
+
+/**
+ * 형제 요소 사이에 빈 간격을 두는 레이아웃 프리미티브.
+ *
+ * 색·모양 같은 실체는 없고 위치만 잡아요.
+ * 요소 자체의 여백(`margin`)을 건드리지 않고 간격을 주고 싶을 때 씁니다.
+ *
+ * @example
+ * <Title />
+ * <Spacing size={16} />
+ * <Description />
+ *
+ * @example
+ * <Spacing direction="horizontal" size="1rem" />
+ */
+export default styled.div<SpacingProps>`
+  flex-shrink: 0;
+  ${({ direction = "vertical", size }) => {
+    const value = typeof size === "number" ? `${size}px` : size;
+    return direction === "vertical" ? `height: ${value};` : `width: ${value};`;
+  }}
+`;

--- a/frontend/src/shared/components/primitives/layout/Spacing/index.tsx
+++ b/frontend/src/shared/components/primitives/layout/Spacing/index.tsx
@@ -11,7 +11,7 @@ interface SpacingProps {
   direction?: "vertical" | "horizontal";
   /**
    * 벌릴 간격.
-   * 숫자를 넘기면 `px`로 붙고, 문자열은 `1rem`, `8%`처럼 단위까지 그대적용돼요.
+   * 숫자를 넘기면 `rem`으로 붙고, 문자열은 `16px`, `8%`처럼 단위까지 그대로 적용돼요.
    */
   size: string | number;
 }
@@ -24,16 +24,16 @@ interface SpacingProps {
  *
  * @example
  * <Title />
- * <Spacing size={16} />
+ * <Spacing size={1} />
  * <Description />
  *
  * @example
- * <Spacing direction="horizontal" size="1rem" />
+ * <Spacing direction="horizontal" size="16px" />
  */
 export default styled.div<SpacingProps>`
   flex-shrink: 0;
   ${({ direction = "vertical", size }) => {
-    const value = typeof size === "number" ? `${size}px` : size;
+    const value = typeof size === "number" ? `${size}rem` : size;
     return direction === "vertical" ? `height: ${value};` : `width: ${value};`;
   }}
 `;


### PR DESCRIPTION
## 관련 이슈

- #198
- 상위 이슈: #175

## 작업 내용

공통 컴포넌트 개발 중 형제 요소 사이에 빈 간격을 두는 `Spacing` 레이아웃 프리미티브를 구현하였습니다.

### Spacing 레이아웃 프리미티브 구현

`shared/components/primitives/layout/Spacing`에 두 컴포넌트의 간격을 margin이 아닌 컴포넌트로 사용할 수 있도록 공통 컴포넌트를 구현하였습니다.
`direction`으로 방향을, `size`로 간격을 정하며, 그냥 숫자를 넘기면 `rem` 단위로 붙고, 문자열은 단위까지 그대로 사용합니다.

```tsx
// 사용 예시
<Title />
<Spacing size={16} />
<Description />

<Spacing direction="horizontal" size="1rem" />
```

간격은 `height`(vertical) 또는 `width`(horizontal)로 잡았습니다.

```tsx
export default styled.div<SpacingProps>`
  flex-shrink: 0;
  ${({ direction = "vertical", size }) => {
    const value = typeof size === "number" ? `${size}rem` : size;
    return direction === "vertical" ? `height: ${value};` : `width: ${value};`;
  }}
`;
```

`direction` 기본값은 `vertical`입니다. 부모가 flex 컨테이너일 때 공간이 부족하면 이 요소가 먼저 줄어들어 간격이 사라질 수 있어, 지정한 크기를 유지하도록 `flex-shrink: 0`을 두었습니다.

타입과 스타일 요소에 JSDoc을 작성하였습니다. 타입이 이미 드러내는 내용은 적지 않고, 자식을 받지 않는 이유와 `size` 단위 처리 방식처럼 코드만 보고는 알기 어려운 내용을 남겼습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable spacing layout component for creating consistent vertical or horizontal gaps.
  * Supports numeric pixel values and unit-based size values.
  * Prevents content from shrinking within layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->