### PR TITLE
[BE] 내 워크스페이스 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/knot/backend/global/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/knot/backend/global/config/OpenApiConfig.java
@@ -53,6 +53,9 @@ public class OpenApiConfig {
             if (isWorkspaceDetailOperation(handlerMethod)) {
                 customizeWorkspaceDetailOperation(operation);
             }
+            if (isWorkspaceListOperation(handlerMethod)) {
+                customizeWorkspaceListOperation(operation);
+            }
             return operation;
         };
     }
@@ -71,6 +74,12 @@ public class OpenApiConfig {
     private void customizeWorkspaceDetailOperation(Operation operation) {
         operation.summary("워크스페이스 단건 조회")
                 .responses(workspaceDetailResponses());
+        operation.security(List.of(new SecurityRequirement().addList(ACCESS_TOKEN_COOKIE)));
+    }
+
+    private void customizeWorkspaceListOperation(Operation operation) {
+        operation.summary("내 워크스페이스 목록 조회")
+                .responses(workspaceListResponses());
         operation.security(List.of(new SecurityRequirement().addList(ACCESS_TOKEN_COOKIE)));
     }
 
@@ -143,6 +152,23 @@ public class OpenApiConfig {
                 );
     }
 
+    private ApiResponses workspaceListResponses() {
+        return new ApiResponses().addApiResponse(
+                "200",
+                jsonResponse(
+                        "워크스페이스 목록 조회 성공",
+                        "WorkspaceListResponse"
+                )
+        )
+                .addApiResponse(
+                        "401",
+                        jsonResponse(
+                                "인증되지 않은 요청",
+                                "ErrorResponse"
+                        )
+                );
+    }
+
     private ApiResponse jsonResponse(
             String description,
             String schemaName
@@ -170,6 +196,15 @@ public class OpenApiConfig {
                 handlerMethod.getBeanType()
                         .getName()
         ) && "detail".equals(handlerMethod.getMethod()
+                .getName()
+        );
+    }
+
+    private boolean isWorkspaceListOperation(HandlerMethod handlerMethod) {
+        return WORKSPACE_QUERY_CONTROLLER.equals(
+                handlerMethod.getBeanType()
+                        .getName()
+        ) && "list".equals(handlerMethod.getMethod()
                 .getName()
         );
     }

--- a/backend/src/main/java/com/knot/backend/workspace/application/WorkspaceQueryService.java
+++ b/backend/src/main/java/com/knot/backend/workspace/application/WorkspaceQueryService.java
@@ -1,11 +1,13 @@
 package com.knot.backend.workspace.application;
 
 import com.knot.backend.workspace.application.dto.result.WorkspaceDetailResult;
+import com.knot.backend.workspace.application.dto.result.WorkspaceListResult;
 import com.knot.backend.workspace.domain.Workspace;
 import com.knot.backend.workspace.domain.WorkspaceErrorCode;
 import com.knot.backend.workspace.domain.WorkspaceException;
 import com.knot.backend.workspace.domain.WorkspaceMemberRepository;
 import com.knot.backend.workspace.domain.WorkspaceRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,11 @@ public class WorkspaceQueryService {
                 memberId
         );
         return WorkspaceDetailResult.from(workspace);
+    }
+
+    public WorkspaceListResult findAllByMemberId(long memberId) {
+        List<Workspace> workspaces = workspaceRepository.findAllByMemberId(memberId);
+        return WorkspaceListResult.from(workspaces);
     }
 
     private void validateWorkspaceId(Long workspaceId) {

--- a/backend/src/main/java/com/knot/backend/workspace/application/dto/result/WorkspaceListItemResult.java
+++ b/backend/src/main/java/com/knot/backend/workspace/application/dto/result/WorkspaceListItemResult.java
@@ -1,0 +1,16 @@
+package com.knot.backend.workspace.application.dto.result;
+
+import com.knot.backend.workspace.domain.Workspace;
+
+public record WorkspaceListItemResult(
+        long id,
+        String name
+) {
+
+    public static WorkspaceListItemResult from(Workspace workspace) {
+        return new WorkspaceListItemResult(
+                workspace.getId(),
+                workspace.getName()
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/workspace/application/dto/result/WorkspaceListResult.java
+++ b/backend/src/main/java/com/knot/backend/workspace/application/dto/result/WorkspaceListResult.java
@@ -1,0 +1,15 @@
+package com.knot.backend.workspace.application.dto.result;
+
+import com.knot.backend.workspace.domain.Workspace;
+import java.util.List;
+
+public record WorkspaceListResult(List<WorkspaceListItemResult> workspaces) {
+
+    public static WorkspaceListResult from(List<Workspace> workspaces) {
+        return new WorkspaceListResult(
+                workspaces.stream()
+                        .map(WorkspaceListItemResult::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/workspace/domain/WorkspaceRepository.java
+++ b/backend/src/main/java/com/knot/backend/workspace/domain/WorkspaceRepository.java
@@ -1,5 +1,6 @@
 package com.knot.backend.workspace.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WorkspaceRepository {
@@ -9,4 +10,6 @@ public interface WorkspaceRepository {
     Optional<Workspace> findById(Long workspaceId);
 
     Optional<Workspace> findByIdForUpdate(Long workspaceId);
+
+    List<Workspace> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/knot/backend/workspace/infrastructure/WorkspaceJpaRepository.java
+++ b/backend/src/main/java/com/knot/backend/workspace/infrastructure/WorkspaceJpaRepository.java
@@ -2,12 +2,23 @@ package com.knot.backend.workspace.infrastructure;
 
 import com.knot.backend.workspace.domain.Workspace;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 interface WorkspaceJpaRepository extends JpaRepository<Workspace, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Workspace> findWithLockById(Long workspaceId);
+
+    @Query(value = """
+            SELECT w.*
+            FROM workspace_members wm
+            JOIN workspaces w ON w.id = wm.workspace_id
+            WHERE wm.member_id = :memberId
+            ORDER BY wm.joined_at DESC, w.id DESC
+            """, nativeQuery = true)
+    List<Workspace> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/knot/backend/workspace/infrastructure/WorkspaceRepositoryAdapter.java
+++ b/backend/src/main/java/com/knot/backend/workspace/infrastructure/WorkspaceRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.knot.backend.workspace.infrastructure;
 
 import com.knot.backend.workspace.domain.Workspace;
 import com.knot.backend.workspace.domain.WorkspaceRepository;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
@@ -26,5 +27,10 @@ public class WorkspaceRepositoryAdapter implements WorkspaceRepository {
     @Override
     public Optional<Workspace> findByIdForUpdate(Long workspaceId) {
         return workspaceJpaRepository.findWithLockById(workspaceId);
+    }
+
+    @Override
+    public List<Workspace> findAllByMemberId(Long memberId) {
+        return workspaceJpaRepository.findAllByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceQueryController.java
+++ b/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceQueryController.java
@@ -3,7 +3,9 @@ package com.knot.backend.workspace.presentation;
 import com.knot.backend.auth.domain.AuthenticatedMember;
 import com.knot.backend.workspace.application.WorkspaceQueryService;
 import com.knot.backend.workspace.application.dto.result.WorkspaceDetailResult;
+import com.knot.backend.workspace.application.dto.result.WorkspaceListResult;
 import com.knot.backend.workspace.presentation.dto.response.WorkspaceDetailResponse;
+import com.knot.backend.workspace.presentation.dto.response.WorkspaceListResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,5 +31,11 @@ public class WorkspaceQueryController {
                 authenticatedMember.getMemberId()
         );
         return WorkspaceDetailResponse.from(result);
+    }
+
+    @GetMapping
+    public WorkspaceListResponse list(@AuthenticationPrincipal AuthenticatedMember authenticatedMember) {
+        WorkspaceListResult result = workspaceQueryService.findAllByMemberId(authenticatedMember.getMemberId());
+        return WorkspaceListResponse.from(result);
     }
 }

--- a/backend/src/main/java/com/knot/backend/workspace/presentation/dto/response/WorkspaceListItemResponse.java
+++ b/backend/src/main/java/com/knot/backend/workspace/presentation/dto/response/WorkspaceListItemResponse.java
@@ -1,0 +1,18 @@
+package com.knot.backend.workspace.presentation.dto.response;
+
+import com.knot.backend.workspace.application.dto.result.WorkspaceListItemResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "워크스페이스 목록 항목")
+public record WorkspaceListItemResponse(
+        @Schema(description = "워크스페이스 ID", example = "1") long id,
+        @Schema(description = "워크스페이스 이름", example = "Knot 팀") String name
+) {
+
+    public static WorkspaceListItemResponse from(WorkspaceListItemResult result) {
+        return new WorkspaceListItemResponse(
+                result.id(),
+                result.name()
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/workspace/presentation/dto/response/WorkspaceListResponse.java
+++ b/backend/src/main/java/com/knot/backend/workspace/presentation/dto/response/WorkspaceListResponse.java
@@ -1,0 +1,20 @@
+package com.knot.backend.workspace.presentation.dto.response;
+
+import com.knot.backend.workspace.application.dto.result.WorkspaceListResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "내 워크스페이스 목록 응답")
+public record WorkspaceListResponse(
+        @Schema(description = "내가 속한 워크스페이스 목록") List<WorkspaceListItemResponse> workspaces
+) {
+
+    public static WorkspaceListResponse from(WorkspaceListResult result) {
+        return new WorkspaceListResponse(
+                result.workspaces()
+                        .stream()
+                        .map(WorkspaceListItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
@@ -173,6 +173,43 @@ class ApiDocumentationAcceptanceTest {
     }
 
     @Test
+    @DisplayName("OpenAPI JSON에 내 워크스페이스 목록 조회 계약을 공개한다")
+    void openApi_success_workspaceListContract() throws Exception {
+        // given
+        String openApiPath = "/v3/api-docs";
+        String listPath = "$.paths['/workspaces'].get";
+        String listResponseRef = "#/components/schemas/WorkspaceListResponse";
+        String listItemResponseRef = "#/components/schemas/WorkspaceListItemResponse";
+        String errorResponseRef = "#/components/schemas/ErrorResponse";
+        String workspacesSchemaPath = "$.components.schemas.WorkspaceListResponse.properties.workspaces";
+        String itemSchemaPath = "$.components.schemas.WorkspaceListItemResponse.properties";
+
+        // when
+        ResultActions result = mockMvc.perform(get(openApiPath));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath(listPath).exists())
+                .andExpect(jsonPath(listPath + ".summary").value("내 워크스페이스 목록 조회"))
+                .andExpect(
+                        jsonPath(listPath + ".responses['200'].content['application/json'].schema['$ref']")
+                                .value(listResponseRef)
+                )
+                .andExpect(
+                        jsonPath(listPath + ".responses['401'].content['application/json'].schema['$ref']")
+                                .value(errorResponseRef)
+                )
+                .andExpect(jsonPath(listPath + ".security[*].accessTokenCookie").exists())
+                .andExpect(jsonPath(workspacesSchemaPath + ".type").value("array"))
+                .andExpect(jsonPath(workspacesSchemaPath + ".items['$ref']").value(listItemResponseRef))
+                .andExpect(jsonPath(itemSchemaPath + ".id").exists())
+                .andExpect(jsonPath(itemSchemaPath + ".name").exists())
+                .andExpect(jsonPath(itemSchemaPath + ".role").doesNotExist())
+                .andExpect(jsonPath(itemSchemaPath + ".joinedAt").doesNotExist())
+                .andExpect(jsonPath(itemSchemaPath + ".createdAt").doesNotExist());
+    }
+
+    @Test
     @DisplayName("OpenAPI JSON에 워크스페이스 초대 발급·조회·재발급 계약을 공개한다")
     void openApi_success_workspaceInvitationContract() throws Exception {
         // given

--- a/backend/src/test/java/com/knot/backend/workspace/application/WorkspaceQueryServiceTest.java
+++ b/backend/src/test/java/com/knot/backend/workspace/application/WorkspaceQueryServiceTest.java
@@ -2,17 +2,21 @@ package com.knot.backend.workspace.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.knot.backend.workspace.application.dto.result.WorkspaceDetailResult;
+import com.knot.backend.workspace.application.dto.result.WorkspaceListResult;
 import com.knot.backend.workspace.domain.Workspace;
 import com.knot.backend.workspace.domain.WorkspaceErrorCode;
 import com.knot.backend.workspace.domain.WorkspaceException;
 import com.knot.backend.workspace.domain.WorkspaceMemberRepository;
 import com.knot.backend.workspace.domain.WorkspaceRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
@@ -140,5 +144,83 @@ class WorkspaceQueryServiceTest {
         assertThatThrownBy(action).isInstanceOf(WorkspaceException.class)
                 .extracting(exception -> ((WorkspaceException) exception).getErrorCode())
                 .isEqualTo(WorkspaceErrorCode.WORKSPACE_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("인증된 멤버가 속한 워크스페이스를 최근 참여 순서로 조회한다")
+    void findAllByMemberId_success() {
+        // given
+        WorkspaceRepository workspaceRepository = mock(WorkspaceRepository.class);
+        WorkspaceMemberRepository workspaceMemberRepository = mock(WorkspaceMemberRepository.class);
+        WorkspaceQueryService service = new WorkspaceQueryService(
+                workspaceRepository,
+                workspaceMemberRepository
+        );
+        Workspace recentWorkspace = workspace(
+                2L,
+                "최근 팀"
+        );
+        Workspace previousWorkspace = workspace(
+                1L,
+                "이전 팀"
+        );
+        when(workspaceRepository.findAllByMemberId(10L)).thenReturn(
+                List.of(
+                        recentWorkspace,
+                        previousWorkspace
+                )
+        );
+
+        // when
+        WorkspaceListResult result = service.findAllByMemberId(10L);
+
+        // then
+        assertThat(result.workspaces()).extracting(
+                workspace -> workspace.id(),
+                workspace -> workspace.name()
+        )
+                .containsExactly(
+                        tuple(
+                                2L,
+                                "최근 팀"
+                        ),
+                        tuple(
+                                1L,
+                                "이전 팀"
+                        )
+                );
+        verify(workspaceRepository).findAllByMemberId(10L);
+        verifyNoInteractions(workspaceMemberRepository);
+    }
+
+    @Test
+    @DisplayName("소속 워크스페이스가 없으면 빈 목록을 반환한다")
+    void findAllByMemberId_success_emptyMemberships() {
+        // given
+        WorkspaceRepository workspaceRepository = mock(WorkspaceRepository.class);
+        WorkspaceMemberRepository workspaceMemberRepository = mock(WorkspaceMemberRepository.class);
+        WorkspaceQueryService service = new WorkspaceQueryService(
+                workspaceRepository,
+                workspaceMemberRepository
+        );
+        when(workspaceRepository.findAllByMemberId(10L)).thenReturn(List.of());
+
+        // when
+        WorkspaceListResult result = service.findAllByMemberId(10L);
+
+        // then
+        assertThat(result.workspaces()).isEmpty();
+        verify(workspaceRepository).findAllByMemberId(10L);
+        verifyNoInteractions(workspaceMemberRepository);
+    }
+
+    private Workspace workspace(
+            long workspaceId,
+            String name
+    ) {
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.getId()).thenReturn(workspaceId);
+        when(workspace.getName()).thenReturn(name);
+        return workspace;
     }
 }

--- a/backend/src/test/java/com/knot/backend/workspace/infrastructure/WorkspaceRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/knot/backend/workspace/infrastructure/WorkspaceRepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.knot.backend.workspace.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.knot.backend.testsupport.TestcontainersConfiguration;
 import com.knot.backend.workspace.domain.Workspace;
@@ -35,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 class WorkspaceRepositoryIntegrationTest {
     private static final Instant CREATED_AT = Instant.parse("2026-08-24T00:00:00Z");
     private static final Instant JOINED_AT = Instant.parse("2026-08-24T00:01:00Z");
+    private static final Instant RECENT_JOINED_AT = Instant.parse("2026-08-24T00:02:00Z");
 
     @Autowired
     private WorkspaceRepository workspaceRepository;
@@ -91,6 +93,106 @@ class WorkspaceRepositoryIntegrationTest {
                         memberId
                 )
         ).isTrue();
+    }
+
+    @DisplayName("멤버의 OWNER·MEMBER 워크스페이스만 최근 참여 순서로 조회한다")
+    @Test
+    void findAllByMemberId_success_filtersAndSortsMemberships() {
+        // given
+        long memberId = saveMember(5L);
+        long otherMemberId = saveMember(6L);
+        Workspace olderWorkspace = saveAndFlush(
+                Workspace.create(
+                        "이전 팀",
+                        CREATED_AT
+                )
+        );
+        Workspace tiedLowerWorkspace = saveAndFlush(
+                Workspace.create(
+                        "최근 한 팀",
+                        CREATED_AT
+                )
+        );
+        Workspace tiedHigherWorkspace = saveAndFlush(
+                Workspace.create(
+                        "최근 두 팀",
+                        CREATED_AT
+                )
+        );
+        Workspace otherWorkspace = saveAndFlush(
+                Workspace.create(
+                        "다른 팀",
+                        CREATED_AT
+                )
+        );
+        saveAndFlush(
+                WorkspaceMember.create(
+                        olderWorkspace.getId(),
+                        memberId,
+                        WorkspaceMemberRole.OWNER,
+                        JOINED_AT
+                )
+        );
+        saveAndFlush(
+                WorkspaceMember.create(
+                        tiedLowerWorkspace.getId(),
+                        memberId,
+                        WorkspaceMemberRole.MEMBER,
+                        RECENT_JOINED_AT
+                )
+        );
+        saveAndFlush(
+                WorkspaceMember.create(
+                        tiedHigherWorkspace.getId(),
+                        memberId,
+                        WorkspaceMemberRole.OWNER,
+                        RECENT_JOINED_AT
+                )
+        );
+        saveAndFlush(
+                WorkspaceMember.create(
+                        otherWorkspace.getId(),
+                        otherMemberId,
+                        WorkspaceMemberRole.MEMBER,
+                        RECENT_JOINED_AT
+                )
+        );
+
+        // when
+        List<Workspace> workspaces = workspaceRepository.findAllByMemberId(memberId);
+
+        // then
+        assertThat(workspaces).extracting(
+                Workspace::getId,
+                Workspace::getName
+        )
+                .containsExactly(
+                        tuple(
+                                tiedHigherWorkspace.getId(),
+                                "최근 두 팀"
+                        ),
+                        tuple(
+                                tiedLowerWorkspace.getId(),
+                                "최근 한 팀"
+                        ),
+                        tuple(
+                                olderWorkspace.getId(),
+                                "이전 팀"
+                        )
+                );
+    }
+
+    @DisplayName("소속 워크스페이스가 없으면 빈 목록을 조회한다")
+    @Test
+    void findAllByMemberId_success_emptyMemberships() {
+        // given
+        long memberId = saveMember(7L);
+
+        // when
+        List<Workspace> workspaces = workspaceRepository.findAllByMemberId(memberId);
+
+        // then
+        assertThat(workspaces).isEmpty();
     }
 
     @DisplayName("같은 워크스페이스와 멤버 조합은 중복 저장할 수 없다")

--- a/backend/src/test/java/com/knot/backend/workspace/presentation/WorkspaceQueryAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/workspace/presentation/WorkspaceQueryAcceptanceTest.java
@@ -9,8 +9,10 @@ import com.knot.backend.auth.domain.AuthTokenProvider;
 import com.knot.backend.auth.domain.AuthenticatedMember;
 import com.knot.backend.testsupport.TestApplicationProperties;
 import com.knot.backend.testsupport.TestcontainersConfiguration;
+import com.knot.backend.workspace.domain.WorkspaceMemberRole;
 import jakarta.servlet.http.Cookie;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -34,6 +36,7 @@ class WorkspaceQueryAcceptanceTest {
     private static final String JWT_COOKIE_NAME = "KNOT_ACCESS_TOKEN";
     private static final Instant CREATED_AT = Instant.parse("2026-08-29T00:00:00Z");
     private static final Instant JOINED_AT = Instant.parse("2026-08-29T00:01:00Z");
+    private static final Instant RECENT_JOINED_AT = Instant.parse("2026-08-29T00:02:00Z");
 
     private final MockMvc mockMvc;
     private final AuthTokenProvider authTokenProvider;
@@ -202,7 +205,113 @@ class WorkspaceQueryAcceptanceTest {
                 .andExpect(jsonPath("$.message").value("워크스페이스를 찾을 수 없습니다"));
     }
 
+    @Test
+    @DisplayName("인증된 멤버의 OWNER·MEMBER 워크스페이스만 결정적 순서로 반환하고 데이터를 변경하지 않는다")
+    void list_success_filtersSortsAndDoesNotModifyData() throws Exception {
+        // given
+        long memberId = saveMember();
+        long otherMemberId = saveMember("other-member");
+        long olderWorkspaceId = saveWorkspace("이전 팀");
+        long tiedLowerWorkspaceId = saveWorkspace("최근 한 팀");
+        long tiedHigherWorkspaceId = saveWorkspace("최근 두 팀");
+        long otherWorkspaceId = saveWorkspace("다른 팀");
+        saveWorkspaceMember(
+                olderWorkspaceId,
+                memberId,
+                WorkspaceMemberRole.OWNER,
+                JOINED_AT
+        );
+        saveWorkspaceMember(
+                tiedLowerWorkspaceId,
+                memberId,
+                WorkspaceMemberRole.MEMBER,
+                RECENT_JOINED_AT
+        );
+        saveWorkspaceMember(
+                tiedHigherWorkspaceId,
+                memberId,
+                WorkspaceMemberRole.OWNER,
+                RECENT_JOINED_AT
+        );
+        saveWorkspaceMember(
+                otherWorkspaceId,
+                otherMemberId,
+                WorkspaceMemberRole.MEMBER,
+                RECENT_JOINED_AT
+        );
+        String token = accessToken(memberId);
+        List<String> workspaceSnapshot = workspaceSnapshots();
+        List<String> workspaceMemberSnapshot = workspaceMemberSnapshots();
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/workspaces").cookie(
+                        new Cookie(
+                                JWT_COOKIE_NAME,
+                                token
+                        )
+                )
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaces").isArray())
+                .andExpect(jsonPath("$.workspaces.length()").value(3))
+                .andExpect(jsonPath("$.workspaces[0].id").value(tiedHigherWorkspaceId))
+                .andExpect(jsonPath("$.workspaces[0].name").value("최근 두 팀"))
+                .andExpect(jsonPath("$.workspaces[0].role").doesNotExist())
+                .andExpect(jsonPath("$.workspaces[0].joinedAt").doesNotExist())
+                .andExpect(jsonPath("$.workspaces[0].createdAt").doesNotExist())
+                .andExpect(jsonPath("$.workspaces[1].id").value(tiedLowerWorkspaceId))
+                .andExpect(jsonPath("$.workspaces[1].name").value("최근 한 팀"))
+                .andExpect(jsonPath("$.workspaces[2].id").value(olderWorkspaceId))
+                .andExpect(jsonPath("$.workspaces[2].name").value("이전 팀"));
+        assertThat(workspaceSnapshots()).isEqualTo(workspaceSnapshot);
+        assertThat(workspaceMemberSnapshots()).isEqualTo(workspaceMemberSnapshot);
+    }
+
+    @Test
+    @DisplayName("소속 워크스페이스가 없는 인증된 멤버는 빈 목록을 반환받는다")
+    void list_success_emptyMemberships() throws Exception {
+        // given
+        long memberId = saveMember();
+        String token = accessToken(memberId);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/workspaces").cookie(
+                        new Cookie(
+                                JWT_COOKIE_NAME,
+                                token
+                        )
+                )
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaces").isArray())
+                .andExpect(jsonPath("$.workspaces").isEmpty());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 워크스페이스 목록 조회 요청은 401을 반환한다")
+    void list_failure_unauthenticated() throws Exception {
+        // given
+
+        // when
+        ResultActions result = mockMvc.perform(get("/workspaces"));
+
+        // then
+        result.andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHENTICATED"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다"));
+    }
+
     private long saveMember() {
+        return saveMember("hyunsung");
+    }
+
+    private long saveMember(String nickname) {
         return jdbcClient.sql("""
                 INSERT INTO members (nickname, profile_image_url)
                 VALUES (:nickname, NULL)
@@ -210,7 +319,7 @@ class WorkspaceQueryAcceptanceTest {
                 """)
                 .param(
                         "nickname",
-                        "hyunsung"
+                        nickname
                 )
                 .query(Long.class)
                 .single();
@@ -238,9 +347,23 @@ class WorkspaceQueryAcceptanceTest {
             long workspaceId,
             long memberId
     ) {
+        saveWorkspaceMember(
+                workspaceId,
+                memberId,
+                WorkspaceMemberRole.MEMBER,
+                JOINED_AT
+        );
+    }
+
+    private void saveWorkspaceMember(
+            long workspaceId,
+            long memberId,
+            WorkspaceMemberRole role,
+            Instant joinedAt
+    ) {
         jdbcClient.sql("""
                 INSERT INTO workspace_members (workspace_id, member_id, role, joined_at)
-                VALUES (:workspaceId, :memberId, 'MEMBER', CAST(:joinedAt AS TIMESTAMPTZ))
+                VALUES (:workspaceId, :memberId, :role, CAST(:joinedAt AS TIMESTAMPTZ))
                 """)
                 .param(
                         "workspaceId",
@@ -251,10 +374,35 @@ class WorkspaceQueryAcceptanceTest {
                         memberId
                 )
                 .param(
+                        "role",
+                        role.name()
+                )
+                .param(
                         "joinedAt",
-                        JOINED_AT.toString()
+                        joinedAt.toString()
                 )
                 .update();
+    }
+
+    private List<String> workspaceSnapshots() {
+        return jdbcClient.sql("""
+                SELECT id::text || '|' || name || '|' || created_at::text
+                FROM workspaces
+                ORDER BY id
+                """)
+                .query(String.class)
+                .list();
+    }
+
+    private List<String> workspaceMemberSnapshots() {
+        return jdbcClient.sql("""
+                SELECT id::text || '|' || workspace_id::text || '|' || member_id::text || '|' || role || '|'
+                    || joined_at::text
+                FROM workspace_members
+                ORDER BY id
+                """)
+                .query(String.class)
+                .list();
     }
 
     private String workspaceSnapshot(long workspaceId) {

--- a/backend/src/test/java/com/knot/backend/workspace/presentation/WorkspaceQueryControllerTest.java
+++ b/backend/src/test/java/com/knot/backend/workspace/presentation/WorkspaceQueryControllerTest.java
@@ -12,6 +12,8 @@ import com.knot.backend.auth.domain.AuthenticatedMember;
 import com.knot.backend.global.exception.GlobalExceptionHandler;
 import com.knot.backend.workspace.application.WorkspaceQueryService;
 import com.knot.backend.workspace.application.dto.result.WorkspaceDetailResult;
+import com.knot.backend.workspace.application.dto.result.WorkspaceListItemResult;
+import com.knot.backend.workspace.application.dto.result.WorkspaceListResult;
 import com.knot.backend.workspace.domain.WorkspaceErrorCode;
 import com.knot.backend.workspace.domain.WorkspaceException;
 import java.util.List;
@@ -142,6 +144,44 @@ class WorkspaceQueryControllerTest {
         // then
         result.andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("WORKSPACE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("인증된 멤버가 목록 조회하면 200과 ID·이름 목록을 반환한다")
+    void list_success() throws Exception {
+        // given
+        SecurityContextHolder.getContext()
+                .setAuthentication(memberAuthentication());
+        when(workspaceQueryService.findAllByMemberId(10L)).thenReturn(
+                new WorkspaceListResult(
+                        List.of(
+                                new WorkspaceListItemResult(
+                                        2L,
+                                        "최근 팀"
+                                ),
+                                new WorkspaceListItemResult(
+                                        1L,
+                                        "이전 팀"
+                                )
+                        )
+                )
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(get("/workspaces"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaces").isArray())
+                .andExpect(jsonPath("$.workspaces.length()").value(2))
+                .andExpect(jsonPath("$.workspaces[0].id").value(2L))
+                .andExpect(jsonPath("$.workspaces[0].name").value("최근 팀"))
+                .andExpect(jsonPath("$.workspaces[0].role").doesNotExist())
+                .andExpect(jsonPath("$.workspaces[0].joinedAt").doesNotExist())
+                .andExpect(jsonPath("$.workspaces[0].createdAt").doesNotExist())
+                .andExpect(jsonPath("$.workspaces[1].id").value(1L))
+                .andExpect(jsonPath("$.workspaces[1].name").value("이전 팀"));
+        verify(workspaceQueryService).findAllByMemberId(10L);
     }
 
     private UsernamePasswordAuthenticationToken memberAuthentication() {


### PR DESCRIPTION
## 관련 이슈

- #242

## 작업 내용

- access token cookie로 인증된 멤버가 `GET /workspaces`에서 자신의 워크스페이스 목록을 조회하도록 구현했습니다.
- `workspace_members.member_id`를 DB 조건으로 사용하고 `joined_at DESC`, `workspace_id DESC` 순서로 단일 join 조회합니다.
- 응답은 `{ "workspaces": [{ "id", "name" }] }`로 제한하고 역할·참여 시각·생성 시각은 노출하지 않습니다.
- 빈 소속 목록은 200과 빈 배열로 반환하며 조회 경로는 read-only transaction을 유지합니다.
- OpenAPI에 목록 조회의 200·401 응답 schema와 access token cookie 요구사항을 추가했습니다.
- Application Service, Controller, PostgreSQL Repository, Acceptance, OpenAPI 테스트로 소속 필터·OWNER/MEMBER 포함·동률 정렬·빈 목록·401·DB 무변경을 검증했습니다.
- `./gradlew spotlessCheck test integrationTest acceptanceTest bootJar`와 `git diff --check`를 통과했습니다.

### 참고 사항

- 팀의 일반 다건 응답은 raw array가 원칙이지만, 이 API는 Issue #242에서 확정한 FE-BE 계약에 따라 `workspaces` wrapper를 사용합니다.
- MVP 범위에 따라 페이지네이션과 새 DB migration은 추가하지 않았습니다. 기존 `workspace_members(member_id)` 인덱스를 사용합니다.
- AI는 구현·테스트 초안과 리뷰에 활용했고, 인증 경계·read-only transaction·DB 필터와 정렬·응답 정보 노출을 직접 검토하고 전체 테스트로 재검증했습니다.
- 변경 범위 컨벤션 감사는 통과했습니다. 전체 저장소 감사의 기존 위반 5건은 이번 diff 밖의 `develop` 파일에 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to retrieve all workspaces a member belongs to.
  * Workspace results include each workspace’s ID and name.
  * Results are ordered by most recent membership, with deterministic tie-breaking.
  * Added OpenAPI documentation for the workspace list endpoint, including authentication and response details.
* **Tests**
  * Added coverage for successful, empty, and unauthorized workspace list requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->