### PR TITLE
[BE] 워크스페이스 OpenAPI 문서 설정 분리

### DIFF
--- a/backend/src/main/java/com/knot/backend/global/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/knot/backend/global/config/OpenApiConfig.java
@@ -27,6 +27,7 @@ import org.springframework.web.method.HandlerMethod;
 public class OpenApiConfig {
     public static final String ACCESS_TOKEN_COOKIE = "accessTokenCookie";
     public static final String CSRF_TOKEN_HEADER = "csrfTokenHeader";
+    public static final String CSRF_TOKEN_HEADER_NAME = "X-XSRF-TOKEN";
     private static final String WORKSPACE_PACKAGE = "com.knot.backend.workspace.presentation.";
     private static final String WORKSPACE_CONTROLLER = WORKSPACE_PACKAGE + "WorkspaceController";
     private static final String WORKSPACE_QUERY_CONTROLLER = WORKSPACE_PACKAGE + "WorkspaceQueryController";
@@ -185,7 +186,7 @@ public class OpenApiConfig {
                         CSRF_TOKEN_HEADER,
                         new SecurityScheme().type(SecurityScheme.Type.APIKEY)
                                 .in(SecurityScheme.In.HEADER)
-                                .name("X-XSRF-TOKEN")
+                                .name(CSRF_TOKEN_HEADER_NAME)
                 )
                 .addSchemas(
                         "ErrorResponse",

--- a/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceController.java
+++ b/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceController.java
@@ -5,7 +5,6 @@ import com.knot.backend.workspace.application.WorkspaceService;
 import com.knot.backend.workspace.application.dto.result.WorkspaceCreateResult;
 import com.knot.backend.workspace.presentation.dto.request.WorkspaceCreateRequest;
 import com.knot.backend.workspace.presentation.dto.response.WorkspaceCreateResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkspaceController {
     private final WorkspaceService workspaceService;
 
-    @Operation(summary = "워크스페이스 생성")
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<WorkspaceCreateResponse> create(
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember,

--- a/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceInvitationController.java
+++ b/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceInvitationController.java
@@ -1,24 +1,11 @@
 package com.knot.backend.workspace.presentation;
 
 import com.knot.backend.auth.domain.AuthenticatedMember;
-import com.knot.backend.global.config.OpenApiConfig;
-import com.knot.backend.global.response.ErrorResponse;
 import com.knot.backend.workspace.application.WorkspaceInvitationService;
 import com.knot.backend.workspace.application.dto.result.WorkspaceInvitationResult;
 import com.knot.backend.workspace.presentation.dto.response.WorkspaceInvitationResponse;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "워크스페이스 초대", description = "워크스페이스 초대 코드와 링크 발급, 조회, 재발급")
-@SecurityRequirement(name = OpenApiConfig.ACCESS_TOKEN_COOKIE)
 @RestController
 @RequestMapping("/workspaces/{workspaceId}")
 public class WorkspaceInvitationController {
@@ -38,80 +24,6 @@ public class WorkspaceInvitationController {
         this.workspaceInvitationService = workspaceInvitationService;
     }
 
-    // @formatter:off
-    @Operation(
-            summary = "워크스페이스 초대 발급",
-            parameters = @Parameter(
-                    name = "X-XSRF-TOKEN",
-                    description = "CSRF 토큰",
-                    in = ParameterIn.HEADER,
-                    required = true,
-                    schema = @Schema(type = "string")
-            )
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "기존 활성 초대 반환",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = WorkspaceInvitationResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "새 초대 생성",
-                    headers = @Header(
-                            name = HttpHeaders.LOCATION,
-                            description = "생성된 초대 조회 URI",
-                            schema = @Schema(type = "string", format = "uri")
-                    ),
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = WorkspaceInvitationResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 Workspace ID",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 필요",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "CSRF 검증 실패 또는 워크스페이스 접근 거부",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "워크스페이스 없음",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "활성 초대 복구 실패",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            )})
-    // @formatter:on
     @PostMapping("/invitations")
     public ResponseEntity<WorkspaceInvitationResponse> issue(
             @PathVariable Long workspaceId,
@@ -127,58 +39,6 @@ public class WorkspaceInvitationController {
         return responseBuilder.body(WorkspaceInvitationResponse.from(result));
     }
 
-    // @formatter:off
-    @Operation(summary = "워크스페이스 초대 조회")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "활성 초대 조회",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = WorkspaceInvitationResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 Workspace ID",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 필요",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "워크스페이스 접근 거부",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "워크스페이스 또는 활성 초대 없음",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "활성 초대 복구 실패",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            )})
-    // @formatter:on
     @GetMapping("/invitation")
     public WorkspaceInvitationResponse get(
             @PathVariable Long workspaceId,
@@ -192,72 +52,6 @@ public class WorkspaceInvitationController {
         );
     }
 
-    // @formatter:off
-    @Operation(
-            summary = "워크스페이스 초대 재발급",
-            parameters = @Parameter(
-                    name = "X-XSRF-TOKEN",
-                    description = "CSRF 토큰",
-                    in = ParameterIn.HEADER,
-                    required = true,
-                    schema = @Schema(type = "string")
-            )
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "새 초대 생성",
-                    headers = @Header(
-                            name = HttpHeaders.LOCATION,
-                            description = "생성된 초대 조회 URI",
-                            schema = @Schema(type = "string", format = "uri")
-                    ),
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = WorkspaceInvitationResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 Workspace ID",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "인증 필요",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "CSRF 검증 실패 또는 워크스페이스 접근 거부",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "워크스페이스 없음",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "초대 생성 실패",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = ErrorResponse.class)
-                    )
-            )})
-    // @formatter:on
     @PostMapping("/invitations/reissue")
     public ResponseEntity<WorkspaceInvitationResponse> reissue(
             @PathVariable Long workspaceId,

--- a/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceInvitationOpenApiConfig.java
+++ b/backend/src/main/java/com/knot/backend/workspace/presentation/WorkspaceInvitationOpenApiConfig.java
@@ -1,0 +1,242 @@
+package com.knot.backend.workspace.presentation;
+
+import com.knot.backend.global.config.OpenApiConfig;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import java.util.List;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.HandlerMethod;
+
+@Configuration(proxyBeanMethods = false)
+public class WorkspaceInvitationOpenApiConfig {
+    private static final String INVITATION_RESPONSE_SCHEMA = "WorkspaceInvitationResponse";
+    private static final String ERROR_RESPONSE_SCHEMA = "ErrorResponse";
+
+    @Bean
+    public OperationCustomizer workspaceInvitationOperationCustomizer() {
+        return (
+                operation,
+                handlerMethod
+        ) -> {
+            if (!isWorkspaceInvitationOperation(handlerMethod)) {
+                return operation;
+            }
+            switch (handlerMethod.getMethod()
+                    .getName()) {
+                case "issue" -> customizeIssueOperation(operation);
+                case "get" -> customizeGetOperation(operation);
+                case "reissue" -> customizeReissueOperation(operation);
+                default -> {
+                }
+            }
+            return operation;
+        };
+    }
+
+    private void customizeIssueOperation(Operation operation) {
+        operation.summary("워크스페이스 초대 발급")
+                .responses(issueResponses())
+                .security(accessTokenSecurity())
+                .addParametersItem(csrfTokenParameter());
+    }
+
+    private void customizeGetOperation(Operation operation) {
+        operation.summary("워크스페이스 초대 조회")
+                .responses(getResponses())
+                .security(accessTokenSecurity());
+    }
+
+    private void customizeReissueOperation(Operation operation) {
+        operation.summary("워크스페이스 초대 재발급")
+                .responses(reissueResponses())
+                .security(accessTokenSecurity())
+                .addParametersItem(csrfTokenParameter());
+    }
+
+    private ApiResponses issueResponses() {
+        return new ApiResponses().addApiResponse(
+                "200",
+                jsonResponse(
+                        "기존 활성 초대 반환",
+                        INVITATION_RESPONSE_SCHEMA
+                )
+        )
+                .addApiResponse(
+                        "201",
+                        createdResponse(INVITATION_RESPONSE_SCHEMA)
+                )
+                .addApiResponse(
+                        "400",
+                        jsonResponse(
+                                "잘못된 Workspace ID",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "401",
+                        jsonResponse(
+                                "인증 필요",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "403",
+                        jsonResponse(
+                                "CSRF 검증 실패 또는 워크스페이스 접근 거부",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "404",
+                        jsonResponse(
+                                "워크스페이스 없음",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "500",
+                        jsonResponse(
+                                "활성 초대 복구 실패",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                );
+    }
+
+    private ApiResponses getResponses() {
+        return new ApiResponses().addApiResponse(
+                "200",
+                jsonResponse(
+                        "활성 초대 조회",
+                        INVITATION_RESPONSE_SCHEMA
+                )
+        )
+                .addApiResponse(
+                        "400",
+                        jsonResponse(
+                                "잘못된 Workspace ID",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "401",
+                        jsonResponse(
+                                "인증 필요",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "403",
+                        jsonResponse(
+                                "워크스페이스 접근 거부",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "404",
+                        jsonResponse(
+                                "워크스페이스 또는 활성 초대 없음",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "500",
+                        jsonResponse(
+                                "활성 초대 복구 실패",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                );
+    }
+
+    private ApiResponses reissueResponses() {
+        return new ApiResponses().addApiResponse(
+                "201",
+                createdResponse(INVITATION_RESPONSE_SCHEMA)
+        )
+                .addApiResponse(
+                        "400",
+                        jsonResponse(
+                                "잘못된 Workspace ID",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "401",
+                        jsonResponse(
+                                "인증 필요",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "403",
+                        jsonResponse(
+                                "CSRF 검증 실패 또는 워크스페이스 접근 거부",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "404",
+                        jsonResponse(
+                                "워크스페이스 없음",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                )
+                .addApiResponse(
+                        "500",
+                        jsonResponse(
+                                "초대 생성 실패",
+                                ERROR_RESPONSE_SCHEMA
+                        )
+                );
+    }
+
+    private ApiResponse createdResponse(String schemaName) {
+        return jsonResponse(
+                "새 초대 생성",
+                schemaName
+        ).addHeaderObject(
+                HttpHeaders.LOCATION,
+                new Header().description("생성된 초대 조회 URI")
+                        .schema(new StringSchema().format("uri"))
+        );
+    }
+
+    private ApiResponse jsonResponse(
+            String description,
+            String schemaName
+    ) {
+        return new ApiResponse().description(description)
+                .content(
+                        new Content().addMediaType(
+                                org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                                new MediaType().schema(new Schema<>().$ref("#/components/schemas/" + schemaName))
+                        )
+                );
+    }
+
+    private Parameter csrfTokenParameter() {
+        return new Parameter().name(OpenApiConfig.CSRF_TOKEN_HEADER_NAME)
+                .description("CSRF 토큰")
+                .in("header")
+                .required(true)
+                .schema(new StringSchema());
+    }
+
+    private List<SecurityRequirement> accessTokenSecurity() {
+        return List.of(new SecurityRequirement().addList(OpenApiConfig.ACCESS_TOKEN_COOKIE));
+    }
+
+    private boolean isWorkspaceInvitationOperation(HandlerMethod handlerMethod) {
+        return WorkspaceInvitationController.class.equals(handlerMethod.getBeanType());
+    }
+}

--- a/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ApiDocumentationAcceptanceTest.java
@@ -114,6 +114,7 @@ class ApiDocumentationAcceptanceTest {
                 .andExpect(jsonPath("$.paths['/auth/nickname'].post").exists())
                 .andExpect(jsonPath(createWorkspacePath).exists())
                 .andExpect(jsonPath(detailWorkspacePath).exists())
+                .andExpect(jsonPath(createWorkspacePath + ".summary").value("워크스페이스 생성"))
                 .andExpect(jsonPath(detailWorkspacePath + ".summary").value("워크스페이스 단건 조회"))
                 .andExpect(
                         jsonPath(createWorkspacePath + ".responses['201'].content['application/json'].schema['$ref']")
@@ -180,6 +181,7 @@ class ApiDocumentationAcceptanceTest {
         String issuePath = "$.paths['/workspaces/{workspaceId}/invitations'].post";
         String getPath = "$.paths['/workspaces/{workspaceId}/invitation'].get";
         String reissuePath = "$.paths['/workspaces/{workspaceId}/invitations/reissue'].post";
+        String invitationResponseRef = "#/components/schemas/WorkspaceInvitationResponse";
         String errorResponseRef = "#/components/schemas/ErrorResponse";
 
         // when
@@ -187,14 +189,25 @@ class ApiDocumentationAcceptanceTest {
 
         // then
         result.andExpect(status().isOk())
+                .andExpect(jsonPath(issuePath + ".summary").value("워크스페이스 초대 발급"))
                 .andExpect(jsonPath(issuePath + ".security[*].accessTokenCookie").exists())
                 .andExpect(jsonPath(issuePath + ".parameters[?(@.name == 'X-XSRF-TOKEN')]").exists())
                 .andExpect(
-                        jsonPath(issuePath + ".responses['200'].content['application/json'].schema['$ref']").exists()
+                        jsonPath(issuePath + ".parameters[?(@.name == 'X-XSRF-TOKEN')].required").value(hasItem(true))
+                )
+                .andExpect(
+                        jsonPath(issuePath + ".parameters[?(@.name == 'X-XSRF-TOKEN')].schema.type")
+                                .value(hasItem("string"))
+                )
+                .andExpect(
+                        jsonPath(issuePath + ".responses['200'].content['application/json'].schema['$ref']")
+                                .value(invitationResponseRef)
                 )
                 .andExpect(jsonPath(issuePath + ".responses['201'].headers.Location").exists())
+                .andExpect(jsonPath(issuePath + ".responses['201'].headers.Location.schema.format").value("uri"))
                 .andExpect(
-                        jsonPath(issuePath + ".responses['201'].content['application/json'].schema['$ref']").exists()
+                        jsonPath(issuePath + ".responses['201'].content['application/json'].schema['$ref']")
+                                .value(invitationResponseRef)
                 )
                 .andExpect(
                         jsonPath(issuePath + ".responses['400'].content['application/json'].schema['$ref']")
@@ -216,8 +229,13 @@ class ApiDocumentationAcceptanceTest {
                         jsonPath(issuePath + ".responses['500'].content['application/json'].schema['$ref']")
                                 .value(errorResponseRef)
                 )
+                .andExpect(jsonPath(getPath + ".summary").value("워크스페이스 초대 조회"))
                 .andExpect(jsonPath(getPath + ".security[*].accessTokenCookie").exists())
-                .andExpect(jsonPath(getPath + ".responses['200'].content['application/json'].schema['$ref']").exists())
+                .andExpect(jsonPath(getPath + ".parameters[?(@.name == 'X-XSRF-TOKEN')]").doesNotExist())
+                .andExpect(
+                        jsonPath(getPath + ".responses['200'].content['application/json'].schema['$ref']")
+                                .value(invitationResponseRef)
+                )
                 .andExpect(
                         jsonPath(getPath + ".responses['400'].content['application/json'].schema['$ref']")
                                 .value(errorResponseRef)
@@ -238,11 +256,21 @@ class ApiDocumentationAcceptanceTest {
                         jsonPath(getPath + ".responses['500'].content['application/json'].schema['$ref']")
                                 .value(errorResponseRef)
                 )
+                .andExpect(jsonPath(reissuePath + ".summary").value("워크스페이스 초대 재발급"))
                 .andExpect(jsonPath(reissuePath + ".security[*].accessTokenCookie").exists())
                 .andExpect(jsonPath(reissuePath + ".parameters[?(@.name == 'X-XSRF-TOKEN')]").exists())
-                .andExpect(jsonPath(reissuePath + ".responses['201'].headers.Location").exists())
                 .andExpect(
-                        jsonPath(reissuePath + ".responses['201'].content['application/json'].schema['$ref']").exists()
+                        jsonPath(reissuePath + ".parameters[?(@.name == 'X-XSRF-TOKEN')].required").value(hasItem(true))
+                )
+                .andExpect(
+                        jsonPath(reissuePath + ".parameters[?(@.name == 'X-XSRF-TOKEN')].schema.type")
+                                .value(hasItem("string"))
+                )
+                .andExpect(jsonPath(reissuePath + ".responses['201'].headers.Location").exists())
+                .andExpect(jsonPath(reissuePath + ".responses['201'].headers.Location.schema.format").value("uri"))
+                .andExpect(
+                        jsonPath(reissuePath + ".responses['201'].content['application/json'].schema['$ref']")
+                                .value(invitationResponseRef)
                 )
                 .andExpect(
                         jsonPath(reissuePath + ".responses['400'].content['application/json'].schema['$ref']")


### PR DESCRIPTION
## 관련 이슈

- Closes #245

## 작업 내용

- 워크스페이스 초대 발급·조회·재발급의 OpenAPI 문서 조립을 `WorkspaceInvitationOpenApiConfig`의 `OperationCustomizer`로 분리했습니다.
- `WorkspaceInvitationController`에서는 method-level Swagger 애너테이션과 formatter 예외를 제거하고 HTTP 매핑·Service 호출·응답 생성만 유지했습니다.
- `WorkspaceController`의 중복 `@Operation`을 제거하고 기존 `OpenApiConfig`가 생성 API 문서 계약을 계속 담당하도록 정리했습니다.
- OpenAPI JSON의 endpoint별 summary, access token cookie, CSRF header 유무, 성공·오류 schema와 `Location` URI 형식을 Acceptance 테스트로 고정했습니다.

### 참고 사항

- HTTP 상태, 오류 코드, 응답 body와 초대 발급·조회·재발급 동작은 변경하지 않았습니다.
- 검증: `./gradlew clean spotlessCheck test integrationTest acceptanceTest bootJar --no-parallel` 성공
- 검증: 팀 컨벤션 01~08 원문 hash, 변경 범위 컨벤션 감사, `git diff --check`, 독립 코드 리뷰 성공
- 전체 소스 컨벤션 감사는 이번 변경 밖 `develop` 기존 파일 5건을 계속 탐지하며, 이번 변경 파일에서는 새 위반이 없습니다.
