### PR TITLE
[FE] 초대 코드 입력 페이지 UI 구현

### DIFF
--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/constants/inviteCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/constants/inviteCode.ts
@@ -1,0 +1,2 @@
+/** 참여 코드 글자 수. 입력창 `maxLength`이자 자동 검증을 시작하는 기준이에요. */
+export const INVITE_CODE_LENGTH = 6;

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
@@ -1,0 +1,85 @@
+import styled from "@emotion/styled";
+import Spinner from "@primitives/ui/Spinner";
+import TextField from "@primitives/ui/TextField";
+
+import { INVITE_CODE_LENGTH } from "./constants/inviteCode";
+import { useWorkspaceCode } from "./model/useWorkspaceCode";
+
+/**
+ * 초대 코드 입력 카드.
+ *
+ * 팀에서 전달받은 6자리 참여 코드를 입력하면 별도 버튼 없이 자동으로 검증을 시작해요.
+ * 검증 중에는 입력을 잠그고 우측에 스피너를 보여주며, 통과하면 입장 확인 화면으로 넘어가고
+ * 실패하면 에러 보더와 `올바르지 않은 코드예요. 다시 확인해 주세요.`를 띄운 뒤 잠금을 풉니다.
+ *
+ * 입력값은 BE 계약(#243)과 같이 대문자로 표시하고, `maxLength`로 7자째 입력은 막아요.
+ * 미리보기 API(#243)가 아직 없어 짧은 지연 뒤 형식 검사로 대신하고,
+ * 통과하면 임시 workspaceId로 `/workspace/:workspaceId/join`으로 이동합니다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10168 초대 코드 입력}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10172 초대 코드 입력/입력 에러}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=443-910 Field/TextField/Code}
+ */
+export default function WorkspaceCodeCard() {
+  const { inputCode, isVerifying, errorMessage, handleChange } =
+    useWorkspaceCode();
+
+  return (
+    <Container>
+      <Header>
+        <Title>초대 코드 입력</Title>
+        <Description>팀에서 전달받은 참여 코드를 입력하세요</Description>
+      </Header>
+
+      <TextField
+        variant="code"
+        value={inputCode}
+        onChange={handleChange}
+        placeholder="코드를 입력하세요"
+        maxLength={INVITE_CODE_LENGTH}
+        errorMessage={errorMessage}
+        readOnly={isVerifying}
+        aria-busy={isVerifying}
+        rightComponent={isVerifying && <Spinner />}
+        aria-label="참여 코드"
+        autoComplete="off"
+        autoCapitalize="characters"
+        autoFocus
+      />
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem; /* 28px */
+  width: 100%;
+  max-width: 28.75rem; /* 460px */
+  padding: 3rem; /* 48px */
+  border-radius: 1.5rem; /* 24px */
+  background-color: ${({ theme }) => theme.neutral[0]};
+  box-shadow: ${({ theme }) => theme.shadow02};
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem; /* 12px */
+  text-align: center;
+  overflow-wrap: break-word;
+`;
+
+const Title = styled.h1`
+  color: ${({ theme }) => theme.neutral[900]};
+  ${({ theme }) => theme.text.heading02};
+`;
+
+const Description = styled.p`
+  color: ${({ theme }) => theme.neutral[600]};
+  ${({ theme }) => theme.text.body01};
+`;

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
@@ -2,14 +2,19 @@ import styled from "@emotion/styled";
 import Spinner from "@primitives/ui/Spinner";
 import TextField from "@primitives/ui/TextField";
 
+import CheckIcon from "@/assets/icons/check.svg";
+
 import { INVITE_CODE_LENGTH } from "./constants/inviteCode";
 import { useWorkspaceCode } from "./model/useWorkspaceCode";
+
+const SUCCESS_MESSAGE = "확인됐어요. 곧 다음 단계로 이동해요.";
 
 /**
  * 초대 코드 입력 카드.
  *
  * 팀에서 전달받은 6자리 참여 코드를 입력하면 별도 버튼 없이 자동으로 검증을 시작해요.
- * 검증 중에는 입력을 잠그고 우측에 스피너를 보여주며, 통과하면 입장 확인 화면으로 넘어가고
+ * 검증 중에는 입력을 잠그고 우측에 스피너를 보여줘요. 통과하면 우측 체크와
+ * `확인됐어요. 곧 다음 단계로 이동해요.`를 1.5초 동안 보여준 뒤 입장 확인 화면으로 넘어가고,
  * 실패하면 에러 보더와 `올바르지 않은 코드예요. 다시 확인해 주세요.`를 띄운 뒤 잠금을 풉니다.
  *
  * 입력값은 BE 계약(#243)과 같이 대문자로 표시하고, `maxLength`로 7자째 입력은 막아요.
@@ -21,10 +26,17 @@ import { useWorkspaceCode } from "./model/useWorkspaceCode";
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10168 초대 코드 입력}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10172 초대 코드 입력/입력 에러}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=443-910 Field/TextField/Code}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=664-552 Field/TextField/Code status=인증 완료}
  */
 export default function WorkspaceCodeCard() {
-  const { inputCode, isVerifying, errorMessage, handleChange } =
+  const { inputCode, isVerifying, isVerified, errorMessage, handleChange } =
     useWorkspaceCode();
+
+  const rightComponent = isVerifying ? (
+    <Spinner />
+  ) : isVerified ? (
+    <SuccessIcon />
+  ) : null;
 
   return (
     <Container>
@@ -40,9 +52,10 @@ export default function WorkspaceCodeCard() {
         placeholder="코드를 입력하세요"
         maxLength={INVITE_CODE_LENGTH}
         errorMessage={errorMessage}
-        readOnly={isVerifying}
+        successMessage={isVerified ? SUCCESS_MESSAGE : undefined}
+        readOnly={isVerifying || isVerified}
         aria-busy={isVerifying}
-        rightComponent={isVerifying && <Spinner />}
+        rightComponent={rightComponent}
         aria-label="참여 코드"
         autoComplete="off"
         autoCapitalize="characters"
@@ -82,4 +95,10 @@ const Title = styled.h1`
 const Description = styled.p`
   color: ${({ theme }) => theme.neutral[600]};
   ${({ theme }) => theme.text.body01};
+`;
+
+const SuccessIcon = styled(CheckIcon)`
+  width: 1.25rem; /* 20px */
+  height: 1.25rem;
+  color: ${({ theme }) => theme.sub.accent[500]};
 `;

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -1,0 +1,68 @@
+import useNavigateToWorkspaceJoin from "@hooks/domain/workspace/useNavigateToWorkspaceJoin";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
+
+import { INVITE_CODE_LENGTH } from "../constants/inviteCode";
+
+export const useWorkspaceCode = () => {
+  const [inputCode, setInputCode] = useState("");
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  // TODO: query 훅으로 수정하기
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
+
+  /**
+   * 6자를 채우면 별도 트리거 없이 호출되는 임시 검증.
+   *
+   * TODO(#243): 미리보기 API(`GET /invitations/{tokenOrCode}`)가 붙으면
+   * 아래 지연·형식 검사를 쿼리 호출로 바꾸고 응답의 workspaceId로 이동해요.
+   */
+  const verify = (value: string) => {
+    setIsVerifying(true);
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setIsVerifying(false);
+
+      // TODO(#243): API 응답의 workspaceId로 교체
+      if (value === "000000") {
+        const TEMP_WORKSPACE_ID = "temp";
+        navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+        return;
+      }
+
+      const INVITE_CODE_ERROR_MESSAGE =
+        "올바르지 않은 코드예요. 다시 확인해 주세요.";
+
+      setErrorMessage(INVITE_CODE_ERROR_MESSAGE);
+    }, 800); // TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. 추후에 api로 교체하면 loading 상태일 때의 동작을 하게 돼요
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (isVerifying) return;
+
+    const nextCode = event.target.value
+      .toUpperCase()
+      .slice(0, INVITE_CODE_LENGTH);
+
+    setInputCode(nextCode);
+    setErrorMessage(undefined);
+
+    if (nextCode.length === INVITE_CODE_LENGTH) verify(nextCode);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return {
+    inputCode,
+    isVerifying,
+    errorMessage,
+    handleChange,
+  };
+};

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -15,7 +15,7 @@ export const useWorkspaceCode = () => {
 
   const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
 
-  /** 검증을 통과하면 1초 동안 성공 상태를 보여준 뒤 입장 확인 화면으로 이동. */
+  /** 검증을 통과하면 1.5초 동안 성공 상태를 보여준 뒤 입장 확인 화면으로 이동. */
   const { isTimedOut: isVerified, start: showSuccess } = useTimeout({
     timeout: SUCCESS_DISPLAY_MS,
     callback: () => {

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -1,17 +1,29 @@
+import useTimeout from "@hooks/common/useTimeout";
 import useNavigateToWorkspaceJoin from "@hooks/domain/workspace/useNavigateToWorkspaceJoin";
-import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useState } from "react";
 
 import { INVITE_CODE_LENGTH } from "../constants/inviteCode";
 
+// TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. 추후에 api로 교체하면 loading 상태일 때의 동작을 하게 돼요
+const VERIFY_DELAY_MS = 800;
+/** 검증을 통과한 뒤 성공 상태를 보여주는 시간. 지나면 입장 확인 화면으로 이동해요. */
+const SUCCESS_DISPLAY_MS = 1500;
+
 export const useWorkspaceCode = () => {
   const [inputCode, setInputCode] = useState("");
-  const [isVerifying, setIsVerifying] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
 
-  // TODO: query 훅으로 수정하기
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
+
+  /** 검증을 통과하면 1초 동안 성공 상태를 보여준 뒤 입장 확인 화면으로 이동. */
+  const { isTimedOut: isVerified, start: showSuccess } = useTimeout({
+    timeout: SUCCESS_DISPLAY_MS,
+    callback: () => {
+      // TODO(#243): API 응답의 workspaceId로 교체
+      const TEMP_WORKSPACE_ID = "temp";
+      navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+    },
+  });
 
   /**
    * 6자를 채우면 별도 트리거 없이 호출되는 임시 검증.
@@ -19,17 +31,12 @@ export const useWorkspaceCode = () => {
    * TODO(#243): 미리보기 API(`GET /invitations/{tokenOrCode}`)가 붙으면
    * 아래 지연·형식 검사를 쿼리 호출로 바꾸고 응답의 workspaceId로 이동해요.
    */
-  const verify = (value: string) => {
-    setIsVerifying(true);
-
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null;
-      setIsVerifying(false);
-
-      // TODO(#243): API 응답의 workspaceId로 교체
-      if (value === "000000") {
-        const TEMP_WORKSPACE_ID = "temp";
-        navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+  const { isTimedOut: isVerifying, start: verify } = useTimeout({
+    timeout: VERIFY_DELAY_MS,
+    callback: () => {
+      // 임시로 000000을 통과 코드로 설정
+      if (inputCode === "000000") {
+        showSuccess();
         return;
       }
 
@@ -37,11 +44,11 @@ export const useWorkspaceCode = () => {
         "올바르지 않은 코드예요. 다시 확인해 주세요.";
 
       setErrorMessage(INVITE_CODE_ERROR_MESSAGE);
-    }, 800); // TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. 추후에 api로 교체하면 loading 상태일 때의 동작을 하게 돼요
-  };
+    },
+  });
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (isVerifying) return;
+    if (isVerifying || isVerified) return;
 
     const nextCode = event.target.value
       .toUpperCase()
@@ -50,18 +57,13 @@ export const useWorkspaceCode = () => {
     setInputCode(nextCode);
     setErrorMessage(undefined);
 
-    if (nextCode.length === INVITE_CODE_LENGTH) verify(nextCode);
+    if (nextCode.length === INVITE_CODE_LENGTH) verify();
   };
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
-    };
-  }, []);
 
   return {
     inputCode,
     isVerifying,
+    isVerified,
     errorMessage,
     handleChange,
   };

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
@@ -1,0 +1,141 @@
+import { ThemeProvider } from "@emotion/react";
+import { theme } from "@provider/themeProvider";
+import { PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceCodeCard from ".";
+
+const ERROR_MESSAGE = "올바르지 않은 코드예요. 다시 확인해 주세요.";
+const ELSEWHERE_PATH = "/elsewhere";
+// TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
+const VALID_CODE = "000000";
+const INVALID_CODE = "X35D3@";
+
+const renderCard = () => {
+  const router = createMemoryRouter(
+    [
+      { path: PATH_ROUTE.WORKSPACE_CODE, element: <WorkspaceCodeCard /> },
+      { path: PATH_ROUTE.WORKSPACE_JOIN, element: <p>입장 확인</p> },
+      { path: ELSEWHERE_PATH, element: <p>다른 화면</p> },
+    ],
+    { initialEntries: [PATH_ROUTE.WORKSPACE_CODE] },
+  );
+
+  render(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  );
+
+  const input = screen.getByRole("textbox", { name: "참여 코드" });
+
+  return { router, input };
+};
+
+const typeCode = (input: HTMLElement, value: string) => {
+  fireEvent.change(input, { target: { value } });
+};
+
+const finishVerification = async () => {
+  await act(async () => {
+    vi.runAllTimers();
+  });
+};
+
+describe("WorkspaceCodeCard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("6자를 채우면 입력을 잠그고 스피너를 보여준다", () => {
+    const { input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "true");
+    expect(
+      input.parentElement?.querySelector('[aria-hidden="true"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("지연 뒤 유효한 코드면 임시 workspaceId로 입장 확인 화면에 이동한다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("지연 뒤 유효하지 않은 코드면 에러 문구를 보여주고 입력 잠금을 푼다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, INVALID_CODE);
+    await finishVerification();
+
+    expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).not.toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "false");
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+  });
+
+  it("에러 상태에서 값을 고치면 에러가 사라진다", async () => {
+    const { input } = renderCard();
+
+    typeCode(input, INVALID_CODE);
+    await finishVerification();
+    typeCode(input, "X35D3");
+
+    expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("에러를 고쳐 다시 6자를 채우면 재검증한다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, INVALID_CODE);
+    await finishVerification();
+    typeCode(input, "X35D3");
+    typeCode(input, VALID_CODE);
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("7자째 입력은 막힌다", () => {
+    const { input } = renderCard();
+
+    typeCode(input, "X35D3S7");
+
+    expect(input).toHaveAttribute("maxlength", "6");
+    expect(input).toHaveValue("X35D3S");
+  });
+
+  it("소문자를 입력하면 대문자로 표시한다", () => {
+    const { input } = renderCard();
+
+    typeCode(input, "x35d");
+
+    expect(input).toHaveValue("X35D");
+  });
+
+  it("로딩 중 페이지를 벗어나면 이동을 실행하지 않는다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await act(async () => {
+      await router.navigate(ELSEWHERE_PATH);
+    });
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
+  });
+});

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
@@ -11,7 +11,7 @@ const ERROR_MESSAGE = "올바르지 않은 코드예요. 다시 확인해 주세
 const SUCCESS_MESSAGE = "확인됐어요. 곧 다음 단계로 이동해요.";
 const ELSEWHERE_PATH = "/elsewhere";
 const VERIFY_DELAY_MS = 800;
-const SUCCESS_DELAY_MS = 1000;
+const SUCCESS_DELAY_MS = 1500;
 // TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
 const VALID_CODE = "000000";
 const INVALID_CODE = "X35D3@";
@@ -149,7 +149,7 @@ describe("WorkspaceCodeCard", () => {
     expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
   });
 
-  it("성공 메시지를 1초 동안 보여준 뒤 입장 확인 화면으로 이동한다", async () => {
+  it("성공 메시지를 1.5초 동안 보여준 뒤 입장 확인 화면으로 이동한다", async () => {
     const { router, input } = renderCard();
 
     typeCode(input, VALID_CODE);

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
@@ -8,7 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkspaceCodeCard from ".";
 
 const ERROR_MESSAGE = "올바르지 않은 코드예요. 다시 확인해 주세요.";
+const SUCCESS_MESSAGE = "확인됐어요. 곧 다음 단계로 이동해요.";
 const ELSEWHERE_PATH = "/elsewhere";
+const VERIFY_DELAY_MS = 800;
+const SUCCESS_DELAY_MS = 1000;
 // TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
 const VALID_CODE = "000000";
 const INVALID_CODE = "X35D3@";
@@ -41,6 +44,12 @@ const typeCode = (input: HTMLElement, value: string) => {
 const finishVerification = async () => {
   await act(async () => {
     vi.runAllTimers();
+  });
+};
+
+const advanceTimers = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
   });
 };
 
@@ -125,6 +134,46 @@ describe("WorkspaceCodeCard", () => {
     typeCode(input, "x35d");
 
     expect(input).toHaveValue("X35D");
+  });
+
+  it("유효한 코드면 검증이 끝난 뒤 성공 메시지와 체크 표시를 보여주고 입력은 잠근 채 둔다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await advanceTimers(VERIFY_DELAY_MS);
+
+    expect(screen.getByText(SUCCESS_MESSAGE)).toBeInTheDocument();
+    expect(input.parentElement?.querySelector("svg")).toBeInTheDocument();
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "false");
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+  });
+
+  it("성공 메시지를 1초 동안 보여준 뒤 입장 확인 화면으로 이동한다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await advanceTimers(VERIFY_DELAY_MS);
+    await advanceTimers(SUCCESS_DELAY_MS - 1);
+
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+
+    await advanceTimers(1);
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("성공 메시지를 보여주는 동안 페이지를 벗어나면 이동을 실행하지 않는다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await advanceTimers(VERIFY_DELAY_MS);
+    await act(async () => {
+      await router.navigate(ELSEWHERE_PATH);
+    });
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
   });
 
   it("로딩 중 페이지를 벗어나면 이동을 실행하지 않는다", async () => {

--- a/frontend/src/pages/workspace/code/index.tsx
+++ b/frontend/src/pages/workspace/code/index.tsx
@@ -1,19 +1,20 @@
+import WorkspaceCodeCard from "@widgets/workspace/WorkspaceCodeCard";
+
 /**
  * 초대 코드 입력 화면 (`/workspace/code`)
  *
  * 팀에서 전달받은 참여 코드를 입력해 워크스페이스를 찾는 화면이다.
- * 입력 전 / 입력 에러(만료·오타 등 유효하지 않은 코드) 상태를 한 화면에서 다룬다.
+ * 입력 전 / 로딩 / 입력 에러(만료·오타 등 유효하지 않은 코드) 상태를 한 화면에서 다룬다.
  * 코드가 유효하면 워크스페이스 입장 확인(`/workspace/:workspaceId/join`)으로 이동한다.
  *
- * 초대 링크로 들어오는 경우에도 `?code=` 쿼리를 달고 이 화면으로 진입한다.
+ * 초대 링크(`?code=` 쿼리 등)로 들어오는 진입은 이 화면의 범위가 아니며,
+ * 링크 형식과 함께 링크 입장 페이지 Issue(#192 하위)에서 다룬다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10168 초대 코드 입력
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10172 초대 코드 입력/입력 에러
  */
 export default function WorkspaceCodePage() {
-  return (
-    <div>
-      <h1>Workspace Code Page</h1>
-    </div>
-  );
+  return <WorkspaceCodeCard />;
 }

--- a/frontend/src/shared/components/primitives/ui/TextField/index.tsx
+++ b/frontend/src/shared/components/primitives/ui/TextField/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import Input from "@primitives/ui/Input";
+import Input, { type InputVariant } from "@primitives/ui/Input";
 import type { InputHTMLAttributes } from "react";
 import { useId } from "react";
 
@@ -8,7 +8,10 @@ interface TextFieldProps extends Omit<
   "value"
 > {
   value: string;
+  variant?: InputVariant;
   errorMessage?: string;
+  /** 우측에 표시할 컴포넌트 */
+  rightComponent?: React.ReactNode;
 }
 
 /**
@@ -25,10 +28,14 @@ interface TextFieldProps extends Omit<
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=424-596 Field/TextField 컴포넌트 세트
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1325 status=입력 에러 (에러 메시지 포함)
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=627-2967 Field/TextField/Code status=로딩 (`isLoading`)
  */
 export default function TextField({
   value,
+  variant,
   errorMessage,
+  rightComponent,
+  readOnly = false,
   id,
   ...props
 }: TextFieldProps) {
@@ -39,13 +46,20 @@ export default function TextField({
 
   return (
     <Container>
-      <Input
-        id={inputId}
-        value={value}
-        status={isError ? "error" : value.length > 0 ? "filled" : "empty"}
-        aria-describedby={isError ? errorMessageId : undefined}
-        {...props}
-      />
+      <InputWrapper>
+        <Input
+          id={inputId}
+          value={value}
+          variant={variant}
+          status={isError ? "error" : value.length > 0 ? "filled" : "empty"}
+          readOnly={readOnly}
+          aria-describedby={isError ? errorMessageId : undefined}
+          {...props}
+        />
+        {rightComponent && (
+          <RightComponentWrapper>{rightComponent}</RightComponentWrapper>
+        )}
+      </InputWrapper>
       {isError && (
         <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
       )}
@@ -58,6 +72,23 @@ const Container = styled.div`
   flex-direction: column;
   gap: 0.5rem;
   width: 100%;
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const RightComponentWrapper = styled.span`
+  position: absolute;
+  top: 0;
+  right: 0.9375rem; /* 15px */
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  color: ${({ theme }) => theme.neutral[500]};
 `;
 
 const ErrorMessage = styled.p`

--- a/frontend/src/shared/components/primitives/ui/TextField/index.tsx
+++ b/frontend/src/shared/components/primitives/ui/TextField/index.tsx
@@ -10,9 +10,23 @@ interface TextFieldProps extends Omit<
   value: string;
   variant?: InputVariant;
   errorMessage?: string;
+  /** 검증을 통과했을 때 아래에 보여줄 메시지. `errorMessage`가 있으면 에러가 우선해요 */
+  successMessage?: string;
   /** 우측에 표시할 컴포넌트 */
   rightComponent?: React.ReactNode;
 }
+
+interface GetStatusParams {
+  isError: boolean;
+  isSuccess: boolean;
+  value: string;
+}
+
+const getStatus = ({ isError, isSuccess, value }: GetStatusParams) => {
+  if (isError) return "error";
+  if (isSuccess) return "success";
+  return value.length > 0 ? "filled" : "empty";
+};
 
 /**
  * 에러 메시지까지 함께 다루는 입력 필드.
@@ -21,7 +35,8 @@ interface TextFieldProps extends Omit<
  * `Input`은 상태 판단 없이 받은 status만 그려요.
  *
  * `errorMessage`를 넘기면 입력창이 에러 스타일로 바뀌면서 아래에 메시지가 생기고,
- * 그 메시지는 `aria-describedby`로 입력창과 연결돼요.
+ * `successMessage`를 넘기면 성공 스타일로 바뀌면서 아래에 메시지가 생겨요.
+ * 둘 다 있으면 에러가 우선하고, 보이는 메시지는 `aria-describedby`로 입력창과 연결돼요.
  *
  * `id`를 직접 넘기지 않으면 `useId`로 만든 값을 쓰므로,
  * 외부 `label`과 연결해야 할 때만 `id`를 넘기면 돼요.
@@ -29,11 +44,13 @@ interface TextFieldProps extends Omit<
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=424-596 Field/TextField 컴포넌트 세트
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1325 status=입력 에러 (에러 메시지 포함)
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=627-2967 Field/TextField/Code status=로딩 (`isLoading`)
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=664-552 Field/TextField/Code status=인증 완료 (`successMessage`)
  */
 export default function TextField({
   value,
   variant,
   errorMessage,
+  successMessage,
   rightComponent,
   readOnly = false,
   id,
@@ -41,8 +58,10 @@ export default function TextField({
 }: TextFieldProps) {
   const generatedId = useId();
   const inputId = id ?? generatedId;
-  const errorMessageId = `${inputId}-error`;
+  const messageId = `${inputId}-message`;
   const isError = Boolean(errorMessage);
+  const isSuccess = !isError && Boolean(successMessage);
+  const hasMessage = isError || isSuccess;
 
   return (
     <Container>
@@ -51,17 +70,18 @@ export default function TextField({
           id={inputId}
           value={value}
           variant={variant}
-          status={isError ? "error" : value.length > 0 ? "filled" : "empty"}
+          status={getStatus({ isError, isSuccess, value })}
           readOnly={readOnly}
-          aria-describedby={isError ? errorMessageId : undefined}
+          aria-describedby={hasMessage ? messageId : undefined}
           {...props}
         />
         {rightComponent && (
           <RightComponentWrapper>{rightComponent}</RightComponentWrapper>
         )}
       </InputWrapper>
-      {isError && (
-        <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
+      {isError && <ErrorMessage id={messageId}>{errorMessage}</ErrorMessage>}
+      {isSuccess && (
+        <SuccessMessage id={messageId}>{successMessage}</SuccessMessage>
       )}
     </Container>
   );
@@ -91,7 +111,14 @@ const RightComponentWrapper = styled.span`
   color: ${({ theme }) => theme.neutral[500]};
 `;
 
-const ErrorMessage = styled.p`
-  color: ${({ theme }) => theme.sub.warning[800]};
+const Message = styled.p`
   ${({ theme }) => theme.text.caption02};
+`;
+
+const ErrorMessage = styled(Message)`
+  color: ${({ theme }) => theme.sub.warning[800]};
+`;
+
+const SuccessMessage = styled(Message)`
+  color: ${({ theme }) => theme.sub.accent[500]};
 `;

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceJoin/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceJoin/index.ts
@@ -1,0 +1,19 @@
+import { getRouterPath } from "@routes/PATH_ROUTE";
+import { useNavigate } from "react-router";
+
+/**
+ * 워크스페이스 입장 확인 화면(`/workspace/:workspaceId/join`)으로 이동하는 도메인 훅.
+ */
+const useNavigateToWorkspaceJoin = () => {
+  const navigate = useNavigate();
+
+  const navigateToWorkspaceJoin = (workspaceId: string) => {
+    navigate(
+      getRouterPath({ routeKey: "WORKSPACE_JOIN", params: { workspaceId } }),
+    );
+  };
+
+  return { navigateToWorkspaceJoin };
+};
+
+export default useNavigateToWorkspaceJoin;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -46,6 +46,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "src/**/test.{ts,tsx}"],
   },
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
           focusable: "false",
           "aria-hidden": "true",
         },
+        // webpack 설정과 같이 size prop을 만들어요. 플러그인이 jsx로 변환하므로 타입 표기는 넣지 않아요
+        template: ({ componentName, jsx, exports }, { tpl }) => tpl`
+const ${componentName} = ({ size = 24, ...props }) => (
+  ${jsx}
+);
+
+${exports}
+`,
       },
     }),
   ],


### PR DESCRIPTION
## 관련 이슈

- #258
- 상위 이슈: #192

## 작업 내용

워크스페이스 기능 중 초대 코드 입력 페이지(`/workspace/code`)의 UI·상태·이동 흐름을 구현하였습니다.
미리보기 API(#243)가 아직 머지되지 않아 검증은 임시 지연과 고정 통과 코드로 대체하였고, API 연동은 후속 Issue에서 진행하겠습니다.
상위 이슈의 TODO 중 워크스페이스 입장 확인 페이지와 초대 링크로 입장하는 페이지는 후속 PR에서 진행하겠습니다.

### WorkspaceCodeCard 위젯 구현

카드는 `modules/widgets/workspace/WorkspaceCodeCard`에 workspace 도메인 위젯으로 두고, `pages/workspace/code`는 카드를 놓기만 하도록 하였습니다.
폼 상태·검증·이동 로직은 `model/useWorkspaceCode` 훅에, 코드 글자 수는 `constants/inviteCode`에 모았습니다.

Figma `초대 코드 입력` 프레임대로 별도 제출 버튼 없이 6자를 모두 채우면 자동으로 검증을 시작합니다.
입력값은 BE 계약(#243)과 같이 대문자로 표시하고, `maxLength`로 7자째 입력을 막았습니다.

```mermaid
stateDiagram-v2
    [*] --> 입력중
    입력중 --> 검증중: 6자 입력 "readOnly + Spinner"
    검증중 --> 인증완료: 통과 "readOnly + Check + 성공 문구"
    검증중 --> 에러: 실패 "aria-invalid + 에러 문구"
    에러 --> 입력중: 값 수정 "에러 해제"
    인증완료 --> [*]: 1.5초 뒤 "/workspace/:workspaceId/join" 이동
```

검증 중과 인증 완료 상태에서는 입력을 잠그고 `handleChange`도 무시하여, 이동 직전에 값이 바뀌지 않도록 하였습니다.

### 임시 검증과 입장 확인 화면 이동

미리보기 API가 없어 `useTimeout` 두 개로 응답 대기와 성공 표시를 흉내 냈습니다.
`VERIFY_DELAY_MS`(800ms) 뒤에 판정하고, 통과하면 `SUCCESS_DISPLAY_MS` 동안 인증 완료 상태를 보여준 뒤 이동합니다.
지연·판정 코드는 `TODO(#243)` 주석과 함께 `useWorkspaceCode` 한곳에 모아 API 연동 시 쿼리 호출로 바꿀 수 있게 하였습니다.

```ts
const { isTimedOut: isVerifying, start: verify } = useTimeout({
  timeout: VERIFY_DELAY_MS,
  callback: () => {
    // 임시로 000000을 통과 코드로 설정
    if (inputCode === "000000") {
      showSuccess();
      return;
    }
    setErrorMessage(INVITE_CODE_ERROR_MESSAGE);
  },
});
```

이동은 #204와 같은 방식으로 `shared/hooks/domain/workspace/useNavigateToWorkspaceJoin` 도메인 훅을 추가하여 처리하였고, 통과 시 임시 workspaceId(`temp`)로 `/workspace/temp/join`에 이동합니다.
`useTimeout`이 언마운트 시 타이머를 정리하므로, 로딩 중이나 성공 표시 중에 페이지를 벗어나면 이동을 실행하지 않습니다.

### TextField에 variant·rightComponent·readOnly·successMessage 추가

로딩·인증 완료 표현을 카드에 하드코딩하지 않도록 `TextField` 프리미티브를 확장하였습니다.
`isLoading` 같은 상태 전용 prop 대신 우측에 아무 컴포넌트나 놓을 수 있는 `rightComponent`로 일반화하여, 스피너와 체크 아이콘을 사용처에서 결정하도록 하였습니다.

```tsx
<TextField
  variant="code"
  value={inputCode}
  onChange={handleChange}
  maxLength={INVITE_CODE_LENGTH}
  errorMessage={errorMessage}
  successMessage={isVerified ? SUCCESS_MESSAGE : undefined}
  readOnly={isVerifying || isVerified}
  aria-busy={isVerifying}
  rightComponent={isVerifying ? <Spinner /> : isVerified ? <SuccessIcon /> : null}
/>
```

`successMessage`를 넘기면 `Input`의 `status`가 `success`로 바뀌고 아래에 accent 색 메시지가 생기며, `errorMessage`와 함께 있으면 에러가 우선합니다.
보이는 메시지는 하나뿐이므로 `aria-describedby` 대상 id를 `-error`에서 `-message`로 통합하였습니다.
기존 사용처는 새 prop을 넘기지 않으면 이전과 같이 동작합니다.

### vitest 설정 보완

위젯 폴더의 `test.tsx` 콜로케이션 테스트가 실행되도록 `include`에 `src/**/test.{ts,tsx}` 패턴을 추가하였습니다.
또한 vitest의 svgr 플러그인에는 webpack과 달리 `size` prop 기본값 템플릿이 없어 SVG 아이콘 렌더 시 `size is not defined`가 발생하였으므로, webpack 설정과 같은 템플릿을 추가하였습니다.

### 참고 사항

- Issue TODO의 "영문 대문자·숫자 6자 형식 검사 유틸과 단위 테스트"는 두지 않고, `000000`만 통과하는 고정 코드로 대체하였습니다. 형식 검사는 API 연동 시 서버 응답으로 대체될 것이라 판단하였는데, 임시 유틸이라도 두는 편이 나을지 의견 부탁드립니다.
- 인증 완료 상태(Figma `Field/TextField/Code status=인증 완료`, `successMessage`)는 Issue TODO에 없던 항목을 Figma 기준으로 추가한 것입니다.
- 인증 완료 상태를 보여주는 시간은 `SUCCESS_DISPLAY_MS = 1500`(1.5초)으로 두었습니다. 문구를 읽을 시간과 이동 지연 사이의 균형을 고려한 값인데, 더 짧거나 길어야 한다면 의견 부탁드립니다.
- 로딩 표현을 `Input`/`TextField`의 전용 prop이 아니라 `rightComponent`로 일반화한 방향이 적절한지 봐주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an invite-code entry experience for joining workspaces.
  - Invite codes are automatically capitalized and limited to six characters.
  - Added verification feedback with loading, success, and error states.
  - Valid codes now continue to the workspace join flow.
  - Added accessible input behavior, including focus management and status announcements.

- **Improvements**
  - Enhanced text fields to support success messages, validation states, and trailing indicators.
  - Invalid codes can be corrected and resubmitted without restarting the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->