### PR TITLE
[BE] Java 필드 애노테이션 줄바꿈과 120자 formatter 규칙 반영

### DIFF
--- a/backend/config/spotless/eclipse-formatter.xml
+++ b/backend/config/spotless/eclipse-formatter.xml
@@ -6,12 +6,12 @@
         <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
         <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
         <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
-        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_if_empty"/>
-        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
 
         <!-- 49 = force split + one item per line + default continuation indentation. -->
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="49"/>

--- a/backend/src/main/java/com/knot/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/knot/backend/global/exception/GlobalExceptionHandler.java
@@ -26,9 +26,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(
-            MethodArgumentNotValidException exception
-    ) {
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
         List<FieldErrorResponse> fieldErrors = exception.getBindingResult()
                 .getFieldErrors()
                 .stream()
@@ -47,9 +45,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
-            ConstraintViolationException exception
-    ) {
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException exception) {
         List<FieldErrorResponse> fieldErrors = exception.getConstraintViolations()
                 .stream()
                 .map(this::toFieldErrorResponse)
@@ -62,16 +58,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> handleUnreadableMessage(
-            HttpMessageNotReadableException ignored
-    ) {
+    public ResponseEntity<ErrorResponse> handleUnreadableMessage(HttpMessageNotReadableException ignored) {
         return respond(CommonErrorCode.INVALID_REQUEST_BODY);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponse> handleTypeMismatch(
-            MethodArgumentTypeMismatchException exception
-    ) {
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException exception) {
         FieldErrorResponse fieldError = new FieldErrorResponse(
                 exception.getName(),
                 CommonErrorCode.INVALID_PARAMETER.getMessage()
@@ -84,9 +76,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<ErrorResponse> handleMissingParameter(
-            MissingServletRequestParameterException exception
-    ) {
+    public ResponseEntity<ErrorResponse> handleMissingParameter(MissingServletRequestParameterException exception) {
 
         FieldErrorResponse fieldError = new FieldErrorResponse(
                 exception.getParameterName(),

--- a/backend/src/main/java/com/knot/backend/global/exception/ProjectException.java
+++ b/backend/src/main/java/com/knot/backend/global/exception/ProjectException.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 
 @Getter
 public abstract class ProjectException extends RuntimeException {
-    @Serial private static final long serialVersionUID = 1L;
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private final ErrorCode errorCode;
 
     protected ProjectException(ErrorCode errorCode) {

--- a/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
+++ b/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Import;
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class KnotApplicationTests {
-    @Autowired private ConfigurableApplicationContext applicationContext;
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
## 관련 이슈

- Closes #199

## 작업 내용

- Eclipse JDT formatter의 최대 줄 길이를 100자에서 120자로 변경했습니다.
- 필드 애노테이션과 필드 선언이 각각 별도 줄에 작성되도록 formatter 설정을 변경했습니다.
- 파라미터·인자가 2개 이상일 때 강제 줄바꿈하는 기존 alignment 값 `49`는 유지했습니다.
- `spotlessApply` 결과에 따라 기존 Java 파일 3개의 포맷을 기계적으로 반영했습니다.

### 검증

- 백엔드 컨벤션 01~08 source hash gate 및 전체 소스 감사 통과
- `spotlessApply` 재실행 전후 diff hash 동일
- `./gradlew spotlessCheck` 통과
- `./gradlew test` 통과
- `./gradlew integrationTest` 통과
- `./gradlew bootJar` 통과
- 로컬 `acceptanceTest`는 Docker daemon 부재로 컨텍스트 생성 전에 중단
- PR Backend CI `verify` 통과로 acceptance 포함 원격 전체 검증 완료
- Governance와 CodeRabbit 통과

### 참고 사항

- 제품 동작과 공개 API 변경은 없습니다.
- AI는 formatter 설정 대조, 기계적 포맷 적용과 검증에 활용했으며 변경된 설정과 diff를 직접 확인했습니다.
