### PR TITLE
[FE] 프로덕션 번들의 jsxDEV 런타임 오류 수정

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -34,7 +34,7 @@ export default (env, argv) => {
       port: 3000,
       historyApiFallback: true, // SPA 라우팅을 위해 추가
       client: {
-        overlay: true, // 빌드 오류 시 브라우저에 오버레이 표시
+        overlay: { errors: true, warnings: false }, // 빌드 오류만 브라우저에 오버레이 표시 (경고는 숨김)
       },
     },
     module: {

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -52,6 +52,7 @@ export default (env, argv) => {
                     {
                       runtime: "automatic",
                       importSource: "@emotion/react", // css prop을 위해 emotion의 jsx로 변환해요
+                      development: isDev, // 프로덕션 빌드에서는 jsxDEV 대신 jsx를 사용해요
                     },
                   ],
                   "@babel/preset-typescript", // 타입스크립트를 변환해요


### PR DESCRIPTION
## 관련 이슈

- #161

## 작업 내용

#253 머지 후 `pnpm build && pnpm start`로 프로덕션 번들을 실행하면 첫 렌더링에서 `TypeError: Jr.jsxDEV is not a function`으로 크래시하는 문제를 수정하였습니다. 배포 워크플로가 만드는 `webpack --mode production` 산출물도 동일한 코드이므로 Dev/Prod 배포 결과에 그대로 영향을 줍니다.

### 프로덕션 번들에서 `jsxDEV` 호출 제거

원인은 Babel과 webpack이 서로 다른 환경 값을 보고 있었기 때문입니다.

- `@babel/preset-react` 8은 `development` 옵션을 명시하지 않으면 Babel 환경(`BABEL_ENV || NODE_ENV || "development"`)을 따라 개발용 변환(`jsxDEV`)을 선택합니다.
- `webpack --mode production`은 Node 프로세스의 `NODE_ENV`를 바꾸지 않으므로 Babel은 개발 환경으로 판단하고, `@emotion/react/jsx-dev-runtime` → `react/jsx-dev-runtime`의 `jsxDEV`를 호출하는 코드를 만듭니다.
- 반면 번들 내부의 `process.env.NODE_ENV`는 production 모드의 `optimization.nodeEnv`에 의해 `"production"`으로 치환되어 `react/jsx-dev-runtime`이 `jsx-dev-runtime.production.js`로 해석되는데, 이 파일은 `exports.jsxDEV = void 0`입니다.

`webpack.config.js`의 preset-react 옵션에 `development: isDev`를 명시하여 production 빌드에서는 `jsx`, development 빌드에서는 `jsxDEV`를 사용하도록 하였습니다.

```js
[
  "@babel/preset-react",
  {
    runtime: "automatic",
    importSource: "@emotion/react",
    development: isDev,
  },
],
```

### dev-server 오버레이에서 경고 숨김

`pnpm start`(`webpack serve --mode production`)에서 webpack 성능 힌트 경고(번들 386KiB > 권장 244KiB)가 브라우저 오버레이로 화면을 가리고 있어, `client.overlay`를 `{ errors: true, warnings: false }`로 바꿔 오류만 표시하도록 하였습니다. 터미널 로그의 경고는 그대로 남습니다.

### 참고 사항

- 로컬(Node 22)에서 `webpack --mode production` 산출물의 `jsxDEV` 문자열이 3건 → 0건이 되는 것을 확인하였습니다. development 빌드는 기존과 같이 `jsxDEV`를 사용합니다(88건).
- 번들 크기 경고 자체(코드 스플리팅)는 이 PR의 범위가 아닙니다.
- Governance의 브랜치 타입 목록에 맞추기 위해 #253과 같은 `fe/bugfix/#161` 브랜치에 이어서 커밋하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development error overlays now display build errors without showing warnings.
  * Production builds now use optimized React rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->