### PR TITLE
[FE] 프론트엔드 빌드의 tsc 실패 수정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query-devtools": "^5.102.0",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "css-loader": "^7.1.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,10 +1,10 @@
 declare module "*.css";
 
-declare const process: {
-  env: {
+declare namespace NodeJS {
+  interface ProcessEnv {
     API_BASE_URL: string;
-  };
-};
+  }
+}
 declare module "*.svg" {
   import type { FunctionComponent, SVGProps } from "react";
   const Component: FunctionComponent<

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,7 @@
     "target": "es6",
     "module": "esnext",
     "strict": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",


### PR DESCRIPTION
## 관련 이슈

- #161

## 작업 내용

#252 머지 직후 처음 실행된 [Frontend Dev CD](https://github.com/woowacourse-teams/2026-Knot/actions/runs/33362135895)가 `pnpm build`의 `pnpm tsc` 단계에서 실패하여, 빌드가 통과하도록 TypeScript 설정과 전역 타입 선언을 수정하였습니다.
CI 환경 문제가 아니라 저장소 설정 문제로, 로컬에서도 동일한 7개 오류가 그대로 재현되었습니다.

### 서드파티 선언 파일 검사 제외

`tsconfig.json`의 `skipLibCheck`가 `false`라 `node_modules` 안의 `.d.ts`까지 검사 대상이었고, 오류 7건 중 5건이 여기서 발생하였습니다.

- `@babel/core@8`이 타입 없는 `convert-source-map`을 import
- `@svgr/*@8`이 babel 7 타입 기준으로 빌드되어 babel 8의 `@babel/core`·`@babel/template`과 불일치 (`TransformOptions`, `TemplateBuilder`)
- `@svgr/core` → `prettier`, `@tanstack/query-devtools` → `solid-js`: 설치하지 않은 optional peer

프로젝트에서 고칠 수 없는 서드파티 선언 파일 문제이므로 TypeScript 기본 권장값대로 `skipLibCheck: true`로 변경하였습니다. 자체 `.d.ts`(`global.d.ts`, `emotion.d.ts`)도 검사에서 빠진다는 점은 알려진 트레이드오프입니다.

### `process` 전역 재선언 제거

나머지 2건은 `src/global.d.ts`의 `declare const process`와 `@types/node`의 `process`가 충돌(TS2451)한 것입니다. `@types/node`는 직접 설치하지 않았지만 `vitest.config.ts` → `vitest/config` → vite 선언 파일의 `/// <reference types="node" />`를 통해 이미 프로그램에 포함되고 있었습니다.

`skipLibCheck`만 켜도 오류는 사라지지만 두 선언 중 어느 쪽이 적용될지 모호하게 남으므로, `process`를 다시 선언하는 대신 `NodeJS.ProcessEnv` 인터페이스만 확장하도록 바꾸고 `@types/node`를 명시적 devDependency로 추가하였습니다.

**Before**

```ts
declare const process: {
  env: {
    API_BASE_URL: string;
  };
};
```

**After**

```ts
declare namespace NodeJS {
  interface ProcessEnv {
    API_BASE_URL: string;
  }
}
```

`process.env.API_BASE_URL`은 이전과 같이 `string`으로 추론되는 것을 확인하였습니다. `@types/node`는 lockfile에 이미 있던 26.1.2를 그대로 사용하여 lockfile 변경은 importer 항목 3줄뿐입니다.

### 참고 사항

- 로컬(Node 22, TS 7.0.2)에서 `pnpm tsc` exit 0과 `webpack --mode production` 통과를 확인하였습니다. 첫 커밋(`skipLibCheck`)만으로도 `pnpm tsc`는 통과합니다.
- `getReferenceSourceIcon.test.ts`의 vitest 실패 3건은 이 변경과 무관하게 develop에서도 동일하게 실패하는 기존 문제입니다. 배포 워크플로는 테스트를 실행하지 않아 배포를 막지는 않습니다.
- 머지되면 `paths: frontend/**` 조건으로 Frontend Dev CD가 다시 실행됩니다. `API_BASE_URL_DEV`/`API_BASE_URL_PROD` Repository Variable은 여전히 등록이 필요합니다.
