### PR TITLE
[BE] OpenAPI 문서 제공

### DIFF
--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -110,8 +110,24 @@ jobs:
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             "$NCP_DEV_USER@$NCP_DEV_HOST" \
-            'bash -se' <<'REMOTE'
+          'bash -se' <<'REMOTE'
           set -Eeuo pipefail
+
+          sudo -n /usr/bin/install \
+            -d \
+            -o root \
+            -g root \
+            -m 755 \
+            /etc/systemd/system/knot-backend.service.d
+
+          sudo -n /usr/bin/tee \
+            /etc/systemd/system/knot-backend.service.d/10-development-profile.conf \
+            > /dev/null <<'UNIT'
+          [Service]
+          Environment=SPRING_PROFILES_ACTIVE=dev
+          UNIT
+
+          sudo -n /usr/bin/systemctl daemon-reload
 
           sudo -n /usr/bin/install \
             -o knot \

--- a/backend/.codex/skills/knot-api-spec/SKILL.md
+++ b/backend/.codex/skills/knot-api-spec/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: knot-api-spec
+description: Create and update frontend-facing Markdown API specifications for the 2026-Knot backend from actual controllers, DTOs, security configuration, exception handling, cookies, and tests.
+---
+
+# Knot API Specification
+
+Knot 백엔드의 실제 HTTP 계약을 프론트엔드가 바로 사용할 수 있는 Markdown API 명세로 정리한다. 모든 엔드포인트는 지정된 Header, Path Parameter, Query Parameter, Request Body, Response, Error Response 형식을 사용한다.
+
+~~~~markdown
+## Header
+
+| Key | Type | Required | Example | Description |
+|---|---|---|---|---|
+| 없음 | - | - | - | 헤더 없음 |
+
+## Path Parameter
+
+| Key | Type | Required | Example | Description |
+|---|---|---|---|---|
+| 없음 | - | - | - | Path Parameter 없음 |
+
+## Query Parameter
+
+| Key | Type | Required | Example | Description |
+|---|---|---|---|---|
+| 없음 | - | - | - | Query Parameter 없음 |
+
+## Request Body
+
+| Field | Type | Required | Description | Example |
+|---|---|---|---|---|
+| 없음 | - | - | Request Body 없음 | - |
+
+### Request Example
+```json
+{
+}
+```
+
+## Response
+
+### Status Code
+
+| Status | Description |
+|---|---|
+| 200 | 성공 |
+
+### Response Body
+
+| Field | Type | Nullable | Description | Example |
+|---|---|---|---|---|
+| 없음 | - | - | Response Body 없음 | - |
+
+### Response Example
+```json
+{
+}
+```
+
+## Error Response
+
+| Status | Error Code | Description |
+|---|---|---|
+| 없음 | 없음 | 오류 응답 없음 |
+~~~~
+
+## 적용 범위
+
+- 사용자가 API 명세서, API 문서, 프론트엔드 전달용 API 계약, 엔드포인트 정리를 요청할 때 사용한다.
+- 명세만 요청받은 경우에는 코드 구현, 데이터베이스 변경, branch, commit, push, PR을 수행하지 않는다.
+- 사용자가 파일 작성을 명시하지 않으면 답변으로 Markdown 초안을 제공한다. 파일 작성을 명시한 경우에만 문서 파일을 만든다.
+- 현재 코드와 사용자가 원하는 계약이 다르면 원하는 내용을 사실처럼 문서화하지 말고, 현재 동작과 불일치를 함께 보고한다.
+
+## 명세 작성 전 조사
+
+백엔드 모듈 디렉터리에서 다음 근거를 확인한다.
+
+1. `@RequestMapping`, `@GetMapping`, `@PostMapping`, `@PutMapping`, `@PatchMapping`, `@DeleteMapping`이 있는 Controller
+2. Request/Response DTO와 record의 필드, 타입, nullable 여부
+3. `@Valid`, `@NotBlank`, `@Size` 등 입력 제약
+4. `SecurityFilterChain`, CORS, CSRF, 인증·인가 설정
+5. `ResponseEntity`, `@ResponseStatus`, authentication entry point, logout handler, OAuth handler
+6. `@RestControllerAdvice`와 ErrorCode의 HTTP 상태 매핑
+7. 해당 동작을 검증하는 단위·통합·인수 테스트
+8. `application.properties` 및 환경별 설정의 base URL, redirect URI, cookie 이름과 보안 속성
+
+검색할 때 `node_modules`, `.opencode/node_modules`, `.persona/rules`, `.persona/evidence`는 implementation context로 읽지 않는다. 프로젝트의 `AGENTS.md`와 명세 대상 코드의 하위 지침은 먼저 확인한다.
+
+## 근거 우선순위
+
+명세의 값은 다음 우선순위로 결정한다.
+
+1. 실행 경로를 직접 정의하는 Controller와 Security 설정
+2. DTO와 validation annotation
+3. 예외 처리기와 테스트가 확인하는 실제 상태 코드·응답
+4. 환경 설정과 사용자가 명시한 운영 URL
+
+코드에서 확인되지 않은 필드, 상태 코드, cookie 속성, redirect 주소는 추측하지 않는다. 확인할 수 없으면 `확인 필요`로 표시한다.
+
+## 문서 구조
+
+문서 처음에는 필요한 경우 다음 공통 정보를 적는다.
+
+~~~~markdown
+# [도메인] API
+
+Base URL: `{{BASE_URL}}`
+
+## 공통 사항
+
+- 브라우저에서 쿠키 인증을 사용하는 요청은 `credentials: "include"`를 사용한다.
+- 운영 Base URL이 코드 설정 또는 사용자 입력으로 확정된 경우에만 실제 URL을 적는다.
+~~~~
+
+그 다음 공개 엔드포인트마다 아래 템플릿을 빠짐없이 작성한다. 해당하지 않는 항목도 삭제하지 않고 `없음`으로 표시한다.
+
+~~~~markdown
+## [기능 이름]
+
+`[HTTP METHOD] [경로]`
+
+## Header
+
+| Key | Type | Required | Example | Description |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## Path Parameter
+
+| Key | Type | Required | Example | Description |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## Query Parameter
+
+| Key | Type | Required | Example | Description |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## Request Body
+
+| Field | Type | Required | Description | Example |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+### Request Example
+```json
+{
+  "field": "value"
+}
+```
+
+## Response
+
+### Status Code
+
+| Status | Description |
+|---|---|
+| 200 | ... |
+
+### Response Body
+
+| Field | Type | Nullable | Description | Example |
+|---|---|---|---|---|
+| `field` | `string` | No | ... | `value` |
+
+### Response Example
+```json
+{
+  "field": "value"
+}
+```
+
+## Error Response
+
+| Status | Error Code | Description |
+|---|---|---|
+| 400 | ... | ... |
+~~~~
+
+### Request 규칙
+
+- 요청 본문이 없으면 `Request Body` 표에 `없음`이라고 적고, 요청 예시는 `없음` 또는 빈 JSON으로 표시한다.
+- Header, Path Parameter, Query Parameter, Request Body를 각각 해당 섹션에 작성한다. 없는 섹션도 유지한다.
+- Cookie는 Header 섹션에 `Cookie` 또는 `Set-Cookie`의 실제 방향을 구분해 작성한다.
+- 필수 여부는 `required = false`, nullable 타입, validation annotation, 기본값을 함께 확인한다.
+- JSON body가 있으면 실제 필드명과 예시를 적는다. DTO의 Java 필드명을 임의로 바꾸지 않는다.
+- `@NotBlank`, `@Size` 등의 제약과 허용 범위를 명세에 포함한다.
+- Cookie 인증은 cookie 값을 프론트가 직접 읽을 수 있는지(`HttpOnly`)와 브라우저가 자동 전송하는지 구분한다.
+- CSRF를 사용하는 상태 변경 요청은 CSRF cookie와 요구되는 header 이름을 모두 적고, 토큰을 얻는 API가 있으면 호출 순서도 설명한다.
+
+### Response 규칙
+
+- `Status Code`에는 성공뿐 아니라 프론트가 처리해야 하는 대표적인 실패 상태도 포함한다.
+- 반환 DTO의 실제 필드, JSON 이름, 타입, nullable 여부를 기준으로 작성한다.
+- `ResponseEntity<Void>` 또는 body가 없는 redirect/204 응답은 `없음`이라고 적는다.
+- `Set-Cookie`, `Location` 같은 응답 header는 Response Body가 아니라 별도로 설명한다.
+- 오류 응답은 프로젝트의 `ErrorResponse` 형태를 따른다. 보통 `code`, `message`, 필요할 때 `fieldErrors`를 적는다.
+- `@JsonInclude` 때문에 생략될 수 있는 필드는 항상 반환된다고 표현하지 않는다.
+- 오류 상태와 error code는 `ErrorResponse`와 `ErrorCode`의 실제 매핑을 확인해 `Error Response` 표에 작성한다.
+
+### Status Code 규칙
+
+- 성공 상태 코드는 Controller의 반환 타입, `ResponseEntity`, `@ResponseStatus`, 테스트로 검증한다.
+- 일반 예외 상태 코드는 `GlobalExceptionHandler`의 `ErrorCategory` 매핑을 확인한다.
+- 인증·인가·CSRF 상태 코드는 `SecurityFilterChain`, entry point, access denied 처리와 테스트를 확인한다.
+- 코드에 상태 코드 근거가 없으면 임의로 `200` 또는 `400`을 쓰지 말고 `확인 필요`라고 표시한다.
+
+## 인증·OAuth API 작성 규칙
+
+OAuth 로그인은 단순 JSON API와 다르므로 다음 흐름을 명세에 포함한다.
+
+1. 프론트가 브라우저 이동으로 OAuth 시작 경로를 연다.
+2. 제공자 callback 경로는 백엔드가 처리하며 프론트가 직접 호출하지 않는다.
+3. 로그인 결과에 따라 access cookie 또는 임시 온보딩 cookie가 발급된다.
+4. 백엔드가 설정된 redirect URI로 브라우저를 이동시킨다.
+
+- `302 Found` 응답은 body보다 `Location`과 `Set-Cookie` 동작을 설명한다.
+- callback 경로가 실제 Controller에 없더라도 Security OAuth 설정이 처리하는 공개 흐름이면 별도 참고 항목으로 설명한다.
+- access token, onboarding token, CSRF token을 같은 종류의 토큰처럼 설명하지 않는다.
+- 운영·로컬 cookie 이름과 `Secure`, `HttpOnly`, `SameSite`가 설정에 따라 달라지면 환경별로 나눈다.
+- cookie의 실제 JWT 값이나 secret, client secret은 명세서에 작성하지 않는다.
+
+## CORS·CSRF 작성 규칙
+
+프론트엔드 연동에 영향을 주는 경우 공통 사항 또는 해당 API Request에 다음을 포함한다.
+
+- 허용 Origin
+- 허용 HTTP method와 요청 header
+- `Access-Control-Allow-Credentials` 여부
+- `credentials: "include"` 필요 여부
+- CSRF token 조회 경로
+- CSRF cookie 이름과 header 이름
+- preflight(`OPTIONS`)가 별도 검증 대상이면 별도 엔드포인트로 문서화
+
+## 전달 형식
+
+- 프론트 전달용 결과는 내부 package 이름이나 서비스 호출 순서를 중심으로 쓰지 않고 공개 HTTP 계약 중심으로 작성한다.
+- API별 제목 바로 아래에 HTTP method와 경로를 표시한다.
+- 모든 API는 `Header`, `Path Parameter`, `Query Parameter`, `Request Body`, `Response`, `Error Response` 섹션을 유지한다.
+- `Response` 안에는 `Status Code`, `Response Body`, `Response Example`을 유지한다.
+- 사용자가 제공한 템플릿의 열 이름과 순서를 우선하며, 타입·필수·nullable·예시·설명을 생략하지 않는다.
+- 예시 JSON은 실제 계약을 대표하는 최소 예시만 사용한다. 인증 토큰, 비밀번호, client secret은 실제 값을 넣지 않는다.
+- 여러 API의 호출 순서가 중요하면 엔드포인트 설명 뒤에 짧은 순서도 또는 번호 목록을 추가한다.
+- 현재 구현되지 않은 API를 구현된 것처럼 작성하지 않는다.
+
+## 파일 작성과 검증
+
+사용자가 문서 파일을 요청하면 기존 문서 위치와 명명 규칙을 먼저 확인한다. 별도 규칙이 없으면 도메인별 파일을 `docs/api/<domain>.md`에 둔다.
+
+작성 후 다음을 확인한다.
+
+- 모든 공개 Controller endpoint가 빠지지 않았는가
+- method/path가 실제 annotation과 일치하는가
+- Header, Path Parameter, Query Parameter, Request Body, Response, Error Response 섹션이 모두 있는가
+- Request 필드와 validation 제약이 DTO와 일치하는가
+- Response 필드와 nullable 여부가 DTO와 일치하는가
+- cookie/header/redirect/CSRF 동작이 Security 설정과 일치하는가
+- 성공과 실패 상태 코드가 실제 코드·테스트 근거를 갖는가
+- 미확인 내용을 추측으로 채우지 않았는가
+- Markdown 표, JSON code fence, 마지막 개행이 정상인가
+
+명세 문서 작성만으로는 `npx ph workflow implement`나 테스트를 실행할 필요가 없다. 코드 동작을 변경하거나 API 계약을 구현하는 요청으로 범위가 넓어지면 프로젝트 `AGENTS.md`의 구현 절차를 따른다.

--- a/backend/.codex/skills/knot-api-spec/agents/openai.yaml
+++ b/backend/.codex/skills/knot-api-spec/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Knot API Spec"
+  short_description: "Create frontend-facing Knot API specs"
+  default_prompt: "Use $knot-api-spec to inspect the backend and write a Request, Response Body, and Status Code API specification."

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 	implementation 'org.springframework.boot:spring-boot-starter-jackson'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/backend/src/main/java/com/knot/backend/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/knot/backend/auth/presentation/AuthController.java
@@ -8,6 +8,7 @@ import com.knot.backend.auth.presentation.dto.response.AuthenticatedMemberRespon
 import com.knot.backend.auth.presentation.dto.response.CsrfTokenResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증", description = "회원가입, 로그인, 리프레쉬, 로그아웃, 확인")
 public class AuthController {
     private final AuthService authService;
     private final AuthCookieManager authCookieManager;

--- a/backend/src/main/java/com/knot/backend/global/config/ApiDocumentationProperties.java
+++ b/backend/src/main/java/com/knot/backend/global/config/ApiDocumentationProperties.java
@@ -1,0 +1,12 @@
+package com.knot.backend.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "knot.api-docs")
+public class ApiDocumentationProperties {
+    private boolean enabled;
+}

--- a/backend/src/main/java/com/knot/backend/global/config/OAuth2LoginProperties.java
+++ b/backend/src/main/java/com/knot/backend/global/config/OAuth2LoginProperties.java
@@ -9,6 +9,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "auth.oauth2")
 public class OAuth2LoginProperties {
     private String successRedirectUri = "/auth/me";
-    private String nicknameRedirectUri = "/nickname";
+    private String nicknameRedirectUri = "/onboarding";
     private String failureRedirectUri = "/login?error=oauth2";
 }

--- a/backend/src/main/java/com/knot/backend/global/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/knot/backend/global/config/OpenApiConfig.java
@@ -1,0 +1,54 @@
+package com.knot.backend.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI knotOpenAPI() {
+        return new OpenAPI().info(
+                new Info().title("Knot Backend API")
+                        .version("1.0.0")
+        )
+                .paths(oAuthPaths());
+    }
+
+    private Paths oAuthPaths() {
+        return new Paths().addPathItem(
+                "/oauth2/authorization/{registrationId}",
+                new PathItem().get(
+                        new Operation().operationId("startOAuthLogin")
+                                .summary("OAuth 로그인 시작")
+                                .addParametersItem(
+                                        new Parameter().name("registrationId")
+                                                .in("path")
+                                                .required(true)
+                                                .schema(new StringSchema())
+                                )
+                                .responses(
+                                        new ApiResponses().addApiResponse(
+                                                "302",
+                                                new ApiResponse()
+                                                        .description("OAuth provider authorization endpoint로 redirect")
+                                                        .addHeaderObject(
+                                                                "Location",
+                                                                new Header()
+                                                                        .description("OAuth provider authorization URL")
+                                                        )
+                                        )
+                                )
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/knot/backend/global/config/SecurityConfig.java
@@ -28,7 +28,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties({JwtProperties.class, OAuth2LoginProperties.class, CorsProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, OAuth2LoginProperties.class, CorsProperties.class,
+        ApiDocumentationProperties.class})
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final GithubOAuth2UserService githubOAuth2UserService;
@@ -39,6 +40,7 @@ public class SecurityConfig {
     private final JwtLogoutHandler jwtLogoutHandler;
     private final JwtProperties jwtProperties;
     private final CorsProperties corsProperties;
+    private final ApiDocumentationProperties apiDocumentationProperties;
 
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
@@ -83,19 +85,30 @@ public class SecurityConfig {
         );
 
         http.cors(Customizer.withDefaults())
-                .authorizeHttpRequests(
-                        auth -> auth.requestMatchers(
-                                "/oauth2/**",
-                                "/login/**",
-                                "/auth/nickname",
-                                "/auth/csrf",
-                                "/actuator/health",
-                                "/error"
+                .authorizeHttpRequests(auth -> {
+                    if (apiDocumentationProperties.isEnabled()) {
+                        auth.requestMatchers(
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml",
+                                "/webjars/**"
                         )
-                                .permitAll()
-                                .anyRequest()
-                                .authenticated()
-                )
+                                .permitAll();
+                    }
+                    auth.requestMatchers(
+                            "/oauth2/**",
+                            "/login/**",
+                            "/auth/nickname",
+                            "/auth/csrf",
+                            "/actuator/health",
+                            "/error"
+                    )
+                            .permitAll()
+                            .anyRequest()
+                            .authenticated();
+                })
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint))
                 .csrf(
                         csrf -> csrf.csrfTokenRepository(csrfTokenRepository)

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+knot.api-docs.enabled=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,6 +17,17 @@ spring.flyway.locations=classpath:db/migration
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
 
+# API documentation
+knot.api-docs.enabled=false
+springdoc.api-docs.enabled=${knot.api-docs.enabled}
+springdoc.swagger-ui.enabled=${knot.api-docs.enabled}
+springdoc.swagger-ui.url=/v3/api-docs
+springdoc.swagger-ui.validatorUrl=none
+springdoc.swagger-ui.supportedSubmitMethods=
+springdoc.swagger-ui.tryItOutEnabled=false
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.queryConfigEnabled=false
+
 # OAuth
 spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -48,5 +48,5 @@ auth.cors.allowed-origin=${AUTH_CORS_ALLOWED_ORIGIN:https://knoted.kr}
 
 # OAuth login result
 auth.oauth2.success-redirect-uri=${AUTH_SUCCESS_REDIRECT_URI:/auth/me}
-auth.oauth2.nickname-redirect-uri=${AUTH_NICKNAME_REDIRECT_URI:/nickname}
+auth.oauth2.nickname-redirect-uri=${AUTH_NICKNAME_REDIRECT_URI:/onboarding}
 auth.oauth2.failure-redirect-uri=${AUTH_FAILURE_REDIRECT_URI:/login?error=oauth2}

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.knot.backend.global.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -27,9 +28,21 @@ import org.springframework.test.web.servlet.MockMvc;
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class ApiDocumentationAcceptanceTest {
     private final MockMvc mockMvc;
+    private final OAuth2LoginProperties oauth2LoginProperties;
 
-    ApiDocumentationAcceptanceTest(MockMvc mockMvc) {
+    ApiDocumentationAcceptanceTest(
+            MockMvc mockMvc,
+            OAuth2LoginProperties oauth2LoginProperties
+    ) {
         this.mockMvc = mockMvc;
+        this.oauth2LoginProperties = oauth2LoginProperties;
+    }
+
+    @Test
+    @DisplayName("OAuth 닉네임 설정 redirect 기본값은 온보딩 경로로 바인딩된다")
+    void oauth2LoginProperties_success_bindsOnboardingRedirect() {
+        // when & then
+        assertThat(oauth2LoginProperties.getNicknameRedirectUri()).isEqualTo("/onboarding");
     }
 
     @Test

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
@@ -1,0 +1,68 @@
+package com.knot.backend.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.knot.backend.testsupport.TestApplicationProperties;
+import com.knot.backend.testsupport.TestcontainersConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Tag("acceptance")
+@ActiveProfiles("dev")
+@Import(TestcontainersConfiguration.class)
+@TestApplicationProperties
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class ApiDocumentationAcceptanceTest {
+    private final MockMvc mockMvc;
+
+    ApiDocumentationAcceptanceTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Test
+    @DisplayName("개발 프로파일에서는 Swagger UI를 공개한다")
+    void swaggerUi_success_developmentProfile() throws Exception {
+        // when & then
+        mockMvc.perform(get("/swagger-ui.html"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", "/swagger-ui/index.html"));
+    }
+
+    @Test
+    @DisplayName("개발 프로파일에서는 OpenAPI JSON을 공개하고 인증 계약을 포함한다")
+    void openApi_success_developmentProfile() throws Exception {
+        // when & then
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.paths['/auth/me'].get").exists())
+                .andExpect(jsonPath("$.paths['/auth/csrf'].get").exists())
+                .andExpect(jsonPath("$.paths['/auth/nickname'].post").exists())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse").exists());
+    }
+
+    @Test
+    @DisplayName("Swagger 설정은 외부 validator와 API 실행 기능을 사용하지 않는다")
+    void swaggerConfig_success_disablesExternalRequestsAndTryItOut() throws Exception {
+        // when & then
+        mockMvc.perform(get("/v3/api-docs/swagger-config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value("/v3/api-docs"))
+                .andExpect(jsonPath("$.validatorUrl").value("none"))
+                .andExpect(jsonPath("$.supportedSubmitMethods").isArray())
+                .andExpect(jsonPath("$.supportedSubmitMethods").isEmpty());
+    }
+}

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
@@ -51,7 +51,16 @@ class ApiDocumentationAcceptanceTest {
                 .andExpect(jsonPath("$.paths['/auth/me'].get").exists())
                 .andExpect(jsonPath("$.paths['/auth/csrf'].get").exists())
                 .andExpect(jsonPath("$.paths['/auth/nickname'].post").exists())
-                .andExpect(jsonPath("$.components.schemas.ErrorResponse").exists());
+                .andExpect(jsonPath("$.paths['/auth/me'].get.responses['401'].content['application/json'].schema['$ref']")
+                        .value("#/components/schemas/ErrorResponse"))
+                .andExpect(jsonPath("$.paths['/auth/csrf'].get.responses['200'].headers['Set-Cookie']").exists())
+                .andExpect(jsonPath("$.paths['/auth/nickname'].post.responses['204'].headers['Set-Cookie']").exists())
+                .andExpect(jsonPath("$.components.schemas.ErrorResponse").exists())
+                .andExpect(jsonPath("$.components.securitySchemes.accessTokenCookie.in").value("cookie"))
+                .andExpect(jsonPath("$.components.securitySchemes.accessTokenCookie.name").value("KNOT_ACCESS_TOKEN"))
+                .andExpect(jsonPath("$.paths['/auth/me'].get.security[0].accessTokenCookie").isArray())
+                .andExpect(jsonPath("$.paths['/oauth2/authorization/{registrationId}'].get.responses['302'].headers.Location")
+                        .exists());
     }
 
     @Test

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
@@ -38,29 +38,31 @@ class ApiDocumentationAcceptanceTest {
         // when & then
         mockMvc.perform(get("/swagger-ui.html"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(header().string("Location", "/swagger-ui/index.html"));
+                .andExpect(
+                        header().string(
+                                "Location",
+                                "/swagger-ui/index.html"
+                        )
+                );
     }
 
     @Test
-    @DisplayName("개발 프로파일에서는 OpenAPI JSON을 공개하고 인증 계약을 포함한다")
+    @DisplayName("개발 프로파일에서는 OpenAPI JSON과 인증 태그를 공개한다")
     void openApi_success_developmentProfile() throws Exception {
         // when & then
         mockMvc.perform(get("/v3/api-docs"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.tags[0].name").value("인증"))
+                .andExpect(jsonPath("$.tags[0].description").value("회원가입, 로그인, 리프레쉬, 로그아웃, 확인"))
                 .andExpect(jsonPath("$.paths['/auth/me'].get").exists())
                 .andExpect(jsonPath("$.paths['/auth/csrf'].get").exists())
                 .andExpect(jsonPath("$.paths['/auth/nickname'].post").exists())
-                .andExpect(jsonPath("$.paths['/auth/me'].get.responses['401'].content['application/json'].schema['$ref']")
-                        .value("#/components/schemas/ErrorResponse"))
-                .andExpect(jsonPath("$.paths['/auth/csrf'].get.responses['200'].headers['Set-Cookie']").exists())
-                .andExpect(jsonPath("$.paths['/auth/nickname'].post.responses['204'].headers['Set-Cookie']").exists())
-                .andExpect(jsonPath("$.components.schemas.ErrorResponse").exists())
-                .andExpect(jsonPath("$.components.securitySchemes.accessTokenCookie.in").value("cookie"))
-                .andExpect(jsonPath("$.components.securitySchemes.accessTokenCookie.name").value("KNOT_ACCESS_TOKEN"))
-                .andExpect(jsonPath("$.paths['/auth/me'].get.security[0].accessTokenCookie").isArray())
-                .andExpect(jsonPath("$.paths['/oauth2/authorization/{registrationId}'].get.responses['302'].headers.Location")
-                        .exists());
+                .andExpect(
+                        jsonPath(
+                                "$.paths['/oauth2/authorization/{registrationId}'].get.responses['302'].headers.Location"
+                        ).exists()
+                );
     }
 
     @Test

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationDisabledAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationDisabledAcceptanceTest.java
@@ -1,0 +1,39 @@
+package com.knot.backend.global.config;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.knot.backend.testsupport.TestApplicationProperties;
+import com.knot.backend.testsupport.TestcontainersConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Tag("acceptance")
+@Import(TestcontainersConfiguration.class)
+@TestApplicationProperties
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class ApiDocumentationDisabledAcceptanceTest {
+    private final MockMvc mockMvc;
+
+    ApiDocumentationDisabledAcceptanceTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Test
+    @DisplayName("개발 프로파일이 아니면 OpenAPI 문서를 공개하지 않는다")
+    void openApi_failure_disabledByDefault() throws Exception {
+        // when & then
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHENTICATED"));
+    }
+}

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationPropertiesTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationPropertiesTest.java
@@ -1,0 +1,18 @@
+package com.knot.backend.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ApiDocumentationPropertiesTest {
+    @Test
+    @DisplayName("API 문서 공개 설정의 기본값은 비활성화다")
+    void default_success_disabled() {
+        // given
+        ApiDocumentationProperties properties = new ApiDocumentationProperties();
+
+        // when & then
+        assertThat(properties.isEnabled()).isFalse();
+    }
+}

--- a/docs/adr/221-developer-api-documentation.md
+++ b/docs/adr/221-developer-api-documentation.md
@@ -1,0 +1,62 @@
+# Springdoc OpenAPI와 Swagger UI를 도입하고 개발 프로파일에서만 PUBLIC으로 제공한다. 문서 기능 기본값은 false로 두며 운영 서버의 접근 제어는 후속 Issue/ADR에서 결정한다.
+
+## 상태
+
+Proposed
+
+## 관련 Issue
+
+- #221 [BE] OpenAPI 문서 제공
+
+## 한 줄 요약
+
+Springdoc OpenAPI와 Swagger UI를 도입하고 개발 프로파일에서만 PUBLIC으로 제공한다. 문서 기능 기본값은 false로 두며 운영 서버의 접근 제어는 후속 Issue/ADR에서 결정한다.
+
+## 왜 이 결정이 필요했나
+
+Spring Boot 4.1.0 REST 백엔드에 runtime API 문서 UI가 없고, Issue #110의 계약을 개발자가 확인할 경로가 필요하다.
+
+인증·멤버 기능은 도입됐지만 완전히 릴리즈되지 않아 개발 서버에서는 모든 개발자가 로그인 없이 문서를 봐야 하며, 운영 접근 정책은 운영 배포 시점에 재논의한다.
+
+결정 동인:
+
+- 개발 서버 즉시 접근성
+- 운영 오배포 방지
+- Boot 호환성
+- FE-BE 계약 정확성
+- 후속 운영 보안 결정과의 분리
+
+## 트레이드 오프
+
+- Springdoc OpenAPI + Swagger UI: runtime 계약으로 브라우저 UI와 JSON/YAML을 제공하지만 drift와 community dependency를 관리해야 한다.
+- Spring REST Docs: 테스트 기반 문서 일치를 강제하지만 runtime Swagger UI를 제공하지 않는다.
+- Springdoc OpenAPI + Spring REST Docs 병행: UI와 테스트 근거를 모두 얻지만 중복 유지보수와 초기 범위가 커진다.
+
+## 무엇을 결정했나
+
+Springdoc OpenAPI와 Swagger UI를 도입하고 개발 프로파일에서만 PUBLIC으로 제공한다. 문서 기능 기본값은 false로 두며 운영 서버의 접근 제어는 후속 Issue/ADR에서 결정한다.
+
+개발 서버에서 즉시 사용할 브라우저 문서가 필요하므로 Springdoc Swagger UI를 선택한다. 기본 비활성·개발 프로파일 명시 활성화로 운영 오배포를 닫고, 운영 권한 정책은 별도 결정으로 분리한다.
+
+## 결과
+
+- runtime dependency와 문서 annotation/customizer 유지보수가 추가된다.
+- 개발 CD가 개발 프로파일을 명시적으로 활성화해야 한다.
+- 개발 서버의 전체 API 경로와 스키마가 공개된다.
+- 운영 서버 접근 정책은 구현하지 않으며 운영 배포 전에 별도 재검토한다.
+- DB migration 없이 기존 API 동작을 유지한다.
+
+## 다시 논의해야 할 조건
+
+- 운영 서버에 문서를 배포할 때
+- 인증·멤버 기능이 완전히 릴리즈될 때
+- Member ID Allowlist·SSO·영속 권한이 필요해질 때
+- 문서 drift·유지보수 비용이 반복될 때
+- Springdoc의 Boot 4.1.x 호환성이 깨질 때
+
+## 확인
+
+- 예정 경로: `docs/adr/221-developer-api-documentation.md`
+- 결정 주체: Knot 팀
+- AI 하네스가 Proposed ADR 파일을 생성했다.
+- 팀이 PR에서 승인한 뒤 Accepted로 바꾼다.


### PR DESCRIPTION
## 관련 이슈

- Closes #221

## 작업 내용

- Springdoc OpenAPI와 Swagger UI runtime dependency를 추가했습니다.
- API 문서 공개 기본값은 비활성화하고, `dev` 프로파일에서만 문서 UI와 OpenAPI JSON/YAML 경로를 공개합니다.
- 문서 endpoint는 설정이 활성화된 경우에만 Security 설정에서 `permitAll`로 허용합니다.
- `AuthController`에는 인증 API 그룹화를 위한 `@Tag`만 추가하고, 요청·응답 스키마는 Springdoc 자동 추론을 사용합니다.
- Swagger UI는 로컬 OpenAPI 경로를 사용하며 외부 validator와 `Try it out`을 비활성화했습니다.
- Spring MVC controller 밖에서 동작하는 OAuth authorization redirect 경로만 OpenAPI 설정에서 보완했습니다.
- 개발 CD 배포 시 `SPRING_PROFILES_ACTIVE=dev`가 systemd drop-in으로 적용되도록 했습니다.
- 개발 프로파일 공개 결정과 운영 접근 제어 보류 내용을 ADR로 기록했습니다.

### 참고 사항

- 현재 인증·멤버 기능이 완전히 릴리즈되지 않아 개발 서버 문서는 전체 공개합니다.
- 운영 서버의 개발자 role, allowlist, SSO 접근 정책은 후속 Issue/ADR에서 결정하며 이번 PR에는 포함하지 않았습니다.
- Issue #221 본문에 남아 있는 `ROLE_DEVELOPER` 및 allowlist TODO는 위 운영 정책 결정 이후 별도로 처리합니다.
- 사용자가 요청한 `backend/.codex/skills/knot-api-spec/` tooling 파일은 별도 `chore` 커밋으로 포함되어 있습니다.
- 검증 완료: `./gradlew check --no-daemon`, `./gradlew spotlessCheck`, Governance unit tests 8건, workflow YAML parse.
- 실제 NCP 배포 실행과 운영 서버 접근 정책 검증은 아직 수행하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive OpenAPI and Swagger UI documentation for backend APIs in development environments.
  * Added authentication endpoint grouping and OAuth login redirect details to the API documentation.
  * API documentation remains disabled by default outside development environments.

* **Improvements**
  * Development deployments now apply the correct Spring profile before restarting the backend service.

* **Documentation**
  * Added guidance and architectural documentation for creating and maintaining API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->