### PR TITLE
[FE] 새 워크스페이스 생성/참여 코드 및 링크 공유 페이지 UI 구현

### DIFF
--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/index.tsx
@@ -1,0 +1,195 @@
+import styled from "@emotion/styled";
+import Button from "@primitives/ui/Button";
+import Divider from "@primitives/ui/Divider";
+import Input from "@primitives/ui/Input";
+
+import CheckIcon from "@/assets/icons/check.svg";
+import CopyIcon from "@/assets/icons/copy.svg";
+
+import { useWorkspaceInvite } from "./model/useWorkspaceInvite";
+
+/**
+ * 팀원 초대 카드.
+ *
+ * 워크스페이스를 만든 직후 참여 코드와 초대 링크를 보여주고 각각 클립보드로 복사하게 해요.
+ * 코드 상자는 아이콘이 check로, 링크 버튼은 `복사됨`으로 잠시 바뀌어 결과를 알리고,
+ * 클립보드에 쓰지 못하면 화면 변화 없이 조용히 넘어갑니다.
+ *
+ * 초대 API(#229)가 아직 없어 코드는 임시 상수이고, `다음`은 현재 `:workspaceId`로
+ * 노션 연동(`/workspace/:workspaceId/notion-connection`)으로 이어져요.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1868 새 워크스페이스 생성/참여 코드 및 링크 공유}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=679-3120 새 워크스페이스 생성/참여 코드 복사}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=704-3182 새 워크스페이스 생성/참여 코드 복사 완료}
+ */
+export default function WorkspaceInviteCard() {
+  const {
+    inviteCode,
+    isCodeCopied,
+    isLinkCopied,
+    displayInviteLink,
+    handleCopyLink,
+    handleNext,
+    handleCopyCode,
+  } = useWorkspaceInvite();
+
+  return (
+    <Container>
+      <Content>
+        <Header>
+          <Title>팀원을 초대하세요</Title>
+          <Description>참여 코드나 링크를 팀원에게 공유하세요</Description>
+        </Header>
+
+        <ShareOptions>
+          <CodeBox
+            type="button"
+            aria-label={`참여 코드 ${inviteCode} 복사`}
+            onClick={handleCopyCode}
+          >
+            <Code>{inviteCode}</Code>
+            {isCodeCopied ? <CheckIcon /> : <CopyIcon />}
+          </CodeBox>
+
+          <Divider label="또는" />
+
+          <LinkField>
+            <LinkInput
+              variant="copy"
+              status="filled"
+              value={displayInviteLink}
+              readOnly
+              aria-label="초대 링크"
+            />
+            <CopyButton
+              size="sm"
+              variant={isLinkCopied ? "accent" : "filled"}
+              onClick={handleCopyLink}
+            >
+              {isLinkCopied ? (
+                <>
+                  <CheckIcon />
+                  복사됨
+                </>
+              ) : (
+                "복사"
+              )}
+            </CopyButton>
+          </LinkField>
+        </ShareOptions>
+      </Content>
+
+      <Button size="lg" isFullWidth onClick={handleNext}>
+        다음
+      </Button>
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem; /* 48px */
+  width: 100%;
+  max-width: 28.75rem; /* 460px */
+  padding: 3rem; /* 48px */
+  border-radius: 1.5rem; /* 24px */
+  background-color: ${({ theme }) => theme.neutral[0]};
+  box-shadow: ${({ theme }) => theme.shadow02};
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem; /* 28px */
+  width: 100%;
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem; /* 12px */
+  text-align: center;
+  overflow-wrap: break-word;
+`;
+
+const Title = styled.h1`
+  color: ${({ theme }) => theme.neutral[900]};
+  ${({ theme }) => theme.text.heading02};
+`;
+
+const Description = styled.p`
+  color: ${({ theme }) => theme.neutral[600]};
+  ${({ theme }) => theme.text.body01};
+`;
+
+const ShareOptions = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem; /* 12px */
+  width: 100%;
+`;
+
+/** @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=691-1746 Card/CodeBox} */
+const CodeBox = styled.button`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 5rem; /* 80px */
+  border: 1.5px dashed ${({ theme }) => theme.sub.accent[500]};
+  border-radius: 0.875rem; /* 14px */
+  background-color: ${({ theme }) => theme.sub.accent[100]};
+  color: ${({ theme }) => theme.sub.accent[500]};
+
+  & > svg {
+    position: absolute;
+    top: 50%;
+    right: 1.25rem; /* 20px */
+    width: 1.5rem; /* 24px */
+    height: 1.5rem;
+    transform: translateY(-50%);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.sub.accent[500]};
+    outline-offset: 2px;
+  }
+`;
+
+const Code = styled.span`
+  padding-left: 0.3125em;
+  font-size: 2rem; /* 32px */
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: 0.3125em; /* 10px */
+  white-space: nowrap;
+`;
+
+/** @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=484-4925 Field/Copy} */
+const LinkField = styled.div`
+  position: relative;
+  display: flex;
+  width: 100%;
+`;
+
+const LinkInput = styled(Input)`
+  flex: 1;
+  min-width: 0;
+  padding-right: 7.5rem; /* 120px */
+  text-overflow: ellipsis;
+`;
+
+const CopyButton = styled(Button)`
+  position: absolute;
+  top: 50%;
+  right: 0.75rem; /* 12px */
+  transform: translateY(-50%);
+`;

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/model/useWorkspaceInvite.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/model/useWorkspaceInvite.ts
@@ -1,0 +1,62 @@
+import useClipboard from "@hooks/common/useClipboard";
+import useTimeout from "@hooks/common/useTimeout";
+import useNavigateToWorkspaceNotionConnection from "@hooks/domain/workspace/useNavigateToWorkspaceNotionConnection";
+import { useParams } from "react-router";
+
+import { getInviteLink } from "../utils/getInviteLink";
+
+const TIMEOUT_DURATION = 2000;
+
+export const useWorkspaceInvite = () => {
+  const { workspaceId } = useParams();
+  const { copy } = useClipboard();
+
+  const { navigateToWorkspaceNotionConnection } =
+    useNavigateToWorkspaceNotionConnection();
+  const { start: startCodeTimeout, isTimedOut: isCodeCopied } = useTimeout({
+    timeout: TIMEOUT_DURATION,
+  });
+  const { start: startLinkTimeout, isTimedOut: isLinkCopied } = useTimeout({
+    timeout: TIMEOUT_DURATION,
+  });
+
+  // TODO(#229): 초대 API 연결 후 응답의 참여 코드로 교체
+  const inviteCode = "X35D3S";
+  const { displayInviteLink, inviteLink } = getInviteLink(inviteCode);
+
+  const handleCopyCode = () => {
+    copy({
+      text: inviteCode,
+      onCopySuccess: () => {
+        alert("참여 코드가 클립보드에 복사되었습니다.");
+        startCodeTimeout();
+      },
+    });
+  };
+
+  const handleCopyLink = () => {
+    copy({
+      text: inviteLink,
+      onCopySuccess: () => {
+        alert("초대 링크가 클립보드에 복사되었습니다.");
+        startLinkTimeout();
+      },
+    });
+  };
+
+  const handleNext = () => {
+    if (!workspaceId) return;
+
+    navigateToWorkspaceNotionConnection(workspaceId);
+  };
+
+  return {
+    inviteCode,
+    isCodeCopied,
+    isLinkCopied,
+    displayInviteLink,
+    handleCopyLink,
+    handleNext,
+    handleCopyCode,
+  };
+};

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/utils/getInviteLink.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/utils/getInviteLink.ts
@@ -1,0 +1,12 @@
+import { PATH_ROUTE } from "@routes/PATH_ROUTE";
+
+/**
+ * 참여 코드로 팀원에게 보낼 초대 링크를 만들어요.
+ *
+ * 링크를 열면 초대 코드 입력 화면(`/workspace/code`)에 `?code=`가 채워진 채로 들어갑니다.
+ * 이 형식은 UI 단계의 임시 결정이라, 초대 API를 붙일 때 BE linkToken 사용 여부와 함께 다시 정해요.
+ */
+export const getInviteLink = (code: string) => ({
+  displayInviteLink: `${PATH_ROUTE.WORKSPACE_CODE}?code=${encodeURIComponent(code)}`,
+  inviteLink: `${window.location.origin}${PATH_ROUTE.WORKSPACE_CODE}?code=${encodeURIComponent(code)}`,
+});

--- a/frontend/src/pages/_layout/CenteredLayout.tsx
+++ b/frontend/src/pages/_layout/CenteredLayout.tsx
@@ -7,7 +7,7 @@ import LogoIcon from "@/assets/logos/logo.svg";
 /**
  * knot 로고 + 중앙 카드 레이아웃
  *
- * 워크스페이스 진입 전 플로우(온보딩, 워크스페이스 생성/참여, 초대 에러)가 공유한다.
+ * 워크스페이스 진입 전 플로우(온보딩, 워크스페이스 생성/참여, 팀원 초대, 초대 에러)가 공유한다.
  * 연한 배경 위에 로고를 띄우고 그 아래 화면 콘텐츠(카드)를 가운데 놓는다.
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10188 워크스페이스 생성 및 참여

--- a/frontend/src/pages/_layout/WorkspaceLayout.tsx
+++ b/frontend/src/pages/_layout/WorkspaceLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router";
 /**
  * GNB 레이아웃
  *
- * 워크스페이스 입장 후의 내부 페이지(홈, 초대, 노션 연동, 탐색)가 공유한다.
+ * 워크스페이스 입장 후의 내부 페이지(홈, 노션 연동, 탐색)가 공유한다.
  */
 export default function WorkspaceLayout() {
   return <Outlet />;

--- a/frontend/src/pages/workspace/[workspaceId]/invite/index.tsx
+++ b/frontend/src/pages/workspace/[workspaceId]/invite/index.tsx
@@ -1,15 +1,18 @@
+import WorkspaceInviteCard from "@widgets/workspace/WorkspaceInviteCard";
+
 /**
  * 팀원 초대 - 참여 코드 및 링크 공유 화면 (`/workspace/:workspaceId/invite`)
  *
  * 워크스페이스를 만든 직후 팀원을 부르는 화면이다.
+ * 참여 코드와 초대 링크를 복사해 공유하고,
  * 다음 단계인 노션 연동(`/workspace/:workspaceId/notion-connection`)으로 이어진다.
  *
- * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10192
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
+ *
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1868 새 워크스페이스 생성/참여 코드 및 링크 공유
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=679-3120 새 워크스페이스 생성/참여 코드 복사
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=704-3182 새 워크스페이스 생성/참여 코드 복사 완료
  */
 export default function WorkspaceInvitePage() {
-  return (
-    <div>
-      <h1>Workspace Invite Page</h1>
-    </div>
-  );
+  return <WorkspaceInviteCard />;
 }

--- a/frontend/src/shared/components/primitives/ui/Button/index.tsx
+++ b/frontend/src/shared/components/primitives/ui/Button/index.tsx
@@ -26,8 +26,9 @@ type ButtonSizeToken =
  *
  * - `filled` : 배경이 채워진 기본 버튼
  * - `outline` : 흰 배경에 테두리만 있는 버튼
+ * - `accent` : 옅은 강조색 배경에 강조색 글자. `복사됨`처럼 방금 끝난 일을 알릴 때 써요
  */
-export type ButtonVariant = "filled" | "outline";
+export type ButtonVariant = "filled" | "outline" | "accent";
 
 /**
  * 버튼이 그려야 할 상태. prop이 아니라 `isLoading`·`disabled`로 계산해요.
@@ -112,6 +113,20 @@ const buttonAppearance = (theme: Theme) => {
         box-shadow: inset 0 0 0 1px ${theme.neutral[200]};
       `,
     },
+    accent: {
+      active: css`
+        background-color: ${theme.sub.accent[100]};
+        color: ${theme.sub.accent[500]};
+      `,
+      loading: css`
+        background-color: ${theme.sub.accent[100]};
+        color: ${theme.sub.accent[500]};
+      `,
+      inactive: css`
+        background-color: ${theme.neutral[200]};
+        color: ${theme.neutral[400]};
+      `,
+    },
   } satisfies Record<ButtonVariant, Record<ButtonStatus, SerializedStyles>>;
 };
 
@@ -127,6 +142,7 @@ const buttonAppearance = (theme: Theme) => {
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=422-440 Button/CTA/L}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=511-284 Button/CTA/M}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=484-4907 Button/CTA/S}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=484-4926 Field/Copy status=copied (`accent`)}
  */
 export default function Button({
   size = "md",

--- a/frontend/src/shared/hooks/common/useClipboard/index.ts
+++ b/frontend/src/shared/hooks/common/useClipboard/index.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+
+interface CopyParams {
+  text: string;
+  onCopySuccess?: () => void;
+}
+
+const useClipboard = () => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copy = async ({ text, onCopySuccess }: CopyParams) => {
+    if (!navigator.clipboard) {
+      console.error("Clipboard API가 지원되지 않는 환경입니다.");
+      return;
+    }
+
+    try {
+      setIsCopied(true);
+      await navigator.clipboard.writeText(text);
+      onCopySuccess?.();
+    } catch (error) {
+      console.error("텍스트 복사에 실패했습니다:", error);
+    } finally {
+      setIsCopied(false);
+    }
+  };
+
+  return { copy, isCopied };
+};
+
+export default useClipboard;

--- a/frontend/src/shared/hooks/common/useTimeout/index.ts
+++ b/frontend/src/shared/hooks/common/useTimeout/index.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseTimeoutParams {
+  /** `start`를 호출한 뒤 `isTimedOut`이 다시 `false`로 돌아가기까지의 시간(ms). */
+  timeout?: number;
+  /** 시간이 지나면 실행될 콜백 함수 */
+  callback?: () => void;
+}
+
+/**
+ * 일정 시간이 지나면 상태를 리셋하는 훅.
+ *
+ * `start`를 호출하면 `isTimedOut`이 `true`가 되고, `timeout`이 지나면 저절로 `false`로 돌아가며 `callback`을 실행해요.
+ * 타이머가 도는 중에 재렌더링되어도 타이머는 유지되고, 콜백은 항상 가장 최근에 전달된 함수가 실행돼요.
+ * 타이머가 도는 중에 `start`를 다시 호출하면 기존 타이머를 취소하고 처음부터 다시 재요.
+ * 언마운트되면 타이머를 정리해서 콜백이 실행되지 않아요.
+ *
+ * 대상마다 따로 피드백을 주려면 대상 수만큼 훅을 호출하면 돼요.
+ */
+const useTimeout = ({ timeout = 2000, callback }: UseTimeoutParams = {}) => {
+  const [isTimedOut, setIsTimedOut] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const clear = useCallback(() => {
+    if (timerRef.current === null) return;
+
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const start = useCallback(() => {
+    clear();
+    setIsTimedOut(true);
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setIsTimedOut(false);
+      callbackRef.current?.();
+    }, timeout);
+  }, [clear, timeout]);
+
+  useEffect(() => clear, [clear]);
+
+  return { isTimedOut, start };
+};
+
+export default useTimeout;

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceNotionConnection/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceNotionConnection/index.ts
@@ -1,0 +1,22 @@
+import { getRouterPath } from "@routes/PATH_ROUTE";
+import { useNavigate } from "react-router";
+
+/**
+ * 노션 연동 화면(`/workspace/:workspaceId/notion-connection`)으로 이동하는 도메인 훅.
+ */
+const useNavigateToWorkspaceNotionConnection = () => {
+  const navigate = useNavigate();
+
+  const navigateToWorkspaceNotionConnection = (workspaceId: string) => {
+    navigate(
+      getRouterPath({
+        routeKey: "WORKSPACE_NOTION_CONNECTION",
+        params: { workspaceId },
+      }),
+    );
+  };
+
+  return { navigateToWorkspaceNotionConnection };
+};
+
+export default useNavigateToWorkspaceNotionConnection;

--- a/frontend/src/shared/routes/routes.tsx
+++ b/frontend/src/shared/routes/routes.tsx
@@ -48,6 +48,10 @@ export const router = createBrowserRouter([
         element: <WorkspaceCreatePage />,
       },
       {
+        path: PATH_ROUTE.WORKSPACE_INVITE,
+        element: <WorkspaceInvitePage />,
+      },
+      {
         path: PATH_ROUTE.WORKSPACE_CODE,
         element: <WorkspaceCodePage />,
       },
@@ -69,10 +73,6 @@ export const router = createBrowserRouter([
       {
         path: PATH_ROUTE.WORKSPACE_HOME,
         element: <WorkspaceHomePage />,
-      },
-      {
-        path: PATH_ROUTE.WORKSPACE_INVITE,
-        element: <WorkspaceInvitePage />,
       },
       {
         path: PATH_ROUTE.WORKSPACE_NOTION_CONNECTION,


### PR DESCRIPTION
## 관련 이슈

- #215
- 상위 이슈: #192

## 작업 내용

워크스페이스 기능 중, 새 워크스페이스를 만든 직후 참여 코드와 초대 링크를 팀원에게 공유하는 페이지(`/workspace/:workspaceId/invite`)UI를 구현하였습니다. 

<img width="1728" height="962" alt="image" src="https://github.com/user-attachments/assets/de66ea83-9d34-4d65-bf00-8f8d4bbe46c4" />

<img width="2000" height="1113" alt="image" src="https://github.com/user-attachments/assets/99fddeb3-37b9-414c-a1a2-be214b7240d7" />



API 연동은 후속 Issue에서 진행하겠습니다.

### useTimeout, useClipboard 공통 훅 추가

복사 피드백에 필요한 두 가지 공통 훅을 `shared/hooks/common`에 추가하였습니다.

`useClipboard`는 `navigator.clipboard.writeText`를 통해서 문자열을 클립보드에 복사합니다.

`useTimeout`은 `start`를 호출하면 `isTimedOut`이 `true`가 되고 `timeout`(기본 2000ms)이 지나면 저절로 `false`로 돌아가는 훅입니다. 타이머가 도는 중에 `start`를 다시 부르면 기존 타이머를 취소하고 처음부터 다시 재며, 언마운트 시 타이머를 정리하고, 콜백은 항상 최신 함수를 실행하도록 `ref`로 보관하였습니다.

```ts
const { start, isTimedOut } = useTimeout({ timeout: 2000 });

const handleCopy = () => {
  copy({ text, onCopySuccess: start });
};

// isTimedOut === true 인 2초 동안만 "복사됨" 표시
```

### 노션 연동 화면 이동 도메인 훅 추가

`다음` 버튼이 향하는 노션 연동 화면(`/workspace/:workspaceId/notion-connection`)으로의 이동을 `shared/hooks/domain/workspace/useNavigateToWorkspaceNotionConnection`으로 분리하였습니다.
경로 문자열을 위젯에서 직접 조립하지 않고 `getRouterPath`로 라우트 키와 파라미터만 넘기도록 하여, 이후 같은 화면으로 이동하는 다른 위젯에서도 재사용할 수 있습니다.

### Button에 accent variant 추가

링크 복사 완료 상태는 옅은 강조색 배경에 강조색 글자를 쓰는데, 기존 `filled`·`outline`으로는 표현할 수 없어 `accent` variant를 추가하였습니다.

**Before**

```ts
export type ButtonVariant = "filled" | "outline";
```

**After**

```ts
export type ButtonVariant = "filled" | "outline" | "accent";
```

`active`·`loading`·`inactive` 세 상태 모두 스타일을 정의하여 기존 `satisfies Record<ButtonVariant, Record<ButtonStatus, ...>>` 제약을 그대로 만족하도록 하였습니다.

### WorkspaceInviteCard 위젯 구현

카드는 `modules/widgets/workspace/WorkspaceInviteCard`에 두고, 내부를 `index.tsx`(ui) / `model/useWorkspaceInvite.ts` / `utils/getInviteLink.ts` 세그먼트로 나누었습니다.

- **코드 상자(CodeBox)**: 코드 텍스트와 copy 아이콘을 담은 버튼입니다. 누르면 참여 코드를 클립보드에 쓰고, 성공 시 아이콘이 잠시 check로 바뀝니다.
- **링크 필드(Field/Copy)**: `Input variant="copy"`에 초대 링크를 읽기 전용으로 보여주고, `복사` 버튼을 누르면 링크 전체를 클립보드에 씁니다. 성공 시 버튼이 `accent` variant의 `복사됨`으로 바뀌었다가 원복됩니다.
- **다음**: 현재 `:workspaceId`로 노션 연동 화면으로 이동합니다.

초대 링크의 경우 현재는 `getInviteLink`에서 `${window.location.origin}/workspace/code?code=<코드>` 형식으로 만들고, 화면에는 origin을 뺀 경로만 보여주도록 `displayInviteLink`와 `inviteLink`를 따로 반환합니다.
이 형식은 UI 단계의 임시 결정이며, API 연동 시 BE linkToken 사용 여부와 함께 다시 확정하겠습니다.

프리미티브는 기존 `Button`, `Divider`, `Input`을 그대로 재사용하였고, 카드 내부에 버튼·필드 스타일을 하드코딩하지 않았습니다.

여기에서 너무나도 세세하게 추상화를 진행하는 것 보다는 우선 이정도 수준으로 가져가려고 합니다..!! 
필요시 shared 공통 컴포넌트나 feature컴포넌트로 추상화 하도록 하겠습니다!
지금의 추상화 레벨에 대해서 문제가 있다면 편하게 말씀해주세요!

### 팀원 초대 페이지를 CenteredLayout으로 연결

디자인상 이 화면은 로고 + 중앙 카드 구성이므로 `WORKSPACE_INVITE` 라우트를 GNB용 `WorkspaceLayout` 그룹에서 `CenteredLayout` 그룹으로 옮겼습니다.
페이지 컴포넌트는 placeholder를 제거하고 `WorkspaceInviteCard`를 놓기만 하며, 로고와 중앙 배치는 레이아웃이 담당합니다. 두 레이아웃의 JSDoc에 적힌 담당 화면 목록도 함께 갱신하였습니다.

### 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace invitation card displaying a participation code and invite link.
  * Added copy-to-clipboard actions with confirmation feedback.
  * Added a next step that continues to workspace Notion connection.
  * Updated invitation page layout and routing.
  * Added an accent button style for copy-status actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->