### PR TITLE
[FE] 새 워크스페이스 생성 페이지(워크스페이스 이름 입력 페이지) UI 구현

### DIFF
--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/constants/workspaceName.ts
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/constants/workspaceName.ts
@@ -1,0 +1,20 @@
+/** 워크스페이스 이름 최대 글자 수. 카운터 `n/20`의 분모이기도 해요. */
+export const WORKSPACE_NAME_MAX_LENGTH = 20;
+
+/**
+ * 워크스페이스 이름에 허용하는 문자. 한글·영어·공백만 통과해요.
+ *
+ * 자모(ㄱ-ㅎ, ㅏ-ㅣ)를 함께 허용하는 이유:
+ * IME로 한글을 조합하는 도중("ㄴ" → "노")에 에러가 깜빡이지 않게 하려고요.
+ */
+export const WORKSPACE_NAME_PATTERN = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z ]*$/;
+
+export const WORKSPACE_NAME_ERROR_MESSAGE =
+  "한글, 영어와 공백만 사용할 수 있어요.";
+
+/**
+ * 초대 화면으로 넘어갈 때 쓰는 임시 workspaceId.
+ *
+ * 워크스페이스 생성 API(#216)가 붙으면 응답의 id로 교체하고 이 상수는 지워요.
+ */
+export const TEMP_WORKSPACE_ID = "temp";

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
@@ -26,7 +26,7 @@ export default function CreateWorkspaceCard() {
     useCreateWorkspace();
 
   return (
-    <Root>
+    <Container>
       <Title>워크스페이스 이름을 입력하세요</Title>
 
       <Form onSubmit={handleSubmit}>
@@ -50,11 +50,11 @@ export default function CreateWorkspaceCard() {
           워크스페이스 생성
         </Button>
       </Form>
-    </Root>
+    </Container>
   );
 }
 
-const Root = styled.section`
+const Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
@@ -1,11 +1,9 @@
 import styled from "@emotion/styled";
-import useNavigateToWorkspaceInvite from "@hooks/domain/workspace/useNavigateToWorkspaceInvite";
 import Button from "@primitives/ui/Button";
 import TextField from "@primitives/ui/TextField";
-import { type ChangeEvent, type FormEvent, useState } from "react";
 
 import { WORKSPACE_NAME_MAX_LENGTH } from "./constants/workspaceName";
-import { getWorkspaceNameErrorMessage } from "./utils/getWorkspaceNameErrorMessage";
+import { useCreateWorkspace } from "./models/useCreateWorkspace";
 
 /**
  * 새 워크스페이스 이름 입력 카드.
@@ -24,24 +22,8 @@ import { getWorkspaceNameErrorMessage } from "./utils/getWorkspaceNameErrorMessa
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1594 새 워크스페이스 생성/입력 에러}
  */
 export default function CreateWorkspaceCard() {
-  const [name, setName] = useState("");
-  const { navigateToWorkspaceInvite } = useNavigateToWorkspaceInvite();
-
-  const errorMessage = getWorkspaceNameErrorMessage(name);
-  const isSubmittable = name.trim().length > 0 && !errorMessage;
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setName(event.target.value.slice(0, WORKSPACE_NAME_MAX_LENGTH));
-  };
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!isSubmittable) return;
-
-    // TODO(#216): 워크스페이스 생성 API 연결 후 응답의 workspaceId로 교체
-    const TEMP_WORKSPACE_ID = "temp";
-    navigateToWorkspaceInvite(TEMP_WORKSPACE_ID);
-  };
+  const { errorMessage, handleChange, handleSubmit, isSubmittable, name } =
+    useCreateWorkspace();
 
   return (
     <Root>

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
@@ -60,6 +60,7 @@ export default function CreateWorkspaceCard() {
             errorMessage={errorMessage}
             aria-label="워크스페이스 이름"
             autoComplete="off"
+            autoFocus
           />
         </Field>
 

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
@@ -1,0 +1,112 @@
+import styled from "@emotion/styled";
+import useNavigateToWorkspaceInvite from "@hooks/domain/workspace/useNavigateToWorkspaceInvite";
+import Button from "@primitives/ui/Button";
+import TextField from "@primitives/ui/TextField";
+import { type ChangeEvent, type FormEvent, useState } from "react";
+
+import { WORKSPACE_NAME_MAX_LENGTH } from "./constants/workspaceName";
+import { getWorkspaceNameErrorMessage } from "./utils/getWorkspaceNameErrorMessage";
+
+/**
+ * 새 워크스페이스 이름 입력 카드.
+ *
+ * 입력 전 · 입력 중 · 입력 에러 세 상태를 한 카드에서 다뤄요.
+ * 글자를 칠 때마다 허용 문자(한글·영어·공백)를 검사해 바로 에러 문구를 띄우고,
+ * `maxLength`로 21자째 입력은 막습니다.
+ *
+ * 값이 비었거나(공백만 있는 값 포함) 에러면 버튼이 비활성이고, 라벨은 늘 `워크스페이스 생성`이에요.
+ * 생성 API(#216)가 아직 없어 유효한 이름으로 제출하면 임시 workspaceId로 초대 화면으로 넘어갑니다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=431-1294 새 워크스페이스 생성/입력 전}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1576 새 워크스페이스 생성/입력 중}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1594 새 워크스페이스 생성/입력 에러}
+ */
+export default function CreateWorkspaceCard() {
+  const [name, setName] = useState("");
+  const { navigateToWorkspaceInvite } = useNavigateToWorkspaceInvite();
+
+  const errorMessage = getWorkspaceNameErrorMessage(name);
+  const isSubmittable = name.trim().length > 0 && !errorMessage;
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value.slice(0, WORKSPACE_NAME_MAX_LENGTH));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isSubmittable) return;
+
+    // TODO(#216): 워크스페이스 생성 API 연결 후 응답의 workspaceId로 교체
+    const TEMP_WORKSPACE_ID = "temp";
+    navigateToWorkspaceInvite(TEMP_WORKSPACE_ID);
+  };
+
+  return (
+    <Root>
+      <Title>워크스페이스 이름을 입력하세요</Title>
+
+      <Form onSubmit={handleSubmit}>
+        <Field>
+          <Counter>
+            {name.length}/{WORKSPACE_NAME_MAX_LENGTH}
+          </Counter>
+          <TextField
+            value={name}
+            onChange={handleChange}
+            placeholder="예시: knot"
+            maxLength={WORKSPACE_NAME_MAX_LENGTH}
+            errorMessage={errorMessage}
+            aria-label="워크스페이스 이름"
+            autoComplete="off"
+          />
+        </Field>
+
+        <Button type="submit" size="lg" isFullWidth disabled={!isSubmittable}>
+          워크스페이스 생성
+        </Button>
+      </Form>
+    </Root>
+  );
+}
+
+const Root = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem; /* 12px */
+  width: 100%;
+  max-width: 28.75rem; /* 460px */
+  padding: 3rem; /* 48px */
+  border-radius: 1.5rem; /* 24px */
+  background-color: ${({ theme }) => theme.neutral[0]};
+  box-shadow: 0 12px 32px 0 rgba(15, 23, 41, 0.08);
+`;
+
+const Title = styled.h1`
+  color: ${({ theme }) => theme.neutral[900]};
+  overflow-wrap: break-word;
+  ${({ theme }) => theme.text.heading02};
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem; /* 24px */
+  width: 100%;
+`;
+
+const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem; /* 8px */
+  width: 100%;
+`;
+
+const Counter = styled.p`
+  width: 100%;
+  color: ${({ theme }) => theme.neutral[600]};
+  text-align: right;
+  ${({ theme }) => theme.text.caption01};
+`;

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/index.tsx
@@ -64,7 +64,7 @@ const Container = styled.section`
   padding: 3rem; /* 48px */
   border-radius: 1.5rem; /* 24px */
   background-color: ${({ theme }) => theme.neutral[0]};
-  box-shadow: 0 12px 32px 0 rgba(15, 23, 41, 0.08);
+  box-shadow: ${({ theme }) => theme.shadow02};
 `;
 
 const Title = styled.h1`

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/models/useCreateWorkspace.ts
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/models/useCreateWorkspace.ts
@@ -1,0 +1,34 @@
+import useNavigateToWorkspaceInvite from "@hooks/domain/workspace/useNavigateToWorkspaceInvite";
+import { ChangeEvent, FormEvent, useState } from "react";
+
+import { WORKSPACE_NAME_MAX_LENGTH } from "../constants/workspaceName";
+import { getWorkspaceNameErrorMessage } from "../utils/getWorkspaceNameErrorMessage";
+
+export const useCreateWorkspace = () => {
+  const [name, setName] = useState("");
+  const { navigateToWorkspaceInvite } = useNavigateToWorkspaceInvite();
+
+  const errorMessage = getWorkspaceNameErrorMessage(name);
+  const isSubmittable = name.trim().length > 0 && !errorMessage;
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value.slice(0, WORKSPACE_NAME_MAX_LENGTH));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isSubmittable) return;
+
+    // TODO(#216): 워크스페이스 생성 API 연결 후 응답의 workspaceId로 교체
+    const TEMP_WORKSPACE_ID = "temp";
+    navigateToWorkspaceInvite(TEMP_WORKSPACE_ID);
+  };
+
+  return {
+    name,
+    errorMessage,
+    isSubmittable,
+    handleChange,
+    handleSubmit,
+  };
+};

--- a/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/utils/getWorkspaceNameErrorMessage.ts
+++ b/frontend/src/modules/widgets/workspace/CreateWorkspaceCard/utils/getWorkspaceNameErrorMessage.ts
@@ -1,0 +1,13 @@
+import {
+  WORKSPACE_NAME_ERROR_MESSAGE,
+  WORKSPACE_NAME_PATTERN,
+} from "../constants/workspaceName";
+
+/**
+ * 워크스페이스 이름이 허용 문자로만 이루어졌는지 검사해요.
+ *
+ * 규칙을 어기면 사용자에게 보여줄 문구를, 통과하면 `undefined`를 돌려줍니다.
+ * 빈 값은 "아직 입력 전"이라 에러가 아니에요. 비어 있을 때 버튼을 막는 건 카드가 따로 맡습니다.
+ */
+export const getWorkspaceNameErrorMessage = (name: string) =>
+  WORKSPACE_NAME_PATTERN.test(name) ? undefined : WORKSPACE_NAME_ERROR_MESSAGE;

--- a/frontend/src/pages/workspace/create/index.tsx
+++ b/frontend/src/pages/workspace/create/index.tsx
@@ -1,3 +1,5 @@
+import CreateWorkspaceCard from "@widgets/workspace/CreateWorkspaceCard";
+
 /**
  * 새 워크스페이스 생성 화면 (`/workspace/create`)
  *
@@ -5,14 +7,12 @@
  * 입력 전 / 입력 중 / 입력 에러 세 가지 상태를 한 화면에서 다룬다.
  * 생성에 성공하면 팀원 초대(`/workspace/:workspaceId/invite`)로 이어진다.
  *
- * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10164 새 워크스페이스 생성/입력 전
- * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10184 새 워크스페이스 생성/입력 중
- * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10160 새 워크스페이스 생성/입력 에러
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
+ *
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=431-1294 새 워크스페이스 생성/입력 전
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1576 새 워크스페이스 생성/입력 중
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1594 새 워크스페이스 생성/입력 에러
  */
 export default function WorkspaceCreatePage() {
-  return (
-    <div>
-      <h1>Workspace Create Page</h1>
-    </div>
-  );
+  return <CreateWorkspaceCard />;
 }

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceInvite/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceInvite/index.ts
@@ -1,0 +1,19 @@
+import { getRouterPath } from "@routes/PATH_ROUTE";
+import { useNavigate } from "react-router";
+
+/**
+ * 팀원 초대 화면(`/workspace/:workspaceId/invite`)으로 이동하는 도메인 훅.
+ */
+const useNavigateToWorkspaceInvite = () => {
+  const navigate = useNavigate();
+
+  const navigateToWorkspaceInvite = (workspaceId: string) => {
+    navigate(
+      getRouterPath({ routeKey: "WORKSPACE_INVITE", params: { workspaceId } }),
+    );
+  };
+
+  return { navigateToWorkspaceInvite };
+};
+
+export default useNavigateToWorkspaceInvite;


### PR DESCRIPTION
## 관련 이슈

- #204

## 작업 내용

가입을 마친 사용자가 `/workspace/create`에서 워크스페이스 이름을 입력하고 생성 버튼을 누르는 화면 UI를 구현하였습니다.
추후에 api 를 연동하도록 하겠습니다

<img width="1728" height="962" alt="image" src="https://github.com/user-attachments/assets/80863e83-26c8-4d39-9c10-cad73a4b5644" />

<img width="2000" height="1113" alt="image" src="https://github.com/user-attachments/assets/a58aa9fa-1518-4409-bcf7-2bfc94ac175d" />

### CreateWorkspaceCard 위젯 구현

로고와 중앙 배치는 기존 `CenteredLayout`이 담당하고, `pages/workspace/create/index.tsx`는 중앙에 있는 카드 부분만 담당합니다.

### 위젯의 폼 로직을 model 훅으로 분리

입력값·에러 문구·제출 가능 여부와 핸들러는 `models/useCreateWorkspace.ts`로 분리하였습니다.
해당 부분은 폼 로직이다보니, 폼 입력에 대한 것만 훅으로 빼고, 제출 로직을 제출 버튼 컴포넌트에 따로 분리하는 것이 좋아보였습니다. 
그렇게 하지 않은 이유는, 그정도로 추상화를 가져갈 만큼 복잡한 케이스가 아니라고 생각했습니다!
혹시나 해당 추상화가 부적절하다면 리뷰에 남겨주세요!!

```tsx
const { errorMessage, handleChange, handleSubmit, isSubmittable, name } =
  useCreateWorkspace();

<TextField value={name} onChange={handleChange} errorMessage={errorMessage} maxLength={20} />
<Button type="submit" disabled={!isSubmittable}>워크스페이스 생성</Button>
```

### 워크스페이스 이름 실시간 검증

요구사항에 맞추어서 글자를 칠 때마다 `WORKSPACE_NAME_PATTERN`으로 허용 문자(한글·영어·공백)를 검사하여 어긋나면 즉시 `한글, 영어와 공백만 사용할 수 있어요.`를 띄우고, `maxLength=20`과 `slice`로 21자째 입력을 막았습니다.
값이 비었거나(공백만 있는 값 포함) 에러 상태면 버튼을 비활성화하고, 라벨은 항상 `워크스페이스 생성`으로 고정하였습니다.

```ts
export const WORKSPACE_NAME_PATTERN = /^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z ]*$/;

export const getWorkspaceNameErrorMessage = (name: string) =>
  WORKSPACE_NAME_PATTERN.test(name) ? undefined : WORKSPACE_NAME_ERROR_MESSAGE;
```

부가적으로, vitest 머지 되면 이후에 테스트 코드 작성하도록 하겠습니다!

### 참고 사항

- 생성 API 연결 없이 일단 Temp 로 이동하다록 하였습니다. api 로직은 추후에 pr 날리겠습니다!
- 아직 머지되지 않은 primitive 컴포넌트는 머지된 이후에 적용하도록 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace creation form with name input, character counter, validation, and submission controls.
  * Workspace names support Korean, English, and spaces, with a 20-character limit.
  * Added clear validation messaging for unsupported characters.
  * Added navigation to the workspace invitation flow after submission.
  * Replaced the workspace creation placeholder with the functional creation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->