### PR TITLE
[FE] 초대 링크로 워크스페이스 입장 플로우 UI 구현

### DIFF
--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/constants/inviteCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/constants/inviteCode.ts
@@ -1,0 +1,2 @@
+/** 참여 코드 글자 수. 입력창 `maxLength`이자 자동 검증을 시작하는 기준이에요. */
+export const INVITE_CODE_LENGTH = 6;

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
@@ -1,0 +1,85 @@
+import styled from "@emotion/styled";
+import Spinner from "@primitives/ui/Spinner";
+import TextField from "@primitives/ui/TextField";
+
+import { INVITE_CODE_LENGTH } from "./constants/inviteCode";
+import { useWorkspaceCode } from "./model/useWorkspaceCode";
+
+/**
+ * 초대 코드 입력 카드.
+ *
+ * 팀에서 전달받은 6자리 참여 코드를 입력하면 별도 버튼 없이 자동으로 검증을 시작해요.
+ * 검증 중에는 입력을 잠그고 우측에 스피너를 보여주며, 통과하면 입장 확인 화면으로 넘어가고
+ * 실패하면 에러 보더와 `올바르지 않은 코드예요. 다시 확인해 주세요.`를 띄운 뒤 잠금을 풉니다.
+ *
+ * 입력값은 BE 계약(#243)과 같이 대문자로 표시하고, `maxLength`로 7자째 입력은 막아요.
+ * 미리보기 API(#243)가 아직 없어 짧은 지연 뒤 형식 검사로 대신하고,
+ * 통과하면 임시 workspaceId로 `/workspace/:workspaceId/join`으로 이동합니다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10168 초대 코드 입력}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10172 초대 코드 입력/입력 에러}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=443-910 Field/TextField/Code}
+ */
+export default function WorkspaceCodeCard() {
+  const { inputCode, isVerifying, errorMessage, handleChange } =
+    useWorkspaceCode();
+
+  return (
+    <Container>
+      <Header>
+        <Title>초대 코드 입력</Title>
+        <Description>팀에서 전달받은 참여 코드를 입력하세요</Description>
+      </Header>
+
+      <TextField
+        variant="code"
+        value={inputCode}
+        onChange={handleChange}
+        placeholder="코드를 입력하세요"
+        maxLength={INVITE_CODE_LENGTH}
+        errorMessage={errorMessage}
+        readOnly={isVerifying}
+        aria-busy={isVerifying}
+        rightComponent={isVerifying && <Spinner />}
+        aria-label="참여 코드"
+        autoComplete="off"
+        autoCapitalize="characters"
+        autoFocus
+      />
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem; /* 28px */
+  width: 100%;
+  max-width: 28.75rem; /* 460px */
+  padding: 3rem; /* 48px */
+  border-radius: 1.5rem; /* 24px */
+  background-color: ${({ theme }) => theme.neutral[0]};
+  box-shadow: ${({ theme }) => theme.shadow02};
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem; /* 12px */
+  text-align: center;
+  overflow-wrap: break-word;
+`;
+
+const Title = styled.h1`
+  color: ${({ theme }) => theme.neutral[900]};
+  ${({ theme }) => theme.text.heading02};
+`;
+
+const Description = styled.p`
+  color: ${({ theme }) => theme.neutral[600]};
+  ${({ theme }) => theme.text.body01};
+`;

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/index.tsx
@@ -2,14 +2,19 @@ import styled from "@emotion/styled";
 import Spinner from "@primitives/ui/Spinner";
 import TextField from "@primitives/ui/TextField";
 
+import CheckIcon from "@/assets/icons/check.svg";
+
 import { INVITE_CODE_LENGTH } from "./constants/inviteCode";
 import { useWorkspaceCode } from "./model/useWorkspaceCode";
+
+const SUCCESS_MESSAGE = "확인됐어요. 곧 다음 단계로 이동해요.";
 
 /**
  * 초대 코드 입력 카드.
  *
  * 팀에서 전달받은 6자리 참여 코드를 입력하면 별도 버튼 없이 자동으로 검증을 시작해요.
- * 검증 중에는 입력을 잠그고 우측에 스피너를 보여주며, 통과하면 입장 확인 화면으로 넘어가고
+ * 검증 중에는 입력을 잠그고 우측에 스피너를 보여줘요. 통과하면 우측 체크와
+ * `확인됐어요. 곧 다음 단계로 이동해요.`를 1.5초 동안 보여준 뒤 입장 확인 화면으로 넘어가고,
  * 실패하면 에러 보더와 `올바르지 않은 코드예요. 다시 확인해 주세요.`를 띄운 뒤 잠금을 풉니다.
  *
  * 입력값은 BE 계약(#243)과 같이 대문자로 표시하고, `maxLength`로 7자째 입력은 막아요.
@@ -21,10 +26,17 @@ import { useWorkspaceCode } from "./model/useWorkspaceCode";
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10168 초대 코드 입력}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10172 초대 코드 입력/입력 에러}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=443-910 Field/TextField/Code}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=664-552 Field/TextField/Code status=인증 완료}
  */
 export default function WorkspaceCodeCard() {
-  const { inputCode, isVerifying, errorMessage, handleChange } =
+  const { inputCode, isVerifying, isVerified, errorMessage, handleChange } =
     useWorkspaceCode();
+
+  const rightComponent = isVerifying ? (
+    <Spinner />
+  ) : isVerified ? (
+    <SuccessIcon />
+  ) : null;
 
   return (
     <Container>
@@ -40,9 +52,10 @@ export default function WorkspaceCodeCard() {
         placeholder="코드를 입력하세요"
         maxLength={INVITE_CODE_LENGTH}
         errorMessage={errorMessage}
-        readOnly={isVerifying}
+        successMessage={isVerified ? SUCCESS_MESSAGE : undefined}
+        readOnly={isVerifying || isVerified}
         aria-busy={isVerifying}
-        rightComponent={isVerifying && <Spinner />}
+        rightComponent={rightComponent}
         aria-label="참여 코드"
         autoComplete="off"
         autoCapitalize="characters"
@@ -82,4 +95,10 @@ const Title = styled.h1`
 const Description = styled.p`
   color: ${({ theme }) => theme.neutral[600]};
   ${({ theme }) => theme.text.body01};
+`;
+
+const SuccessIcon = styled(CheckIcon)`
+  width: 1.25rem; /* 20px */
+  height: 1.25rem;
+  color: ${({ theme }) => theme.sub.accent[500]};
 `;

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -1,0 +1,68 @@
+import useNavigateToWorkspaceJoin from "@hooks/domain/workspace/useNavigateToWorkspaceJoin";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
+
+import { INVITE_CODE_LENGTH } from "../constants/inviteCode";
+
+export const useWorkspaceCode = () => {
+  const [inputCode, setInputCode] = useState("");
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  // TODO: query 훅으로 수정하기
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
+
+  /**
+   * 6자를 채우면 별도 트리거 없이 호출되는 임시 검증.
+   *
+   * TODO(#243): 미리보기 API(`GET /invitations/{tokenOrCode}`)가 붙으면
+   * 아래 지연·형식 검사를 쿼리 호출로 바꾸고 응답의 workspaceId로 이동해요.
+   */
+  const verify = (value: string) => {
+    setIsVerifying(true);
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setIsVerifying(false);
+
+      // TODO(#243): API 응답의 workspaceId로 교체
+      if (value === "000000") {
+        const TEMP_WORKSPACE_ID = "temp";
+        navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+        return;
+      }
+
+      const INVITE_CODE_ERROR_MESSAGE =
+        "올바르지 않은 코드예요. 다시 확인해 주세요.";
+
+      setErrorMessage(INVITE_CODE_ERROR_MESSAGE);
+    }, 800); // TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. 추후에 api로 교체하면 loading 상태일 때의 동작을 하게 돼요
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (isVerifying) return;
+
+    const nextCode = event.target.value
+      .toUpperCase()
+      .slice(0, INVITE_CODE_LENGTH);
+
+    setInputCode(nextCode);
+    setErrorMessage(undefined);
+
+    if (nextCode.length === INVITE_CODE_LENGTH) verify(nextCode);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return {
+    inputCode,
+    isVerifying,
+    errorMessage,
+    handleChange,
+  };
+};

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -21,7 +21,7 @@ export const useWorkspaceCode = () => {
     callback: () => {
       // TODO(#243): API 응답의 workspaceId로 교체
       const TEMP_WORKSPACE_ID = "temp";
-      navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+      navigateToWorkspaceJoin({ workspaceId: TEMP_WORKSPACE_ID });
     },
   });
 

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -15,7 +15,7 @@ export const useWorkspaceCode = () => {
 
   const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
 
-  /** 검증을 통과하면 1초 동안 성공 상태를 보여준 뒤 입장 확인 화면으로 이동. */
+  /** 검증을 통과하면 1.5초 동안 성공 상태를 보여준 뒤 입장 확인 화면으로 이동. */
   const { isTimedOut: isVerified, start: showSuccess } = useTimeout({
     timeout: SUCCESS_DISPLAY_MS,
     callback: () => {

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/model/useWorkspaceCode.ts
@@ -1,17 +1,29 @@
+import useTimeout from "@hooks/common/useTimeout";
 import useNavigateToWorkspaceJoin from "@hooks/domain/workspace/useNavigateToWorkspaceJoin";
-import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useState } from "react";
 
 import { INVITE_CODE_LENGTH } from "../constants/inviteCode";
 
+// TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. 추후에 api로 교체하면 loading 상태일 때의 동작을 하게 돼요
+const VERIFY_DELAY_MS = 800;
+/** 검증을 통과한 뒤 성공 상태를 보여주는 시간. 지나면 입장 확인 화면으로 이동해요. */
+const SUCCESS_DISPLAY_MS = 1500;
+
 export const useWorkspaceCode = () => {
   const [inputCode, setInputCode] = useState("");
-  const [isVerifying, setIsVerifying] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
 
-  // TODO: query 훅으로 수정하기
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
+
+  /** 검증을 통과하면 1초 동안 성공 상태를 보여준 뒤 입장 확인 화면으로 이동. */
+  const { isTimedOut: isVerified, start: showSuccess } = useTimeout({
+    timeout: SUCCESS_DISPLAY_MS,
+    callback: () => {
+      // TODO(#243): API 응답의 workspaceId로 교체
+      const TEMP_WORKSPACE_ID = "temp";
+      navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+    },
+  });
 
   /**
    * 6자를 채우면 별도 트리거 없이 호출되는 임시 검증.
@@ -19,17 +31,12 @@ export const useWorkspaceCode = () => {
    * TODO(#243): 미리보기 API(`GET /invitations/{tokenOrCode}`)가 붙으면
    * 아래 지연·형식 검사를 쿼리 호출로 바꾸고 응답의 workspaceId로 이동해요.
    */
-  const verify = (value: string) => {
-    setIsVerifying(true);
-
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null;
-      setIsVerifying(false);
-
-      // TODO(#243): API 응답의 workspaceId로 교체
-      if (value === "000000") {
-        const TEMP_WORKSPACE_ID = "temp";
-        navigateToWorkspaceJoin(TEMP_WORKSPACE_ID);
+  const { isTimedOut: isVerifying, start: verify } = useTimeout({
+    timeout: VERIFY_DELAY_MS,
+    callback: () => {
+      // 임시로 000000을 통과 코드로 설정
+      if (inputCode === "000000") {
+        showSuccess();
         return;
       }
 
@@ -37,11 +44,11 @@ export const useWorkspaceCode = () => {
         "올바르지 않은 코드예요. 다시 확인해 주세요.";
 
       setErrorMessage(INVITE_CODE_ERROR_MESSAGE);
-    }, 800); // TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. 추후에 api로 교체하면 loading 상태일 때의 동작을 하게 돼요
-  };
+    },
+  });
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (isVerifying) return;
+    if (isVerifying || isVerified) return;
 
     const nextCode = event.target.value
       .toUpperCase()
@@ -50,18 +57,13 @@ export const useWorkspaceCode = () => {
     setInputCode(nextCode);
     setErrorMessage(undefined);
 
-    if (nextCode.length === INVITE_CODE_LENGTH) verify(nextCode);
+    if (nextCode.length === INVITE_CODE_LENGTH) verify();
   };
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
-    };
-  }, []);
 
   return {
     inputCode,
     isVerifying,
+    isVerified,
     errorMessage,
     handleChange,
   };

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
@@ -1,0 +1,141 @@
+import { ThemeProvider } from "@emotion/react";
+import { theme } from "@provider/themeProvider";
+import { PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceCodeCard from ".";
+
+const ERROR_MESSAGE = "올바르지 않은 코드예요. 다시 확인해 주세요.";
+const ELSEWHERE_PATH = "/elsewhere";
+// TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
+const VALID_CODE = "000000";
+const INVALID_CODE = "X35D3@";
+
+const renderCard = () => {
+  const router = createMemoryRouter(
+    [
+      { path: PATH_ROUTE.WORKSPACE_CODE, element: <WorkspaceCodeCard /> },
+      { path: PATH_ROUTE.WORKSPACE_JOIN, element: <p>입장 확인</p> },
+      { path: ELSEWHERE_PATH, element: <p>다른 화면</p> },
+    ],
+    { initialEntries: [PATH_ROUTE.WORKSPACE_CODE] },
+  );
+
+  render(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  );
+
+  const input = screen.getByRole("textbox", { name: "참여 코드" });
+
+  return { router, input };
+};
+
+const typeCode = (input: HTMLElement, value: string) => {
+  fireEvent.change(input, { target: { value } });
+};
+
+const finishVerification = async () => {
+  await act(async () => {
+    vi.runAllTimers();
+  });
+};
+
+describe("WorkspaceCodeCard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("6자를 채우면 입력을 잠그고 스피너를 보여준다", () => {
+    const { input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "true");
+    expect(
+      input.parentElement?.querySelector('[aria-hidden="true"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("지연 뒤 유효한 코드면 임시 workspaceId로 입장 확인 화면에 이동한다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("지연 뒤 유효하지 않은 코드면 에러 문구를 보여주고 입력 잠금을 푼다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, INVALID_CODE);
+    await finishVerification();
+
+    expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).not.toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "false");
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+  });
+
+  it("에러 상태에서 값을 고치면 에러가 사라진다", async () => {
+    const { input } = renderCard();
+
+    typeCode(input, INVALID_CODE);
+    await finishVerification();
+    typeCode(input, "X35D3");
+
+    expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("에러를 고쳐 다시 6자를 채우면 재검증한다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, INVALID_CODE);
+    await finishVerification();
+    typeCode(input, "X35D3");
+    typeCode(input, VALID_CODE);
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("7자째 입력은 막힌다", () => {
+    const { input } = renderCard();
+
+    typeCode(input, "X35D3S7");
+
+    expect(input).toHaveAttribute("maxlength", "6");
+    expect(input).toHaveValue("X35D3S");
+  });
+
+  it("소문자를 입력하면 대문자로 표시한다", () => {
+    const { input } = renderCard();
+
+    typeCode(input, "x35d");
+
+    expect(input).toHaveValue("X35D");
+  });
+
+  it("로딩 중 페이지를 벗어나면 이동을 실행하지 않는다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await act(async () => {
+      await router.navigate(ELSEWHERE_PATH);
+    });
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
+  });
+});

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
@@ -11,7 +11,7 @@ const ERROR_MESSAGE = "올바르지 않은 코드예요. 다시 확인해 주세
 const SUCCESS_MESSAGE = "확인됐어요. 곧 다음 단계로 이동해요.";
 const ELSEWHERE_PATH = "/elsewhere";
 const VERIFY_DELAY_MS = 800;
-const SUCCESS_DELAY_MS = 1000;
+const SUCCESS_DELAY_MS = 1500;
 // TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
 const VALID_CODE = "000000";
 const INVALID_CODE = "X35D3@";
@@ -149,7 +149,7 @@ describe("WorkspaceCodeCard", () => {
     expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
   });
 
-  it("성공 메시지를 1초 동안 보여준 뒤 입장 확인 화면으로 이동한다", async () => {
+  it("성공 메시지를 1.5초 동안 보여준 뒤 입장 확인 화면으로 이동한다", async () => {
     const { router, input } = renderCard();
 
     typeCode(input, VALID_CODE);

--- a/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceCodeCard/test.tsx
@@ -8,7 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkspaceCodeCard from ".";
 
 const ERROR_MESSAGE = "올바르지 않은 코드예요. 다시 확인해 주세요.";
+const SUCCESS_MESSAGE = "확인됐어요. 곧 다음 단계로 이동해요.";
 const ELSEWHERE_PATH = "/elsewhere";
+const VERIFY_DELAY_MS = 800;
+const SUCCESS_DELAY_MS = 1000;
 // TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
 const VALID_CODE = "000000";
 const INVALID_CODE = "X35D3@";
@@ -41,6 +44,12 @@ const typeCode = (input: HTMLElement, value: string) => {
 const finishVerification = async () => {
   await act(async () => {
     vi.runAllTimers();
+  });
+};
+
+const advanceTimers = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
   });
 };
 
@@ -125,6 +134,46 @@ describe("WorkspaceCodeCard", () => {
     typeCode(input, "x35d");
 
     expect(input).toHaveValue("X35D");
+  });
+
+  it("유효한 코드면 검증이 끝난 뒤 성공 메시지와 체크 표시를 보여주고 입력은 잠근 채 둔다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await advanceTimers(VERIFY_DELAY_MS);
+
+    expect(screen.getByText(SUCCESS_MESSAGE)).toBeInTheDocument();
+    expect(input.parentElement?.querySelector("svg")).toBeInTheDocument();
+    expect(input).toHaveAttribute("readonly");
+    expect(input).toHaveAttribute("aria-busy", "false");
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+  });
+
+  it("성공 메시지를 1초 동안 보여준 뒤 입장 확인 화면으로 이동한다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await advanceTimers(VERIFY_DELAY_MS);
+    await advanceTimers(SUCCESS_DELAY_MS - 1);
+
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+
+    await advanceTimers(1);
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("성공 메시지를 보여주는 동안 페이지를 벗어나면 이동을 실행하지 않는다", async () => {
+    const { router, input } = renderCard();
+
+    typeCode(input, VALID_CODE);
+    await advanceTimers(VERIFY_DELAY_MS);
+    await act(async () => {
+      await router.navigate(ELSEWHERE_PATH);
+    });
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
   });
 
   it("로딩 중 페이지를 벗어나면 이동을 실행하지 않는다", async () => {

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/model/useWorkspaceInvite.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/model/useWorkspaceInvite.ts
@@ -22,7 +22,9 @@ export const useWorkspaceInvite = () => {
 
   // TODO(#229): 초대 API 연결 후 응답의 참여 코드로 교체
   const inviteCode = "X35D3S";
-  const { displayInviteLink, inviteLink } = getInviteLink(inviteCode);
+  // TODO(#229): 초대 API 연결 후 응답의 linkToken으로 교체. 링크 진입 게이트의 임시 통과 토큰과 같은 값이에요
+  const linkToken = "Xk3vQ9mZp2LrT7wB1nHc4A";
+  const { displayInviteLink, inviteLink } = getInviteLink(linkToken);
 
   const handleCopyCode = () => {
     copy({

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/utils/getInviteLink.test.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/utils/getInviteLink.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getInviteLink } from "./getInviteLink";
+
+describe("getInviteLink", () => {
+  it("linkToken을 /invite/<linkToken> 진입 경로에 넣어 origin이 붙은 링크와 표시용 경로를 만든다", () => {
+    const linkToken = "Xk3vQ9mZp2LrT7wB1nHc4A";
+
+    const { inviteLink, displayInviteLink } = getInviteLink(linkToken);
+
+    expect(displayInviteLink).toBe(`/invite/${linkToken}`);
+    expect(inviteLink).toBe(`${window.location.origin}/invite/${linkToken}`);
+  });
+
+  it("URL에 그대로 쓸 수 없는 문자는 인코딩한다", () => {
+    const linkToken = "a/b c?d#e";
+
+    const { inviteLink, displayInviteLink } = getInviteLink(linkToken);
+
+    expect(displayInviteLink).toBe(`/invite/${encodeURIComponent(linkToken)}`);
+    expect(inviteLink).toBe(
+      `${window.location.origin}/invite/${encodeURIComponent(linkToken)}`,
+    );
+  });
+});

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/utils/getInviteLink.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteCard/utils/getInviteLink.ts
@@ -1,12 +1,20 @@
-import { PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { getRouterPath } from "@routes/PATH_ROUTE";
 
 /**
- * 참여 코드로 팀원에게 보낼 초대 링크를 만들어요.
+ * linkToken으로 팀원에게 보낼 초대 링크를 만들어요.
  *
- * 링크를 열면 초대 코드 입력 화면(`/workspace/code`)에 `?code=`가 채워진 채로 들어갑니다.
- * 이 형식은 UI 단계의 임시 결정이라, 초대 API를 붙일 때 BE linkToken 사용 여부와 함께 다시 정해요.
+ * 링크를 열면 초대 링크 진입 화면(`/invite/:token`)이 토큰을 판정한 뒤
+ * 입장 확인이나 초대 링크 오류 화면으로 보내요.
+ * 링크에는 BE 발급 응답의 `linkToken`만 넣고 6자 참여 코드는 노출하지 않아요.
  */
-export const getInviteLink = (code: string) => ({
-  displayInviteLink: `${PATH_ROUTE.WORKSPACE_CODE}?code=${encodeURIComponent(code)}`,
-  inviteLink: `${window.location.origin}${PATH_ROUTE.WORKSPACE_CODE}?code=${encodeURIComponent(code)}`,
-});
+export const getInviteLink = (linkToken: string) => {
+  const displayInviteLink = getRouterPath({
+    routeKey: "INVITE",
+    params: { token: linkToken },
+  });
+
+  return {
+    displayInviteLink,
+    inviteLink: `${window.location.origin}${displayInviteLink}`,
+  };
+};

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteLinkGate/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteLinkGate/index.tsx
@@ -1,0 +1,48 @@
+import styled from "@emotion/styled";
+import Spinner from "@primitives/ui/Spinner";
+
+import { useWorkspaceInviteLinkGate } from "./model/useWorkspaceInviteLinkGate";
+
+/**
+ * 초대 링크 진입 게이트.
+ *
+ * `/invite/:token`으로 들어온 사용자를 붙잡아 두고 토큰을 판정하는 동안 스피너만 보여줘요.
+ * 자기 화면은 없고, 판정이 끝나면 입장 확인(`/workspace/:workspaceId/join`)이나
+ * 초대 링크 오류(`/join-error`)로 `replace` 이동해 뒤로 가기 때 이 라우트로 되돌아오지 않게 합니다.
+ *
+ * 마운트되어 있는 동안은 곧 판정 중이므로 스피너를 조건 없이 그리고,
+ * 스크린리더에는 `role="status"` 안의 숨긴 문구로 확인 중임을 알려요.
+ *
+ * 미리보기 API(#243)가 아직 없어 짧은 지연 뒤 임시 linkToken과 비교하는 것으로 대신해요.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 위젯은 스피너 자리만 잡아요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10180 초대 링크로 워크스페이스 입장}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10148 올바르지 않은 초대 링크 접근}
+ */
+export default function WorkspaceInviteLinkGate() {
+  useWorkspaceInviteLinkGate();
+
+  return (
+    <Container role="status">
+      <Spinner />
+      <StatusText>초대 링크를 확인하고 있어요</StatusText>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  color: ${({ theme }) => theme.neutral[800]};
+`;
+
+/** 화면에서는 감추고 보조기기에만 읽히는 문구 */
+const StatusText = styled.span`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+`;

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteLinkGate/model/useWorkspaceInviteLinkGate.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteLinkGate/model/useWorkspaceInviteLinkGate.ts
@@ -1,0 +1,49 @@
+import useTimeout from "@hooks/common/useTimeout";
+import useNavigateToJoinError from "@hooks/domain/workspace/useNavigateToJoinError";
+import useNavigateToWorkspaceJoin from "@hooks/domain/workspace/useNavigateToWorkspaceJoin";
+import { useEffect } from "react";
+import { useParams } from "react-router";
+
+// TODO(#243): 미리보기 API 응답을 기다리는 로딩 상태를 흉내 내고 있어요. api로 교체하면 쿼리의 loading 상태가 이 자리를 대신해요
+const VERIFY_DELAY_MS = 800;
+// TODO(#243): #215 `useWorkspaceInvite`의 임시 linkToken과 같은 값이에요. 미리보기 API가 붙으면 이 비교 자체를 없애요
+const TEMP_VALID_LINK_TOKEN = "Xk3vQ9mZp2LrT7wB1nHc4A";
+// TODO(#243): API 응답의 workspaceId로 교체
+const TEMP_WORKSPACE_ID = "temp";
+
+/**
+ * 진입 직후 토큰을 한 번 판정하고 결과 화면으로 보내는 훅.
+ *
+ * 토큰은 BE 계약(ADR 243)대로 원문 그대로 비교하고 대문자 변환·공백 제거 같은 정규화를 하지 않아요.
+ * 통과·실패 모두 `replace`로 이동해 뒤로 가기 때 이 진입 라우트로 되돌아오지 않게 해요.
+ * 판정 중 페이지를 벗어나면 `useTimeout`이 타이머를 정리해 이동을 실행하지 않아요.
+ *
+ * TODO(#243): 미리보기 API(`GET /invitations/{tokenOrCode}`)가 붙으면
+ * 아래 지연·비교를 쿼리 호출로 바꾸고 응답의 workspaceId로 이동해요.
+ */
+export const useWorkspaceInviteLinkGate = () => {
+  const { token } = useParams();
+
+  const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
+  const { navigateToJoinError } = useNavigateToJoinError();
+
+  const { start: verify } = useTimeout({
+    timeout: VERIFY_DELAY_MS,
+    callback: () => {
+      if (token === TEMP_VALID_LINK_TOKEN) {
+        navigateToWorkspaceJoin({
+          workspaceId: TEMP_WORKSPACE_ID,
+          replace: true,
+        });
+        return;
+      }
+
+      navigateToJoinError({ replace: true });
+    },
+  });
+
+  // `verify`는 useTimeout이 useCallback으로 고정해 주므로 마운트 때 한 번만 실행돼요
+  useEffect(() => {
+    verify();
+  }, [verify]);
+};

--- a/frontend/src/modules/widgets/workspace/WorkspaceInviteLinkGate/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceInviteLinkGate/test.tsx
@@ -1,0 +1,134 @@
+import { ThemeProvider } from "@emotion/react";
+import { theme } from "@provider/themeProvider";
+import { getRouterPath, PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { act, render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import WorkspaceInviteLinkGate from ".";
+
+const ELSEWHERE_PATH = "/elsewhere";
+const VERIFY_DELAY_MS = 800;
+const STATUS_TEXT = "초대 링크를 확인하고 있어요";
+// TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
+const VALID_TOKEN = "Xk3vQ9mZp2LrT7wB1nHc4A";
+const INVALID_TOKEN = "Xk3vQ9mZp2LrT7wB1nHc4B";
+
+const renderGate = (token: string) => {
+  const invitePath = getRouterPath({ routeKey: "INVITE", params: { token } });
+  const router = createMemoryRouter(
+    [
+      { path: ELSEWHERE_PATH, element: <p>다른 화면</p> },
+      { path: PATH_ROUTE.INVITE, element: <WorkspaceInviteLinkGate /> },
+      { path: PATH_ROUTE.WORKSPACE_JOIN, element: <p>입장 확인</p> },
+      { path: PATH_ROUTE.JOIN_ERROR, element: <p>초대 링크 오류</p> },
+    ],
+    { initialEntries: [ELSEWHERE_PATH, invitePath], initialIndex: 1 },
+  );
+
+  render(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  );
+
+  return { router, invitePath };
+};
+
+const advanceTimers = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+const finishVerification = async () => {
+  await act(async () => {
+    vi.runAllTimers();
+  });
+};
+
+const goBack = async (router: ReturnType<typeof createMemoryRouter>) => {
+  await act(async () => {
+    await router.navigate(-1);
+  });
+};
+
+describe("WorkspaceInviteLinkGate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("판정 중에는 스피너와 확인 중 안내를 보여준다", () => {
+    const { router, invitePath } = renderGate(VALID_TOKEN);
+
+    const status = screen.getByRole("status");
+
+    expect(status).toHaveTextContent(STATUS_TEXT);
+    expect(status.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(invitePath);
+  });
+
+  it("지연 뒤 임시 linkToken과 같은 토큰이면 임시 workspaceId로 입장 확인 화면에 이동한다", async () => {
+    const { router, invitePath } = renderGate(VALID_TOKEN);
+
+    await advanceTimers(VERIFY_DELAY_MS - 1);
+
+    expect(router.state.location.pathname).toBe(invitePath);
+
+    await advanceTimers(1);
+
+    expect(router.state.location.pathname).toBe("/workspace/temp/join");
+  });
+
+  it("통과 이동은 replace라 뒤로 가기 때 진입 라우트로 돌아오지 않는다", async () => {
+    const { router } = renderGate(VALID_TOKEN);
+
+    await finishVerification();
+    await goBack(router);
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
+  });
+
+  it("지연 뒤 다른 토큰이면 초대 링크 오류 화면에 이동한다", async () => {
+    const { router } = renderGate(INVALID_TOKEN);
+
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.JOIN_ERROR);
+  });
+
+  it("실패 이동도 replace라 뒤로 가기 때 진입 라우트로 돌아오지 않는다", async () => {
+    const { router } = renderGate(INVALID_TOKEN);
+
+    await finishVerification();
+    await goBack(router);
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
+  });
+
+  it("대소문자만 다른 토큰은 정규화하지 않고 실패로 판정한다", async () => {
+    const lowerCasedToken = VALID_TOKEN.toLowerCase();
+    expect(lowerCasedToken).not.toBe(VALID_TOKEN);
+
+    const { router } = renderGate(lowerCasedToken);
+
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.JOIN_ERROR);
+  });
+
+  it("판정 중 페이지를 벗어나면 이동을 실행하지 않는다", async () => {
+    const { router } = renderGate(VALID_TOKEN);
+
+    await act(async () => {
+      await router.navigate(ELSEWHERE_PATH);
+    });
+    await finishVerification();
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
+  });
+});

--- a/frontend/src/modules/widgets/workspace/WorkspaceJoinCard/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceJoinCard/index.tsx
@@ -1,0 +1,79 @@
+import styled from "@emotion/styled";
+import Button from "@primitives/ui/Button";
+
+import EnterWorkspaceIllustration from "@/assets/illustrations/enterWorkspace.svg";
+
+import { useWorkspaceJoin } from "./model/useWorkspaceJoin";
+
+/**
+ * 워크스페이스 입장 확인 카드.
+ *
+ * 초대 코드를 입력했거나 초대 링크를 타고 온 사용자에게 어느 워크스페이스에 합류하는지 보여주고,
+ * `참여할게요`를 누르면 현재 `:workspaceId`의 워크스페이스 홈(`/workspace/:workspaceId`)으로 이동해요.
+ *
+ * 미리보기 API(#243)가 아직 없어 워크스페이스 이름은 임시 상수이고,
+ * 참여 API(#244)도 호출하지 않은 채 이동만 합니다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10180 초대 링크로 워크스페이스 입장}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10176 초대 코드 입력/워크스페이스 입장}
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=443-801 Card/Onboarding & Workspace}
+ */
+export default function WorkspaceJoinCard() {
+  const { workspaceName, handleJoin } = useWorkspaceJoin();
+
+  return (
+    <Container>
+      <Illustration />
+
+      <Header>
+        <Title>{workspaceName}</Title>
+        <Description>초대를 수락하면 함께 기록할 수 있어요</Description>
+      </Header>
+
+      <Button size="lg" isFullWidth onClick={handleJoin}>
+        참여할게요
+      </Button>
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem; /* 28px */
+  width: 100%;
+  max-width: 28.75rem; /* 460px */
+  padding: 3rem; /* 48px */
+  border-radius: 1.5rem; /* 24px */
+  background-color: ${({ theme }) => theme.neutral[0]};
+  box-shadow: ${({ theme }) => theme.shadow02};
+`;
+
+const Illustration = styled(EnterWorkspaceIllustration)`
+  flex-shrink: 0;
+  width: 3rem; /* 48px */
+  height: 3rem;
+  color: ${({ theme }) => theme.neutral[800]};
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem; /* 12px */
+  text-align: center;
+  overflow-wrap: break-word;
+`;
+
+const Title = styled.h1`
+  color: ${({ theme }) => theme.neutral[900]};
+  ${({ theme }) => theme.text.heading02};
+`;
+
+const Description = styled.p`
+  color: ${({ theme }) => theme.neutral[600]};
+  ${({ theme }) => theme.text.body01};
+`;

--- a/frontend/src/modules/widgets/workspace/WorkspaceJoinCard/model/useWorkspaceJoin.ts
+++ b/frontend/src/modules/widgets/workspace/WorkspaceJoinCard/model/useWorkspaceJoin.ts
@@ -1,0 +1,22 @@
+import useNavigateToWorkspaceHome from "@hooks/domain/workspace/useNavigateToWorkspaceHome";
+import { useParams } from "react-router";
+
+// TODO(#243): 미리보기 API 응답의 워크스페이스 이름으로 교체
+const TEMP_WORKSPACE_NAME = "노티드의 워크스페이스";
+
+export const useWorkspaceJoin = () => {
+  const { workspaceId } = useParams();
+
+  const { navigateToWorkspaceHome } = useNavigateToWorkspaceHome();
+
+  const workspaceName = TEMP_WORKSPACE_NAME;
+
+  /** TODO(#244): 참여 API를 호출해 성공한 뒤 이동하도록 바꿔요. 지금은 현재 `:workspaceId`로 바로 이동해요. */
+  const handleJoin = () => {
+    if (!workspaceId) return;
+
+    navigateToWorkspaceHome(workspaceId);
+  };
+
+  return { workspaceName, handleJoin };
+};

--- a/frontend/src/modules/widgets/workspace/WorkspaceJoinCard/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceJoinCard/test.tsx
@@ -1,0 +1,54 @@
+import { ThemeProvider } from "@emotion/react";
+import { theme } from "@provider/themeProvider";
+import { getRouterPath, PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import WorkspaceJoinCard from ".";
+
+const WORKSPACE_ID = "ws-1";
+// TODO(#243): 미리보기 API 연결 후 msw 응답으로 교체
+const TEMP_WORKSPACE_NAME = "노티드의 워크스페이스";
+const DESCRIPTION = "초대를 수락하면 함께 기록할 수 있어요";
+
+const renderCard = () => {
+  const joinPath = getRouterPath({
+    routeKey: "WORKSPACE_JOIN",
+    params: { workspaceId: WORKSPACE_ID },
+  });
+  const router = createMemoryRouter(
+    [
+      { path: PATH_ROUTE.WORKSPACE_JOIN, element: <WorkspaceJoinCard /> },
+      { path: PATH_ROUTE.WORKSPACE_HOME, element: <p>워크스페이스 홈</p> },
+    ],
+    { initialEntries: [joinPath] },
+  );
+
+  render(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  );
+
+  return { router };
+};
+
+describe("WorkspaceJoinCard", () => {
+  it("임시 워크스페이스 이름과 안내 문구를 보여준다", () => {
+    renderCard();
+
+    expect(
+      screen.getByRole("heading", { name: TEMP_WORKSPACE_NAME }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it("참여할게요를 누르면 현재 workspaceId의 워크스페이스 홈으로 이동한다", () => {
+    const { router } = renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "참여할게요" }));
+
+    expect(router.state.location.pathname).toBe(`/workspace/${WORKSPACE_ID}`);
+  });
+});

--- a/frontend/src/modules/widgets/workspace/WorkspaceJoinErrorNotice/index.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceJoinErrorNotice/index.tsx
@@ -1,0 +1,81 @@
+import styled from "@emotion/styled";
+import useNavigateToWorkspaceCode from "@hooks/domain/workspace/useNavigateToWorkspaceCode";
+import Button from "@primitives/ui/Button";
+
+import InvalidInvitationUrlIllustration from "@/assets/illustrations/invalidInvitationUrl.svg";
+
+/**
+ * 초대 링크 오류 안내.
+ *
+ * 만료되었거나 잘못된 초대 링크로 들어온 사용자에게 카드 없이 이유를 알리고,
+ * `초대 코드 직접 입력하기`로 초대 코드 입력(`/workspace/code`)에 이어 줘요.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 위젯은 로고 아래 내용만 그려요.
+ *
+ * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10148 올바르지 않은 초대 링크 접근}
+ */
+export default function WorkspaceJoinErrorNotice() {
+  const { navigateToWorkspaceCode } = useNavigateToWorkspaceCode();
+
+  return (
+    <Container>
+      <Content>
+        <Illustration />
+
+        <Header>
+          <Title>초대장을 열 수 없어요</Title>
+          <Description>
+            <p>만료되었거나 잘못된 링크예요.</p>
+            <p>초대한 분께 다시 요청해 보세요.</p>
+          </Description>
+        </Header>
+      </Content>
+
+      <Button size="lg" isFullWidth onClick={navigateToWorkspaceCode}>
+        초대 코드 직접 입력하기
+      </Button>
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem; /* 64px */
+  width: 100%;
+  max-width: 22.5rem; /* 360px */
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem; /* 40px */
+`;
+
+const Illustration = styled(InvalidInvitationUrlIllustration)`
+  flex-shrink: 0;
+  width: 3rem; /* 48px */
+  height: 3rem;
+  color: ${({ theme }) => theme.neutral[800]};
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem; /* 16px */
+  text-align: center;
+  overflow-wrap: break-word;
+`;
+
+const Title = styled.h1`
+  color: ${({ theme }) => theme.neutral[800]};
+  ${({ theme }) => theme.text.heading02};
+`;
+
+const Description = styled.div`
+  color: ${({ theme }) => theme.neutral[700]};
+  ${({ theme }) => theme.text.body02};
+`;

--- a/frontend/src/modules/widgets/workspace/WorkspaceJoinErrorNotice/test.tsx
+++ b/frontend/src/modules/widgets/workspace/WorkspaceJoinErrorNotice/test.tsx
@@ -1,0 +1,53 @@
+import { ThemeProvider } from "@emotion/react";
+import { theme } from "@provider/themeProvider";
+import { PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import WorkspaceJoinErrorNotice from ".";
+
+const TITLE = "초대장을 열 수 없어요";
+const DESCRIPTION_LINES = [
+  "만료되었거나 잘못된 링크예요.",
+  "초대한 분께 다시 요청해 보세요.",
+];
+
+const renderNotice = () => {
+  const router = createMemoryRouter(
+    [
+      { path: PATH_ROUTE.JOIN_ERROR, element: <WorkspaceJoinErrorNotice /> },
+      { path: PATH_ROUTE.WORKSPACE_CODE, element: <p>초대 코드 입력</p> },
+    ],
+    { initialEntries: [PATH_ROUTE.JOIN_ERROR] },
+  );
+
+  render(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>,
+  );
+
+  return { router };
+};
+
+describe("WorkspaceJoinErrorNotice", () => {
+  it("제목과 안내 문구 두 줄을 보여준다", () => {
+    renderNotice();
+
+    expect(screen.getByRole("heading", { name: TITLE })).toBeInTheDocument();
+    DESCRIPTION_LINES.forEach((line) => {
+      expect(screen.getByText(line)).toBeInTheDocument();
+    });
+  });
+
+  it("초대 코드 직접 입력하기를 누르면 초대 코드 입력 화면으로 이동한다", () => {
+    const { router } = renderNotice();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "초대 코드 직접 입력하기" }),
+    );
+
+    expect(router.state.location.pathname).toBe(PATH_ROUTE.WORKSPACE_CODE);
+  });
+});

--- a/frontend/src/pages/invite/[token]/index.tsx
+++ b/frontend/src/pages/invite/[token]/index.tsx
@@ -1,0 +1,18 @@
+import WorkspaceInviteLinkGate from "@widgets/workspace/WorkspaceInviteLinkGate";
+
+/**
+ * 초대 링크 진입 화면 (`/invite/:token`)
+ *
+ * 팀원이 공유한 초대 링크(`origin/invite/<linkToken>`)를 열었을 때 가장 먼저 닿는 화면이다.
+ * 자체 UI 없이 토큰을 판정하는 동안 스피너만 보여주고,
+ * 통과하면 워크스페이스 입장 확인(`/workspace/:workspaceId/join`)으로,
+ * 만료·잘못된 링크면 초대 링크 오류(`/join-error`)로 `replace` 이동해 뒤로 가기 때 이 화면으로 돌아오지 않는다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 위젯을 놓기만 한다.
+ *
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10180 초대 링크로 워크스페이스 입장
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10148 올바르지 않은 초대 링크 접근
+ */
+export default function InvitePage() {
+  return <WorkspaceInviteLinkGate />;
+}

--- a/frontend/src/pages/join-error/index.tsx
+++ b/frontend/src/pages/join-error/index.tsx
@@ -1,14 +1,16 @@
+import WorkspaceJoinErrorNotice from "@widgets/workspace/WorkspaceJoinErrorNotice";
+
 /**
  * 초대 링크 오류 화면 (`/join-error`)
  *
  * 만료되었거나 잘못된 초대 링크로 접근했을 때 보여주는 화면이다.
+ * 초대 링크 진입(`/invite/:token`)에서 판정에 실패하면 이 화면으로 오고,
+ * 초대 코드 직접 입력(`/workspace/code`)으로 이어진다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 안내를 놓기만 한다.
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10148
  */
 export default function JoinErrorPage() {
-  return (
-    <div>
-      <h1>Join Error Page</h1>
-    </div>
-  );
+  return <WorkspaceJoinErrorNotice />;
 }

--- a/frontend/src/pages/workspace/[workspaceId]/join/index.tsx
+++ b/frontend/src/pages/workspace/[workspaceId]/join/index.tsx
@@ -1,18 +1,18 @@
+import WorkspaceJoinCard from "@widgets/workspace/WorkspaceJoinCard";
+
 /**
  * 워크스페이스 입장 확인 화면 (`/workspace/:workspaceId/join`)
  *
- * 초대 코드를 입력했거나 초대 링크를 타고 들어온 사용자에게 어느 워크스페이스에
- * 합류하는지 확인시키는 화면이다.
- * 수락하면 워크스페이스 홈(`/workspace/:workspaceId`)으로 이동하고,
- * 링크가 만료·손상된 경우에는 초대 링크 오류(`/join-error`)로 빠진다.
+ * 초대 코드를 입력했거나 초대 링크(`/invite/:token`)를 타고 들어온 사용자에게
+ * 어느 워크스페이스에 합류하는지 확인시키는 화면이다.
+ * 수락하면 워크스페이스 홈(`/workspace/:workspaceId`)으로 이동한다.
+ * 링크가 만료·손상된 경우는 이 화면에 오기 전에 링크 진입 화면이 초대 링크 오류(`/join-error`)로 보낸다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10176 초대 코드 입력/워크스페이스 입장
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10180 초대 링크로 워크스페이스 입장
  */
 export default function WorkspaceJoinPage() {
-  return (
-    <div>
-      <h1>Workspace Join Page</h1>
-    </div>
-  );
+  return <WorkspaceJoinCard />;
 }

--- a/frontend/src/pages/workspace/code/index.tsx
+++ b/frontend/src/pages/workspace/code/index.tsx
@@ -1,19 +1,20 @@
+import WorkspaceCodeCard from "@widgets/workspace/WorkspaceCodeCard";
+
 /**
  * 초대 코드 입력 화면 (`/workspace/code`)
  *
  * 팀에서 전달받은 참여 코드를 입력해 워크스페이스를 찾는 화면이다.
- * 입력 전 / 입력 에러(만료·오타 등 유효하지 않은 코드) 상태를 한 화면에서 다룬다.
+ * 입력 전 / 로딩 / 입력 에러(만료·오타 등 유효하지 않은 코드) 상태를 한 화면에서 다룬다.
  * 코드가 유효하면 워크스페이스 입장 확인(`/workspace/:workspaceId/join`)으로 이동한다.
  *
- * 초대 링크로 들어오는 경우에도 `?code=` 쿼리를 달고 이 화면으로 진입한다.
+ * 초대 링크(`?code=` 쿼리 등)로 들어오는 진입은 이 화면의 범위가 아니며,
+ * 링크 형식과 함께 링크 입장 페이지 Issue(#192 하위)에서 다룬다.
+ *
+ * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10168 초대 코드 입력
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10172 초대 코드 입력/입력 에러
  */
 export default function WorkspaceCodePage() {
-  return (
-    <div>
-      <h1>Workspace Code Page</h1>
-    </div>
-  );
+  return <WorkspaceCodeCard />;
 }

--- a/frontend/src/pages/workspace/code/index.tsx
+++ b/frontend/src/pages/workspace/code/index.tsx
@@ -7,8 +7,7 @@ import WorkspaceCodeCard from "@widgets/workspace/WorkspaceCodeCard";
  * 입력 전 / 로딩 / 입력 에러(만료·오타 등 유효하지 않은 코드) 상태를 한 화면에서 다룬다.
  * 코드가 유효하면 워크스페이스 입장 확인(`/workspace/:workspaceId/join`)으로 이동한다.
  *
- * 초대 링크(`?code=` 쿼리 등)로 들어오는 진입은 이 화면의 범위가 아니며,
- * 링크 형식과 함께 링크 입장 페이지 Issue(#192 하위)에서 다룬다.
+ * 초대 링크로 들어오는 진입은 이 화면이 아니라 링크 진입 라우트(`/invite/:token`)가 맡는다.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *

--- a/frontend/src/shared/components/primitives/ui/TextField/index.tsx
+++ b/frontend/src/shared/components/primitives/ui/TextField/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import Input from "@primitives/ui/Input";
+import Input, { type InputVariant } from "@primitives/ui/Input";
 import type { InputHTMLAttributes } from "react";
 import { useId } from "react";
 
@@ -8,7 +8,10 @@ interface TextFieldProps extends Omit<
   "value"
 > {
   value: string;
+  variant?: InputVariant;
   errorMessage?: string;
+  /** 우측에 표시할 컴포넌트 */
+  rightComponent?: React.ReactNode;
 }
 
 /**
@@ -25,10 +28,14 @@ interface TextFieldProps extends Omit<
  *
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=424-596 Field/TextField 컴포넌트 세트
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1325 status=입력 에러 (에러 메시지 포함)
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=627-2967 Field/TextField/Code status=로딩 (`isLoading`)
  */
 export default function TextField({
   value,
+  variant,
   errorMessage,
+  rightComponent,
+  readOnly = false,
   id,
   ...props
 }: TextFieldProps) {
@@ -39,13 +46,20 @@ export default function TextField({
 
   return (
     <Container>
-      <Input
-        id={inputId}
-        value={value}
-        status={isError ? "error" : value.length > 0 ? "filled" : "empty"}
-        aria-describedby={isError ? errorMessageId : undefined}
-        {...props}
-      />
+      <InputWrapper>
+        <Input
+          id={inputId}
+          value={value}
+          variant={variant}
+          status={isError ? "error" : value.length > 0 ? "filled" : "empty"}
+          readOnly={readOnly}
+          aria-describedby={isError ? errorMessageId : undefined}
+          {...props}
+        />
+        {rightComponent && (
+          <RightComponentWrapper>{rightComponent}</RightComponentWrapper>
+        )}
+      </InputWrapper>
       {isError && (
         <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
       )}
@@ -58,6 +72,23 @@ const Container = styled.div`
   flex-direction: column;
   gap: 0.5rem;
   width: 100%;
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const RightComponentWrapper = styled.span`
+  position: absolute;
+  top: 0;
+  right: 0.9375rem; /* 15px */
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  color: ${({ theme }) => theme.neutral[500]};
 `;
 
 const ErrorMessage = styled.p`

--- a/frontend/src/shared/components/primitives/ui/TextField/index.tsx
+++ b/frontend/src/shared/components/primitives/ui/TextField/index.tsx
@@ -10,9 +10,23 @@ interface TextFieldProps extends Omit<
   value: string;
   variant?: InputVariant;
   errorMessage?: string;
+  /** 검증을 통과했을 때 아래에 보여줄 메시지. `errorMessage`가 있으면 에러가 우선해요 */
+  successMessage?: string;
   /** 우측에 표시할 컴포넌트 */
   rightComponent?: React.ReactNode;
 }
+
+interface GetStatusParams {
+  isError: boolean;
+  isSuccess: boolean;
+  value: string;
+}
+
+const getStatus = ({ isError, isSuccess, value }: GetStatusParams) => {
+  if (isError) return "error";
+  if (isSuccess) return "success";
+  return value.length > 0 ? "filled" : "empty";
+};
 
 /**
  * 에러 메시지까지 함께 다루는 입력 필드.
@@ -21,7 +35,8 @@ interface TextFieldProps extends Omit<
  * `Input`은 상태 판단 없이 받은 status만 그려요.
  *
  * `errorMessage`를 넘기면 입력창이 에러 스타일로 바뀌면서 아래에 메시지가 생기고,
- * 그 메시지는 `aria-describedby`로 입력창과 연결돼요.
+ * `successMessage`를 넘기면 성공 스타일로 바뀌면서 아래에 메시지가 생겨요.
+ * 둘 다 있으면 에러가 우선하고, 보이는 메시지는 `aria-describedby`로 입력창과 연결돼요.
  *
  * `id`를 직접 넘기지 않으면 `useId`로 만든 값을 쓰므로,
  * 외부 `label`과 연결해야 할 때만 `id`를 넘기면 돼요.
@@ -29,11 +44,13 @@ interface TextFieldProps extends Omit<
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=424-596 Field/TextField 컴포넌트 세트
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1325 status=입력 에러 (에러 메시지 포함)
  * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=627-2967 Field/TextField/Code status=로딩 (`isLoading`)
+ * @see https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=664-552 Field/TextField/Code status=인증 완료 (`successMessage`)
  */
 export default function TextField({
   value,
   variant,
   errorMessage,
+  successMessage,
   rightComponent,
   readOnly = false,
   id,
@@ -41,8 +58,10 @@ export default function TextField({
 }: TextFieldProps) {
   const generatedId = useId();
   const inputId = id ?? generatedId;
-  const errorMessageId = `${inputId}-error`;
+  const messageId = `${inputId}-message`;
   const isError = Boolean(errorMessage);
+  const isSuccess = !isError && Boolean(successMessage);
+  const hasMessage = isError || isSuccess;
 
   return (
     <Container>
@@ -51,17 +70,18 @@ export default function TextField({
           id={inputId}
           value={value}
           variant={variant}
-          status={isError ? "error" : value.length > 0 ? "filled" : "empty"}
+          status={getStatus({ isError, isSuccess, value })}
           readOnly={readOnly}
-          aria-describedby={isError ? errorMessageId : undefined}
+          aria-describedby={hasMessage ? messageId : undefined}
           {...props}
         />
         {rightComponent && (
           <RightComponentWrapper>{rightComponent}</RightComponentWrapper>
         )}
       </InputWrapper>
-      {isError && (
-        <ErrorMessage id={errorMessageId}>{errorMessage}</ErrorMessage>
+      {isError && <ErrorMessage id={messageId}>{errorMessage}</ErrorMessage>}
+      {isSuccess && (
+        <SuccessMessage id={messageId}>{successMessage}</SuccessMessage>
       )}
     </Container>
   );
@@ -91,7 +111,14 @@ const RightComponentWrapper = styled.span`
   color: ${({ theme }) => theme.neutral[500]};
 `;
 
-const ErrorMessage = styled.p`
-  color: ${({ theme }) => theme.sub.warning[800]};
+const Message = styled.p`
   ${({ theme }) => theme.text.caption02};
+`;
+
+const ErrorMessage = styled(Message)`
+  color: ${({ theme }) => theme.sub.warning[800]};
+`;
+
+const SuccessMessage = styled(Message)`
+  color: ${({ theme }) => theme.sub.accent[500]};
 `;

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToJoinError/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToJoinError/index.ts
@@ -1,0 +1,24 @@
+import { PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { useNavigate } from "react-router";
+
+interface NavigateToJoinErrorParams {
+  /** `true`면 현재 히스토리 항목을 대체해 뒤로 가기 때 지금 화면으로 돌아오지 않아요. */
+  replace?: boolean;
+}
+
+/**
+ * 초대 링크 오류 화면(`/join-error`)으로 이동하는 도메인 훅.
+ */
+const useNavigateToJoinError = () => {
+  const navigate = useNavigate();
+
+  const navigateToJoinError = ({
+    replace = false,
+  }: NavigateToJoinErrorParams = {}) => {
+    navigate(PATH_ROUTE.JOIN_ERROR, { replace });
+  };
+
+  return { navigateToJoinError };
+};
+
+export default useNavigateToJoinError;

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceHome/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceHome/index.ts
@@ -1,0 +1,19 @@
+import { getRouterPath } from "@routes/PATH_ROUTE";
+import { useNavigate } from "react-router";
+
+/**
+ * 워크스페이스 홈 화면(`/workspace/:workspaceId`)으로 이동하는 도메인 훅.
+ */
+const useNavigateToWorkspaceHome = () => {
+  const navigate = useNavigate();
+
+  const navigateToWorkspaceHome = (workspaceId: string) => {
+    navigate(
+      getRouterPath({ routeKey: "WORKSPACE_HOME", params: { workspaceId } }),
+    );
+  };
+
+  return { navigateToWorkspaceHome };
+};
+
+export default useNavigateToWorkspaceHome;

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceJoin/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceJoin/index.ts
@@ -1,0 +1,19 @@
+import { getRouterPath } from "@routes/PATH_ROUTE";
+import { useNavigate } from "react-router";
+
+/**
+ * 워크스페이스 입장 확인 화면(`/workspace/:workspaceId/join`)으로 이동하는 도메인 훅.
+ */
+const useNavigateToWorkspaceJoin = () => {
+  const navigate = useNavigate();
+
+  const navigateToWorkspaceJoin = (workspaceId: string) => {
+    navigate(
+      getRouterPath({ routeKey: "WORKSPACE_JOIN", params: { workspaceId } }),
+    );
+  };
+
+  return { navigateToWorkspaceJoin };
+};
+
+export default useNavigateToWorkspaceJoin;

--- a/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceJoin/index.ts
+++ b/frontend/src/shared/hooks/domain/workspace/useNavigateToWorkspaceJoin/index.ts
@@ -1,15 +1,25 @@
 import { getRouterPath } from "@routes/PATH_ROUTE";
 import { useNavigate } from "react-router";
 
+interface NavigateToWorkspaceJoinParams {
+  workspaceId: string;
+  /** `true`면 현재 히스토리 항목을 대체해 뒤로 가기 때 지금 화면으로 돌아오지 않아요. */
+  replace?: boolean;
+}
+
 /**
  * 워크스페이스 입장 확인 화면(`/workspace/:workspaceId/join`)으로 이동하는 도메인 훅.
  */
 const useNavigateToWorkspaceJoin = () => {
   const navigate = useNavigate();
 
-  const navigateToWorkspaceJoin = (workspaceId: string) => {
+  const navigateToWorkspaceJoin = ({
+    workspaceId,
+    replace = false,
+  }: NavigateToWorkspaceJoinParams) => {
     navigate(
       getRouterPath({ routeKey: "WORKSPACE_JOIN", params: { workspaceId } }),
+      { replace },
     );
   };
 

--- a/frontend/src/shared/routes/PATH_ROUTE.ts
+++ b/frontend/src/shared/routes/PATH_ROUTE.ts
@@ -19,6 +19,8 @@ export const PATH_ROUTE = {
   CHAT: "/workspace/:workspaceId/chat",
   CHAT_SESSION: "/workspace/:workspaceId/chat/:sessionId",
 
+  INVITE: "/invite/:token",
+
   JOIN_ERROR: "/join-error",
 } as const;
 

--- a/frontend/src/shared/routes/routes.tsx
+++ b/frontend/src/shared/routes/routes.tsx
@@ -1,6 +1,7 @@
 import CenteredLayout from "@pages/_layout/CenteredLayout";
 import ChatLayout from "@pages/_layout/ChatLayout";
 import WorkspaceLayout from "@pages/_layout/WorkspaceLayout";
+import InvitePage from "@pages/invite/[token]";
 import JoinErrorPage from "@pages/join-error";
 import LoginPage from "@pages/login";
 import OnboardingPage from "@pages/onboarding";
@@ -54,6 +55,10 @@ export const router = createBrowserRouter([
       {
         path: PATH_ROUTE.WORKSPACE_CODE,
         element: <WorkspaceCodePage />,
+      },
+      {
+        path: PATH_ROUTE.INVITE,
+        element: <InvitePage />,
       },
       {
         path: PATH_ROUTE.WORKSPACE_JOIN,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -46,6 +46,6 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "src/**/test.{ts,tsx}"],
   },
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
           focusable: "false",
           "aria-hidden": "true",
         },
+        // webpack 설정과 같이 size prop을 만들어요. 플러그인이 jsx로 변환하므로 타입 표기는 넣지 않아요
+        template: ({ componentName, jsx, exports }, { tpl }) => tpl`
+const ${componentName} = ({ size = 24, ...props }) => (
+  ${jsx}
+);
+
+${exports}
+`,
       },
     }),
   ],


### PR DESCRIPTION
## 관련 이슈

- #264

## 작업 내용

초대 링크를 받은 사용자가 `/invite/:token`으로 들어와 워크스페이스 입장 확인을 거쳐 워크스페이스 홈에 들어가고, 링크가 만료·잘못된 경우 초대 링크 오류 화면에서 코드 직접 입력으로 이어지는 플로우의 UI를 구현하였습니다.
FE에 api 계층과 로그인이 아직 없어 미리보기·참여 API(#243·#244) 연동은 후속 Issue로 분리하고, #204·#215·#258과 같이 임시 데이터로 화면·상태·이동까지만 다루었습니다.

```mermaid
flowchart LR
    Invite["/invite/:token<br/>WorkspaceInviteLinkGate"] -->|"토큰 통과 · replace"| Join["/workspace/:workspaceId/join<br/>WorkspaceJoinCard"]
    Invite -->|"토큰 실패 · replace"| Error["/join-error<br/>WorkspaceJoinErrorNotice"]
    Join -->|"참여할게요"| Home["/workspace/:workspaceId"]
    Error -->|"초대 코드 직접 입력하기"| Code["/workspace/code<br/>WorkspaceCodeCard"]
    Code -->|"코드 검증 통과"| Join
```

### 초대 링크 진입 라우트와 `WorkspaceInviteLinkGate`

`PATH_ROUTE`에 `INVITE: "/invite/:token"`을 추가하고 `routes.tsx`의 `CenteredLayout` 그룹에 `pages/invite/[token]`을 등록하였습니다. 페이지는 위젯을 놓기만 하고, 토큰 판정과 이동은 `modules/widgets/workspace/WorkspaceInviteLinkGate`의 `model` 훅이 맡습니다.

게이트는 자기 화면이 없습니다. 마운트되어 있는 동안은 곧 판정 중이므로 `Spinner`를 조건 없이 그리고, 스크린리더에는 `role="status"` 안의 숨긴 문구로 확인 중임을 알립니다.

```ts
export const useWorkspaceInviteLinkGate = () => {
  const { token } = useParams();
  const { navigateToWorkspaceJoin } = useNavigateToWorkspaceJoin();
  const { navigateToJoinError } = useNavigateToJoinError();

  const { start: verify } = useTimeout({
    timeout: VERIFY_DELAY_MS,
    callback: () => {
      if (token === TEMP_VALID_LINK_TOKEN) {
        navigateToWorkspaceJoin({ workspaceId: TEMP_WORKSPACE_ID, replace: true });
        return;
      }
      navigateToJoinError({ replace: true });
    },
  });

  useEffect(() => {
    verify();
  }, [verify]);
};
```

미리보기 API(#243)가 아직 없어 짧은 지연(800ms) 뒤 토큰이 #215의 임시 `linkToken` 상수와 같은지 비교하는 것으로 대신하였고, 지연·비교 코드는 `TODO(#243)` 주석과 함께 훅 상단 한곳에 모았습니다. 토큰은 BE 계약(ADR 243)대로 원문 그대로 비교하며 대문자 변환·공백 제거 같은 정규화를 하지 않습니다.

통과·실패 모두 `replace`로 이동해 뒤로 가기 때 진입 라우트로 되돌아오지 않게 하였고, 판정 중 페이지를 벗어나면 `useTimeout`이 타이머를 정리해 이동을 실행하지 않습니다.

### 워크스페이스 입장 확인 카드 `WorkspaceJoinCard`

`pages/workspace/[workspaceId]/join`의 placeholder를 Figma `초대 링크로 워크스페이스 입장`(node 600-10180)의 `Card/Onboarding & Workspace`대로 교체하였습니다. `enterWorkspace` 일러스트(48px), 워크스페이스 이름 제목, 안내 문구, 주 버튼 `참여할게요`(`Button` size `lg`)로 구성됩니다.

안내 문구는 코드 진입 프레임(600-10176)의 `함께할 수 있어요`가 아니라 `초대를 수락하면 함께 기록할 수 있어요`로 통일하였습니다. 워크스페이스 이름은 미리보기 API 응답 대신 `TODO(#243)` 임시 상수로 채우고, `참여할게요`를 누르면 참여 API(#244) 호출 없이 현재 `:workspaceId`로 워크스페이스 홈(`/workspace/:workspaceId`)에 이동합니다.

### 초대 링크 오류 안내 `WorkspaceJoinErrorNotice`

`pages/join-error`의 placeholder를 Figma `올바르지 않은 초대 링크 접근`(node 600-10148)대로 교체하였습니다. 카드 없이 `invalidInvitationUrl` 일러스트(48px), 제목 `초대장을 열 수 없어요`, 본문 두 줄, 주 버튼 `초대 코드 직접 입력하기`로 구성되며, 버튼을 누르면 기존 `useNavigateToWorkspaceCode`로 `/workspace/code`에 이동합니다.

### 이동 도메인 훅 추가·확장

`shared/hooks/domain/workspace`에 `useNavigateToJoinError`(`/join-error`)와 `useNavigateToWorkspaceHome`(`/workspace/:workspaceId`)을 추가하였습니다.

기존 `useNavigateToWorkspaceJoin`은 게이트에서 `replace` 이동이 필요하여 인자를 객체로 바꾸고 `replace` 옵션을 추가하였습니다. 기존 호출처(`useWorkspaceCode`)도 함께 맞추었습니다.

**Before**

```ts
const navigateToWorkspaceJoin = (workspaceId: string) => {
  navigate(getRouterPath({ routeKey: "WORKSPACE_JOIN", params: { workspaceId } }));
};
```

**After**

```ts
const navigateToWorkspaceJoin = ({
  workspaceId,
  replace = false,
}: NavigateToWorkspaceJoinParams) => {
  navigate(
    getRouterPath({ routeKey: "WORKSPACE_JOIN", params: { workspaceId } }),
    { replace },
  );
};
```

### 초대 링크 형식을 `/invite/<linkToken>`으로 변경

#215에서 임시로 두었던 `?code=` 형식의 초대 링크를 새 진입 라우트에 맞게 `window.location.origin + /invite/<linkToken>`으로 확정하였습니다. 링크에는 BE 발급 응답의 `linkToken` 자리만 두고 6자 참여 코드는 노출하지 않습니다.

**Before**

```ts
export const getInviteLink = (code: string) => ({
  displayInviteLink: `${PATH_ROUTE.WORKSPACE_CODE}?code=${encodeURIComponent(code)}`,
  inviteLink: `${window.location.origin}${PATH_ROUTE.WORKSPACE_CODE}?code=${encodeURIComponent(code)}`,
});
```

**After**

```ts
export const getInviteLink = (linkToken: string) => {
  const displayInviteLink = getRouterPath({
    routeKey: "INVITE",
    params: { token: linkToken },
  });

  return {
    displayInviteLink,
    inviteLink: `${window.location.origin}${displayInviteLink}`,
  };
};
```

경로 조립은 `getRouterPath`에 맡겨 인코딩과 라우트 정의를 한곳에서 관리하도록 하였습니다. `WorkspaceInviteCard`의 `useWorkspaceInvite`에는 임시 코드 상수 옆에 `TODO(#229)` 임시 `linkToken` 상수를 두어, 복사한 링크가 그대로 새 진입 라우트로 열리게 하였습니다. `pages/workspace/code` JSDoc의 링크 진입 설명도 `/invite/:token`을 가리키도록 고쳤습니다.

### 테스트

- `WorkspaceInviteLinkGate/test.tsx` (fake timers): 판정 중 스피너·안내 표시, 지연 직전까지 이동 없음, 통과 시 `/workspace/temp/join` 이동, 실패 시 `/join-error` 이동, 통과·실패 모두 `replace`라 뒤로 가기 때 진입 라우트로 돌아오지 않음, 대소문자만 다른 토큰의 실패 처리, 판정 중 언마운트 시 이동 미실행
- `WorkspaceJoinCard/test.tsx`: 임시 워크스페이스 이름·안내 문구 렌더, `참여할게요` 클릭 시 `/workspace/:workspaceId` 이동
- `WorkspaceJoinErrorNotice/test.tsx`: 제목·본문 두 줄 렌더, `초대 코드 직접 입력하기` 클릭 시 `/workspace/code` 이동
- `getInviteLink.test.ts`: `/invite/<linkToken>` 형식과 URL 인코딩

### 참고 사항

- 이 브랜치는 #262(`fe/feature/#258`) 위에 스택되어 있습니다. #262가 머지되기 전에 `develop`을 대상으로 열면 초대 코드 입력 페이지 변경이 함께 보이므로, 이번 Issue 범위는 `fe/feature/#258` 이후 커밋만 봐 주시면 됩니다.
- 임시 `linkToken` 상수(`Xk3vQ9mZp2LrT7wB1nHc4A`)가 `useWorkspaceInvite`(#229)와 `useWorkspaceInviteLinkGate`(#243) 두 곳에 있습니다. 두 위젯이 서로를 참조하지 않도록 일부러 공유하지 않았고, 각각의 API를 붙일 때 함께 사라질 값이라 그대로 두었습니다. 상수를 한곳으로 모으는 편이 낫다고 보시면 의견 부탁드립니다.
- `WorkspaceJoinCard`의 카드 셸 스타일(흰 배경·`shadow02`·460px·48px 패딩)은 `WorkspaceCodeCard`·`WorkspaceInviteCard`와 같은 값을 각 위젯이 따로 갖고 있습니다. 세 번째 반복이라 `shared`로 내릴지 고민했지만 이번 PR 범위 밖으로 두었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added invite-code entry with automatic validation, loading feedback, success confirmation, and invalid-code messaging.
  - Added invite-link handling with verification and routing to workspace joining or an error screen.
  - Added workspace invitation details and a join button for valid invitations.
  - Added an option to enter an invite code when an invitation link is expired or invalid.

- **Improvements**
  - Invite links now use dedicated tokens and support safe URL encoding.
  - Enhanced text fields with success states, status messages, and trailing indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->