### PR TITLE
[FE] 채팅 필드 UI 및 관련 로직 구현

### DIFF
--- a/frontend/src/modules/features/chat/ChatField/index.tsx
+++ b/frontend/src/modules/features/chat/ChatField/index.tsx
@@ -1,0 +1,42 @@
+import { ComponentProps } from "react";
+import styled from "@emotion/styled";
+import Textarea from "@/shared/components/primitives/ui/Textarea";
+import ChatFieldSubmitButton from "./ui/ChatFieldSubmitButton";
+
+interface ChatFieldProps extends ComponentProps<"textarea"> {}
+
+export default function ChatField({ ...props }: ChatFieldProps) {
+  return (
+    <Container>
+      <ChatTextarea rows={1} placeholder="무엇이든 요청하세요" {...props} />
+      <ChatFieldSubmitButton />
+    </Container>
+  );
+}
+
+const Container = styled.form`
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.4375rem 0.5rem 0.4375rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.625rem;
+  background-color: rgba(255, 255, 255, 0.08);
+`;
+
+const ChatTextarea = styled(Textarea)`
+  flex: 1;
+  min-width: 0;
+  padding: 0.375rem 0;
+  max-height: 12rem;
+  overflow-y: auto;
+  field-sizing: content;
+  background-color: transparent;
+  ${({ theme }) => theme.text.body01};
+  color: ${({ theme }) => theme.neutral[0]};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.neutral[500]};
+  }
+`;

--- a/frontend/src/modules/features/chat/ChatField/index.tsx
+++ b/frontend/src/modules/features/chat/ChatField/index.tsx
@@ -10,7 +10,7 @@ interface ChatFieldProps extends Omit<
 > {}
 
 export default function ChatField({ ...props }: ChatFieldProps) {
-  const { message, submitStatus, handleChange, handleKeyDown, handleSubmit } =
+  const { message, canSubimt, handleChange, handleKeyDown, handleSubmit } =
     useChatField();
 
   return (
@@ -23,7 +23,7 @@ export default function ChatField({ ...props }: ChatFieldProps) {
         onKeyDown={handleKeyDown}
         {...props}
       />
-      <ChatFieldSubmitButton status={submitStatus} />
+      <ChatFieldSubmitButton status={canSubimt ? "active" : "inactive"} />
     </Container>
   );
 }

--- a/frontend/src/modules/features/chat/ChatField/index.tsx
+++ b/frontend/src/modules/features/chat/ChatField/index.tsx
@@ -2,14 +2,28 @@ import { ComponentProps } from "react";
 import styled from "@emotion/styled";
 import Textarea from "@/shared/components/primitives/ui/Textarea";
 import ChatFieldSubmitButton from "./ui/ChatFieldSubmitButton";
+import { useChatField } from "./model/useChatField";
 
-interface ChatFieldProps extends ComponentProps<"textarea"> {}
+interface ChatFieldProps extends Omit<
+  ComponentProps<"textarea">,
+  "value" | "onChange"
+> {}
 
 export default function ChatField({ ...props }: ChatFieldProps) {
+  const { message, submitStatus, handleChange, handleKeyDown, handleSubmit } =
+    useChatField();
+
   return (
-    <Container>
-      <ChatTextarea rows={1} placeholder="무엇이든 요청하세요" {...props} />
-      <ChatFieldSubmitButton />
+    <Container onSubmit={handleSubmit}>
+      <ChatTextarea
+        rows={1}
+        placeholder="무엇이든 요청하세요"
+        value={message}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        {...props}
+      />
+      <ChatFieldSubmitButton status={submitStatus} />
     </Container>
   );
 }

--- a/frontend/src/modules/features/chat/ChatField/model/useChatField.ts
+++ b/frontend/src/modules/features/chat/ChatField/model/useChatField.ts
@@ -1,0 +1,29 @@
+import { ChangeEvent, KeyboardEvent, SubmitEvent, useState } from "react";
+import { ButtonStatus } from "../ui/ChatFieldSubmitButton";
+
+export const useChatField = () => {
+  const [message, setMessage] = useState("");
+
+  const isEmpty = message.trim().length === 0;
+  const submitStatus: ButtonStatus = isEmpty ? "inactive" : "active";
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) =>
+    setMessage(e.target.value);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    if (e.nativeEvent.isComposing) return; // 글자 조립 중일 때 폼 제출 막기
+
+    e.preventDefault(); // "Enter" 입력 시 textarea 기본 동작(줄바꿈) 막기
+    e.currentTarget.form?.requestSubmit(); // "Enter" 입력 시 폼 제출
+  };
+
+  const handleSubmit = (e: SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isEmpty) return;
+
+    // TODO: 메시지 전송 mutation 연결
+  };
+
+  return { message, submitStatus, handleChange, handleKeyDown, handleSubmit };
+};

--- a/frontend/src/modules/features/chat/ChatField/model/useChatField.ts
+++ b/frontend/src/modules/features/chat/ChatField/model/useChatField.ts
@@ -1,11 +1,13 @@
 import { ChangeEvent, KeyboardEvent, SubmitEvent, useState } from "react";
 import { ButtonStatus } from "../ui/ChatFieldSubmitButton";
 
+type SubmitStatus = Extract<ButtonStatus, "inactive" | "active">;
+
 export const useChatField = () => {
   const [message, setMessage] = useState("");
 
   const isEmpty = message.trim().length === 0;
-  const submitStatus: ButtonStatus = isEmpty ? "inactive" : "active";
+  const submitStatus: SubmitStatus = isEmpty ? "inactive" : "active";
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) =>
     setMessage(e.target.value);
@@ -25,5 +27,11 @@ export const useChatField = () => {
     // TODO: 메시지 전송 mutation 연결
   };
 
-  return { message, submitStatus, handleChange, handleKeyDown, handleSubmit };
+  return {
+    message,
+    submitStatus,
+    handleChange,
+    handleKeyDown,
+    handleSubmit,
+  };
 };

--- a/frontend/src/modules/features/chat/ChatField/model/useChatField.ts
+++ b/frontend/src/modules/features/chat/ChatField/model/useChatField.ts
@@ -1,13 +1,9 @@
 import { ChangeEvent, KeyboardEvent, SubmitEvent, useState } from "react";
-import { ButtonStatus } from "../ui/ChatFieldSubmitButton";
-
-type SubmitStatus = Extract<ButtonStatus, "inactive" | "active">;
 
 export const useChatField = () => {
   const [message, setMessage] = useState("");
 
-  const isEmpty = message.trim().length === 0;
-  const submitStatus: SubmitStatus = isEmpty ? "inactive" : "active";
+  const canSubimt = message.trim().length > 0;
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) =>
     setMessage(e.target.value);
@@ -22,14 +18,14 @@ export const useChatField = () => {
 
   const handleSubmit = (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (isEmpty) return;
+    if (message.trim().length === 0) return;
 
     // TODO: 메시지 전송 mutation 연결
   };
 
   return {
     message,
-    submitStatus,
+    canSubimt,
     handleChange,
     handleKeyDown,
     handleSubmit,

--- a/frontend/src/modules/features/chat/ChatField/ui/ChatFieldSubmitButton.tsx
+++ b/frontend/src/modules/features/chat/ChatField/ui/ChatFieldSubmitButton.tsx
@@ -13,10 +13,10 @@ import Spinner from "@/shared/components/primitives/ui/Spinner";
  * - `loading`: 요청을 보냈고 응답은 아직 시작 전. 이미 나간 요청이라 취소 불가
  * - `stop`: 답변 생성 중. 누르면 생성을 중단
  */
-type ButtonStatus = "active" | "inactive" | "loading" | "stop";
+export type ButtonStatus = "active" | "inactive" | "loading" | "stop";
 
 interface ChatFieldSubmitButtonProps extends ComponentProps<"button"> {
-  status?: ButtonStatus;
+  status: ButtonStatus;
 }
 
 const STATUS_STYLE = {
@@ -49,23 +49,24 @@ const STATUS_STYLE = {
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=1080-648
  */
 export default function ChatFieldSubmitButton({
-  status = "active",
+  status,
   ...props
 }: ChatFieldSubmitButtonProps) {
   const isLoading = status === "loading";
+  const isStop = status === "stop";
   const isDisabled = status === "inactive" || isLoading;
 
   return (
     <Root
-      type="submit"
+      {...props}
+      type={isStop ? "button" : "submit"}
       $status={status}
       disabled={isDisabled}
       aria-busy={isLoading}
-      {...props}
     >
       <IconWrapper>
         {isLoading && <Spinner size="1rem" />}
-        {status === "stop" && <StopIcon />}
+        {isStop && <StopIcon />}
         {(status === "active" || status === "inactive") && <Send />}
       </IconWrapper>
     </Root>
@@ -76,8 +77,8 @@ const Root = styled.button<{ $status: ButtonStatus }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 36px;
-  height: 36px;
+  width: 2.25rem;
+  height: 2.25rem;
   padding: 0;
   border-radius: 999px;
   transition:
@@ -105,8 +106,8 @@ const IconWrapper = styled.div`
 `;
 
 const StopIcon = styled.span`
-  width: 11px;
-  height: 11px;
+  width: 0.6875rem;
+  height: 0.6875rem;
   border-radius: 2.5px;
   background-color: currentColor;
 `;

--- a/frontend/src/modules/features/chat/ChatField/ui/ChatFieldSubmitButton.tsx
+++ b/frontend/src/modules/features/chat/ChatField/ui/ChatFieldSubmitButton.tsx
@@ -1,0 +1,112 @@
+import { ComponentProps } from "react";
+import styled from "@emotion/styled";
+import { css, type Theme } from "@emotion/react";
+import Send from "@/assets/icons/send.svg";
+import Spinner from "@/shared/components/primitives/ui/Spinner";
+
+/**
+ * 제출 버튼의 상태. 한 번의 전송 사이클에서
+ * `inactive → active → loading → stop → inactive` 순으로 전이된다.
+ *
+ * - `inactive`: 보낼 내용이 없어 전송 불가. 빈 입력, 글자 수 초과 등
+ * - `active`: 전송 가능한 기본 대기 상태
+ * - `loading`: 요청을 보냈고 응답은 아직 시작 전. 이미 나간 요청이라 취소 불가
+ * - `stop`: 답변 생성 중. 누르면 생성을 중단
+ */
+type ButtonStatus = "active" | "inactive" | "loading" | "stop";
+
+interface ChatFieldSubmitButtonProps extends ComponentProps<"button"> {
+  status?: ButtonStatus;
+}
+
+const STATUS_STYLE = {
+  active: (theme: Theme) => css`
+    background-color: ${theme.neutral[0]};
+    color: ${theme.neutral[800]};
+  `,
+  inactive: (theme: Theme) => css`
+    background-color: ${theme.neutral[500]};
+    color: ${theme.neutral[700]};
+  `,
+  loading: (theme: Theme) => css`
+    background-color: ${theme.neutral[0]};
+    color: ${theme.neutral[800]};
+  `,
+  stop: (theme: Theme) => css`
+    background-color: ${theme.neutral[0]};
+    color: ${theme.neutral[800]};
+  `,
+} as const satisfies Record<
+  ButtonStatus,
+  (theme: Theme) => ReturnType<typeof css>
+>;
+
+/**
+ * 채팅창 제출 버튼
+ *
+ * `inactive`·`loading`에서는 누를 수 없고, 로딩 중이라는 사실은 `aria-busy`로 알린다.
+ *
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=1080-648
+ */
+export default function ChatFieldSubmitButton({
+  status = "active",
+  ...props
+}: ChatFieldSubmitButtonProps) {
+  const isLoading = status === "loading";
+  const isDisabled = status === "inactive" || isLoading;
+
+  return (
+    <Root
+      type="submit"
+      $status={status}
+      disabled={isDisabled}
+      aria-busy={isLoading}
+      {...props}
+    >
+      <IconWrapper>
+        {isLoading && <Spinner size="1rem" />}
+        {status === "stop" && <StopIcon />}
+        {(status === "active" || status === "inactive") && <Send />}
+      </IconWrapper>
+    </Root>
+  );
+}
+
+const Root = styled.button<{ $status: ButtonStatus }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 999px;
+  transition:
+    background-color 0.3s ease-in,
+    color 0.3s ease-in;
+
+  ${({ theme, $status }) => STATUS_STYLE[$status](theme)};
+
+  &[aria-busy="true"] {
+    cursor: progress;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.sub.accent[500]};
+    outline-offset: 2px;
+  }
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1rem;
+  height: 1rem;
+`;
+
+const StopIcon = styled.span`
+  width: 11px;
+  height: 11px;
+  border-radius: 2.5px;
+  background-color: currentColor;
+`;

--- a/frontend/src/shared/provider/themeProvider/GlobalStyle.tsx
+++ b/frontend/src/shared/provider/themeProvider/GlobalStyle.tsx
@@ -25,7 +25,7 @@ const GlobalStyle = () => {
 
         body {
           margin: 0;
-          background-color: ${theme.neutral[0]};
+          background-color: ${theme.neutral[50]};
           color: ${theme.neutral[900]};
           font-family:
             "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,

--- a/frontend/src/shared/provider/themeProvider/theme.ts
+++ b/frontend/src/shared/provider/themeProvider/theme.ts
@@ -65,7 +65,7 @@ export const theme = {
   primary: "#3C3B39",
 
   neutral: {
-    0: "#FDFDFD",
+    0: "#FFFFFF",
     50: "#FAF9F7",
     100: "#F4F2EE",
     200: "#E9E6E1",


### PR DESCRIPTION
## 관련 이슈

Closes #214

## 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능) -->

- 채팅 필드 관련 UI 구현 (ChatFieldSubmitButton, ChatField)
- 채팅 필드 입력 및 제출 로직 구현 (useChatField)
- [전체 배경 컬러 및 theme neutral 컬러 hex 변경](https://github.com/woowacourse-teams/2026-Knot/pull/219/commits/fc0227a98d17f54ff4050137b047a8c1538df653)

### 참고 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

## 1. 공용 타입(ButtonStatus)의 위치에 대한 고민

**[상황]**

useChatField 내부에서 파생시킨 submitStatus가 리터럴 유니온으로 좁혀졌지만, 객체로 래핑되어 반환되면서 string으로 넓어지는 문제가 있었습니다.

```tsx
export const useChatField = () => {
  const [message, setMessage] = useState("");

  const isEmpty = message.trim().length === 0;
  const submitStatus = isEmpty ? "inactive" : "active";
        // ^?: 'inactive' | 'active'

  ...

  return { message, submitStatus, handleChange, handleKeyDown, handleSubmit };
                    // ^?: string
};
```

이로 인해 ChatFieldSubmitButton에 submitStatus를 전달할 때 타입 에러가 발생했습니다.

```tsx
export default function ChatField({ ...props }: ChatFieldProps) {
  const { message, submitStatus, ... } = useChatField();

  return (
   ...
      <ChatFieldSubmitButton status={submitStatus} />
      // Error: Type 'string' is not assignable to type 'ButtonStatus'.ts
    </Container>
  );
}
```

해결하려면 훅의 submitStatus에 ButtonStatus 타입을 어노테이션해야 했고, 이 과정에서 공용으로 쓰이는 ButtonStatus 타입을 어디에 둘 것인가라는 고민이 생겼습니다.

**[결정]**

ChatFieldSubmitButton 컴포넌트 파일에 정의하고 export 하는 방식으로 결정했습니다.

```tsx
export type ButtonStatus = "active" | "inactive" | "loading" | "stop";
```

**[근거]**

ButtonStatus는 버튼의 상태를 표현하는 타입이므로, 도메인 타입 파일(types/chat.ts)보다는 해당 컴포넌트 파일 안에 있는 것이 맥락상 더 자연스럽다고 판단했습니다. 다른 곳에서 이 타입을 참조할 때 Go to Definition으로 이동했을 때에도 컴포넌트 파일로 이동하는 편이 의미 파악에 더 도움이 될 것 같았어요.

**[리뷰 포인트]**

예전에 "공용으로 쓰이는 타입은 별도 파일로 분리하자"고 이야기했던 기억이 있어서, 이번 결정에 대해 어떻게 생각하시는지 의견 듣고 싶습니다.
또, 컴포넌트 파일에서 export 되는 것은 컴포넌트 파일 뿐이어야 한다..?는 하네스 결정 사항이 있었던 것 같기도 해서 남겨봅니다
(일단 찾아봤을 때는 없긴 한데.. 맞나요?)

<br/>
<br/>

## 2. useChatField 훅 분리에 대한 고민

훅을 분리하는 과정에서 두 가지 고민이 있었어요. 사고의 흐름을 함께 남겨두었으니 리뷰할 때 참고해주세요.

### (1) 이 훅은 추상화인가, 단순 추출인가?

ChatField의 상태와 입력/제출 관련 로직을 훅으로 분리했지만, 처음에는 이것을 추상화라기보다 단순 추출이라고 느꼈습니다.

추상화는 내부 복잡도를 감추고 호출부에 안정적이고 적은 인터페이스만 노출해야 한다고 생각하는데, 지금 훅의 반환값들은 모두 컴포넌트에 1:1로 그대로 꽂히고 있기 때문이에요. 훅을 지우고 컴포넌트 안에 다시 인라인해도 컴포넌트가 새로 알아야 할 정보가 없으니, 세부 구현만 캡슐화됐을 뿐 인터페이스 관점의 이득은 크지 않다고 판단했습니다.

그럼에도 훅으로 유지한 이유는, 앞으로 handleSubmit에서 mutate를 호출하면 다음과 같은 절차적 로직이 자연스럽게 붙을 것이라고 예상했기 때문입니다.

- useSendChatMessageMutation() 호출
- isPending을 읽어 loading 상태 파생
- 답변 스트리밍 중인지 읽어 stop 상태 파생
- 전송 성공 시 입력값 초기화
- 에러 처리

지금은 얕은 추상화지만 API 연동 맥락까지 붙으면 의미 있는 캡슐화가 될 것이라고 봤고, 그래서 "괜찮다"는 결론에 도달했습니다.

### (2) ChatField와 강결합인가?

훅을 어디에 위치시킬지에 대해서는, ChatField 디렉토리 내부에 co-location 하기로 결정했습니다. 아래 이유로 ChatField 컴포넌트와 강결합되어 있다고 판단했어요.

- 반환값이 도메인 값이 아니라 특정 컴포넌트에 주입되는 핸들러 묶음입니다. (handleChange, handleKeyDown, handleSubmit)
- handleKeyDown 내부의 e.currentTarget.form?.requestSubmit();가 결정적이었습니다. 이 훅이 이미 textarea가 form 내부에 들어있다는 렌더 구조를 전제로 하고 있기 때문이에요.