### PR TITLE
[BE] 백엔드 Codex 스킬 검색 경로와 자연어 호출 정비

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,23 @@ merge는 사용자가 명시적으로 요청한 범위에서만 수행한다.
 Issue에는 기존 템플릿의 `구현 기능 설명`, `TODO`, `메모`만 사용한다. 전체 내부 계약,
 ADR 전문과 인터뷰 원문은 Issue에 넣지 않는다.
 
+## 백엔드 Codex 스킬
+
+저장소 공통 Codex 스킬은 루트 `.agents/skills`에, 백엔드 전용 Codex 스킬은
+`backend/.agents/skills`에 둔다. Codex는 현재 작업 디렉터리부터 저장소 루트까지 각
+디렉터리의 `.agents/skills`를 찾으므로, 백엔드 작업은 `backend/`에서 시작해야 공통 스킬과
+백엔드 전용 스킬을 함께 발견한다. 저장소 루트에서 시작한 Codex는 하위 디렉터리인
+`backend/.agents/skills`를 자동으로 찾지 않는다.
+
+대표 자연어 요청은 다음 스킬로 연결한다.
+
+- `커밋해줘`, `작업 단위로 커밋해줘`, `커밋 메시지 작성해줘`: `$knot-commit`
+- `PR 본문 작성해줘`, `PR 준비 상태 확인해줘`, `PR 생성해줘`, `PR 올려줘`: `$knot-pr`
+
+명시적 `$knot-commit`, `$knot-pr` 호출도 fallback으로 유지한다. 메시지나 본문 초안 요청은
+실제 commit 또는 PR 게시 권한이 아니다. 실제 commit과 PR 게시는 각각 해당 쓰기 동작을
+현재 요청에서 명시한 경우에만 수행하며, push와 merge 권한은 별도로 판정한다.
+
 ## 임시 snapshot 안전 규칙
 
 Issue 계약 snapshot은 저장소 밖의 OS 임시 파일에만 쓰고 권한을 현재 사용자로 제한한다.

--- a/backend/.agents/skills/knot-commit/SKILL.md
+++ b/backend/.agents/skills/knot-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knot-commit
-description: Create, review, split, and validate commits for the 2026-Knot backend from the actual git diff using Knot's AngularJS-based commit convention, atomic intent rule, allowed types, optional scopes, Korean subjects, and optional reason-focused bodies. Use when Codex needs to draft a commit message, group mixed changes, stage an atomic commit, or review recent commit messages; do not create a commit unless the user explicitly requests it.
+description: “커밋해줘”, “작업 단위로 커밋해줘”, “커밋 메시지 작성해줘”처럼 Knot 백엔드의 실제 git diff를 원자적 커밋으로 계획·검토·생성할 때 사용한다. 메시지 초안은 commit 권한이 아니며 실제 commit은 명시적 요청에만 수행한다. push, PR 게시, merge에는 사용하지 않는다.
 ---
 
 # Knot Commit
@@ -21,7 +21,7 @@ Base every commit decision on the actual backend diff. Use the linked Issue or t
 - Keep implementation, tests, and required configuration for the same intent together when they form one reviewable change.
 - Split unrelated features, fixes, refactors, formatting-only changes, documentation, dependency changes, and tests into separate commits when practical.
 - Do not stage every changed file blindly.
-- Do not amend, rebase, reset, or create a commit unless the user explicitly asks for that operation.
+- Treat `커밋해줘` and `작업 단위로 커밋해줘` as explicit commit creation requests. `커밋 메시지 작성해줘` authorizes only a draft. Do not amend, rebase, or reset unless the user explicitly asks for that operation.
 - Preserve existing user changes and report pre-existing staged or dirty files before staging.
 - Do not claim a test or formatting check passed without running it and reporting the result.
 

--- a/backend/.agents/skills/knot-commit/agents/openai.yaml
+++ b/backend/.agents/skills/knot-commit/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Knot Commit"
+  short_description: "백엔드 diff를 작업 단위의 Knot 커밋으로 정리"
+  default_prompt: "$knot-commit으로 현재 백엔드 diff를 검사해 작업 단위의 커밋을 준비해줘."
+policy:
+  allow_implicit_invocation: true

--- a/backend/.agents/skills/knot-pr/SKILL.md
+++ b/backend/.agents/skills/knot-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: knot-pr
-description: Draft and validate Pull Requests for the 2026-Knot backend from the actual backend git diff and its linked GitHub Issue, including parent and sub-issue context, branch and title conventions, PR template, commit scope, and verification results. Use when Codex needs to prepare or review a Knot backend PR, but do not publish it unless explicitly asked.
+description: “PR 본문 작성해줘”, “PR 준비 상태 확인해줘”, “PR 생성해줘”, “PR 올려줘”처럼 Knot 백엔드의 실제 git diff와 연결된 GitHub Issue로 PR을 작성·검증·게시할 때 사용한다. 초안 요청은 게시 권한이 아니며 실제 게시도 명시적 요청에만 수행한다. commit, push, Issue 수정, merge에는 사용하지 않는다.
 ---
 
 # Knot PR
@@ -23,9 +23,9 @@ The diff is the source of truth for what changed. The Issue is the source of tru
 ## Operating rules
 
 - Work from the `backend` directory. Resolve the Git repository root with `git rev-parse --show-toplevel` when reading root-level rules.
-- Treat the repository's `CONTRIBUTING.md`, `.github/knot-conventions.yml`, and `.github/PULL_REQUEST_TEMPLATE.md` as project sources of truth. User instructions override them.
+- Treat the repository's `CONTRIBUTING.md`, `.github/knot-conventions.yml`, and `.github/pull_request_template.md` as project sources of truth. User instructions override them.
 - Do not commit, push, create a PR, edit an Issue, add labels, or close an Issue unless the user explicitly requests that exact write action.
-- Separate drafting from publishing. Publishing requires confirmation of the final title, base, head, Issue linkage, and body.
+- Separate drafting from publishing. `PR 생성해줘` and `PR 올려줘` explicitly authorize PR publication; resolve and verify the final title, base, head, Issue linkage, and body from repository evidence before publishing. Drafting, body-writing, and readiness-review requests do not authorize publication.
 - Do not claim tests, formatting, review, or Issue completion unless a command or GitHub state proves it.
 - Flag unrelated commits, files, generated artifacts, pre-existing dirty changes, and branch-rule mismatches instead of hiding them.
 
@@ -176,4 +176,4 @@ List blockers separately from optional polish. Include the exact branch, Issue h
 
 ## 6. Publish only on explicit request
 
-When the user explicitly asks to create or publish the PR, confirm the final title, base, head branch, Issue linkage, and body first. Do not close the Issue or add extra Issue references without permission. Use the repository's GitHub publishing workflow for commit, push, and PR creation rather than performing those mutations during a draft-only request.
+When the user explicitly asks to create or publish the PR, resolve and verify the final title, base, head branch, Issue linkage, and body before publishing. Ask only when repository evidence is missing or conflicting in a way that materially changes the PR. Do not close the Issue or add extra Issue references without permission. Use the repository's GitHub publishing workflow for commit, push, and PR creation rather than performing those mutations during a draft-only request.

--- a/backend/.agents/skills/knot-pr/agents/openai.yaml
+++ b/backend/.agents/skills/knot-pr/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Knot PR"
+  short_description: "백엔드 diff와 Issue로 Knot PR 작성·검증"
+  default_prompt: "$knot-pr로 현재 백엔드 diff와 연결된 Issue를 확인해 PR을 준비해줘."
+policy:
+  allow_implicit_invocation: true

--- a/backend/.codex/skills/knot-commit/agents/openai.yaml
+++ b/backend/.codex/skills/knot-commit/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Knot Commit"
-  short_description: "Create atomic Knot commits"
-  default_prompt: "Use $knot-commit to inspect the backend diff and draft an atomic commit message."

--- a/backend/.codex/skills/knot-pr/agents/openai.yaml
+++ b/backend/.codex/skills/knot-pr/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Knot PR"
-  short_description: "Draft and validate Knot PRs"
-  default_prompt: "Use $knot-pr to draft a Knot PR from the current backend diff and linked Issue."

--- a/docs/adr/223-backend-codex-skill-scope.md
+++ b/docs/adr/223-backend-codex-skill-scope.md
@@ -1,0 +1,57 @@
+# 백엔드 commit·PR Codex 스킬은 backend/.agents/skills에 두고 자연어 implicit invocation과 명시적 호출 fallback을 함께 지원한다.
+
+## 상태
+
+Proposed
+
+## 관련 Issue
+
+- #223 [BE] 백엔드 Codex 스킬 검색 경로와 자연어 호출 정비
+
+## 한 줄 요약
+
+백엔드 commit·PR Codex 스킬은 backend/.agents/skills에 두고 자연어 implicit invocation과 명시적 호출 fallback을 함께 지원한다.
+
+## 왜 이 결정이 필요했나
+
+백엔드 전용 스킬이 비공식 backend/.codex/skills 경로에 있어 Codex의 자동 발견과 자연어 선택을 보장할 수 없었다.
+
+백엔드 팀원이 backend에서 commit·PR 작업을 요청할 때 공통 Issue 스킬과 백엔드 전용 전달 스킬을 함께 사용하되 프론트엔드 범위에는 백엔드 스킬을 노출하지 않아야 했다.
+
+결정 동인:
+
+- Codex의 공식 .agents/skills 검색 규칙을 따른다.
+- 공통 워크플로우와 백엔드 전용 워크플로우의 범위를 구분한다.
+- 팀원이 자연어 작업 요청과 명시적 스킬 호출을 모두 사용할 수 있게 한다.
+- 초안 요청과 원격 쓰기 권한의 경계를 유지한다.
+
+## 트레이드 오프
+
+- 모든 스킬을 루트 .agents/skills에 배치: 저장소 루트에서도 발견되지만 프론트엔드 작업에 백엔드 commit·PR 스킬까지 노출된다.
+- 백엔드 전용 스킬을 backend/.agents/skills에 배치: backend 작업 디렉터리가 필요하지만 모듈 범위를 유지하면서 루트 공통 스킬도 함께 발견한다.
+
+## 무엇을 결정했나
+
+백엔드 commit·PR Codex 스킬은 backend/.agents/skills에 두고 자연어 implicit invocation과 명시적 호출 fallback을 함께 지원한다.
+
+백엔드 작업을 backend에서 시작하는 규칙으로 공통·백엔드 스킬을 함께 발견하고, 모듈별 책임과 프론트엔드 분리를 유지할 수 있다.
+
+## 결과
+
+- 백엔드 팀원은 Codex를 backend에서 시작해야 두 스킬 범위를 모두 자동 발견한다.
+- 한국어 대표 요청은 SKILL.md description을 통해 implicit invocation 후보가 된다.
+- 명시적인 $knot-commit과 $knot-pr 호출은 선택 실패 시 fallback으로 남는다.
+- 저장소 루트에서 시작한 Codex는 하위 백엔드 스킬을 자동 발견하지 않는다.
+
+## 다시 논의해야 할 조건
+
+- Codex의 저장소 스킬 검색 규칙이 하위 디렉터리 탐색을 지원하도록 바뀔 때
+- 프론트엔드와 백엔드가 동일한 commit·PR 스킬 계약을 공유하기로 결정할 때
+- 모듈별 스킬 이름 중복 또는 자연어 라우팅 충돌이 발생할 때
+
+## 확인
+
+- 예정 경로: `docs/adr/223-backend-codex-skill-scope.md`
+- 결정 주체: Knot 팀
+- AI 하네스가 Proposed ADR 파일을 생성했다.
+- 팀이 PR에서 승인한 뒤 Accepted로 바꾼다.

--- a/harness/tests/test_backend_codex_skill_contract.py
+++ b/harness/tests/test_backend_codex_skill_contract.py
@@ -1,0 +1,113 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON_SKILLS = ROOT / ".agents" / "skills"
+BACKEND_SKILLS = ROOT / "backend" / ".agents" / "skills"
+LEGACY_BACKEND_SKILLS = ROOT / "backend" / ".codex" / "skills"
+EXPECTED_TRIGGERS = {
+    "knot-commit": (
+        "커밋해줘",
+        "작업 단위로 커밋해줘",
+        "커밋 메시지 작성해줘",
+    ),
+    "knot-pr": (
+        "PR 본문 작성해줘",
+        "PR 준비 상태 확인해줘",
+        "PR 생성해줘",
+        "PR 올려줘",
+    ),
+}
+UNIX_ABSOLUTE_PATH = re.compile(
+    r"(?<![A-Za-z0-9_$./-])/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+"
+)
+WINDOWS_ABSOLUTE_PATH = re.compile(r"[A-Za-z]:\\[^\s`\"']+")
+
+
+def read_frontmatter(path):
+    text = path.read_text(encoding="utf-8")
+    parts = text.split("---", 2)
+    if len(parts) != 3 or parts[0].strip():
+        raise AssertionError(f"invalid frontmatter: {path}")
+
+    fields = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+    return fields, text
+
+
+class BackendCodexSkillContractTest(unittest.TestCase):
+    def test_backend_skills_use_official_module_discovery_path(self):
+        self.assertFalse(LEGACY_BACKEND_SKILLS.exists())
+
+        for name in EXPECTED_TRIGGERS:
+            with self.subTest(skill=name):
+                skill_dir = BACKEND_SKILLS / name
+                self.assertTrue((skill_dir / "SKILL.md").is_file())
+                metadata = skill_dir / "agents" / "openai.yaml"
+                self.assertTrue(metadata.is_file())
+                self.assertIn(
+                    "allow_implicit_invocation: true",
+                    metadata.read_text(encoding="utf-8"),
+                )
+
+    def test_skill_frontmatter_has_directory_name_and_description(self):
+        for skill_file in BACKEND_SKILLS.glob("*/SKILL.md"):
+            with self.subTest(skill=skill_file.parent.name):
+                fields, _ = read_frontmatter(skill_file)
+                self.assertEqual(skill_file.parent.name, fields.get("name"))
+                self.assertTrue(fields.get("description"))
+                self.assertRegex(fields["name"], r"^[a-z0-9-]+$")
+                self.assertLessEqual(len(fields["name"]), 64)
+                self.assertLessEqual(len(fields["description"]), 1024)
+
+    def test_skill_names_are_unique_across_backend_discovery_chain(self):
+        skill_files = list(COMMON_SKILLS.glob("*/SKILL.md"))
+        skill_files.extend(BACKEND_SKILLS.glob("*/SKILL.md"))
+        names = [read_frontmatter(path)[0].get("name") for path in skill_files]
+
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_backend_skills_do_not_depend_on_external_absolute_paths(self):
+        for skill_file in BACKEND_SKILLS.rglob("*"):
+            if not skill_file.is_file():
+                continue
+            with self.subTest(path=skill_file.relative_to(ROOT)):
+                text = skill_file.read_text(encoding="utf-8")
+                self.assertIsNone(UNIX_ABSOLUTE_PATH.search(text))
+                self.assertIsNone(WINDOWS_ABSOLUTE_PATH.search(text))
+
+    def test_representative_korean_requests_route_unambiguously(self):
+        descriptions = {
+            name: read_frontmatter(BACKEND_SKILLS / name / "SKILL.md")[0][
+                "description"
+            ]
+            for name in EXPECTED_TRIGGERS
+        }
+
+        for expected_skill, requests in EXPECTED_TRIGGERS.items():
+            for request in requests:
+                with self.subTest(request=request):
+                    matches = [
+                        name
+                        for name, description in descriptions.items()
+                        if request in description
+                    ]
+                    self.assertEqual([expected_skill], matches)
+
+    def test_repository_guidance_explains_backend_skill_discovery(self):
+        agents_md = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("backend/.agents/skills", agents_md)
+        self.assertIn("백엔드 작업은 `backend/`에서 시작", agents_md)
+        self.assertIn("$knot-commit", agents_md)
+        self.assertIn("$knot-pr", agents_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈

- #223

## 작업 내용

- 백엔드 전용 `knot-commit`, `knot-pr` 스킬을 공식 모듈 검색 경로인 `backend/.agents/skills`로 이동했습니다.
- 대표 한국어 요청과 implicit invocation 정책을 추가하고, 초안·commit·push·PR 게시·merge의 권한 경계를 명시했습니다.
- 백엔드 작업 디렉터리에서 루트 공통 스킬과 백엔드 전용 스킬이 함께 발견되는 규칙을 `AGENTS.md`에 기록했습니다.
- 경로, frontmatter, 중복 이름, 저장소 밖 절대 경로와 대표 자연어 라우팅을 검증하는 계약 테스트를 추가했습니다.
- 모듈별 스킬 배치 결정을 `docs/adr/223-backend-codex-skill-scope.md`에 Proposed 상태로 기록했습니다.

### 참고 사항

- Issue 계층: 상위 이슈와 하위 이슈가 없습니다.
- 검증: 하네스 65개, Governance 8개, 두 스킬의 `quick_validate.py`, 변경 범위 컨벤션 감사가 모두 통과했습니다.
- 검증: `./gradlew spotlessCheck test integrationTest acceptanceTest bootJar`가 `BUILD SUCCESSFUL`로 통과했고 `git diff --check`도 통과했습니다.
- 전체 컨벤션 감사의 5건은 `origin/develop`에 이미 존재하는 Java·SQL 위반이며 이 PR은 해당 파일을 변경하지 않습니다.
- AI 활용 범위는 스킬·테스트·ADR 초안 작성입니다. 모듈 배치와 쓰기 권한 경계는 Issue #223에서 확인한 결정을 반영했고, 실제 diff·계약 테스트·Gradle 전체 검증으로 별도 확인했습니다.
