### PR TITLE
[BE] LLM 벤치마크 공통 실행기·NIM 스트리밍 계측 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 # Codex local evidence
 /backend/.omo/
 /backend/src/main/resources/application-local.properties
+
+# Local Notion exports and LLM benchmark results
+/.benchmark-data/

--- a/tools/llm-benchmark/ab_schedule.py
+++ b/tools/llm-benchmark/ab_schedule.py
@@ -1,0 +1,64 @@
+"""Balanced, reproducible order scheduling for paired A/B trials."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Literal, assert_never
+
+StrategyLabel = Literal["raw", "rag"]
+
+
+class ScheduleError(Exception):
+    """Raised when an A/B schedule cannot be constructed."""
+
+    __slots__ = ("reason",)
+
+    reason: str
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"A/B schedule error: {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class Trial:
+    """One paired case/repeat with a randomized first strategy."""
+
+    case_id: str
+    repeat: int
+    first_strategy: StrategyLabel
+    second_strategy: StrategyLabel
+
+
+def build_schedule(case_ids: tuple[str, ...], repeats: int, seed: int) -> tuple[Trial, ...]:
+    """Create a balanced schedule with the same case paired in both orders."""
+    if not case_ids:
+        raise ScheduleError("at least one case is required")
+    if repeats < 1:
+        raise ScheduleError("repeats must be positive")
+    order_count = len(case_ids) * repeats
+    orders: list[StrategyLabel] = ["raw"] * (order_count // 2)
+    orders.extend(["rag"] * (order_count - len(orders)))
+    random.Random(seed).shuffle(orders)
+    schedule: list[Trial] = []
+    order_index = 0
+    for repeat in range(1, repeats + 1):
+        for case_id in case_ids:
+            first_strategy = orders[order_index]
+            order_index += 1
+            schedule.append(Trial(case_id, repeat, first_strategy, _other_strategy(first_strategy)))
+    return tuple(schedule)
+
+
+def _other_strategy(strategy: StrategyLabel) -> StrategyLabel:
+    match strategy:
+        case "raw":
+            return "rag"
+        case "rag":
+            return "raw"
+        case unreachable:
+            assert_never(unreachable)

--- a/tools/llm-benchmark/benchmark_core.py
+++ b/tools/llm-benchmark/benchmark_core.py
@@ -1,0 +1,238 @@
+"""Typed snapshot, gold-set, and retrieval primitives for the LLM benchmark."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final, assert_never
+
+_SUPPORTED_SUFFIXES: Final[frozenset[str]] = frozenset({".csv", ".markdown", ".md", ".txt"})
+_SENSITIVE_PATH_TERMS: Final[frozenset[str]] = frozenset(
+    {
+        "credential",
+        "credentials",
+        "key",
+        "keys",
+        "password",
+        "passwords",
+        "pem",
+        "private",
+        "secret",
+        "secrets",
+        "token",
+        "tokens",
+        "비밀번호",
+    }
+)
+_PRIVATE_KEY_PATTERN: Final[re.Pattern[str]] = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
+_CREDENTIAL_ASSIGNMENT_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"(?im)^\s*(?:api[_ -]?key|client[_ -]?secret|password|access[_ -]?token|refresh[_ -]?token|private[_ -]?key)\s*[:=]\s*\S+"
+)
+_TOKEN_PATTERN: Final[re.Pattern[str]] = re.compile(r"[0-9A-Za-z가-힣_]+")
+_TOKEN_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "db": "database",
+        "데이터베이스": "database",
+        "노션": "notion",
+    }
+)
+
+
+class Strategy(StrEnum):
+    """A document delivery strategy used by the benchmark."""
+
+    RAW = "raw"
+    RAG = "rag"
+    MCP_REPLAY = "mcp-replay"
+
+
+class SnapshotError(Exception):
+    """Raised when a local export cannot be loaded as a snapshot."""
+
+    __slots__ = ("path", "reason")
+
+    path: Path
+    reason: str
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(reason)
+        self.path = path
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"snapshot error at {self.path}: {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class Document:
+    """A normalized document loaded from a local Notion export."""
+
+    path: Path
+    title: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class Chunk:
+    """A retrieval unit retaining its source document identity."""
+
+    path: Path
+    title: str
+    content: str
+    score: float
+
+
+@dataclass(frozen=True, slots=True)
+class ContextPack:
+    """The context and retrieval metadata sent to the answer generator."""
+
+    text: str
+    source_paths: tuple[str, ...]
+    retrieved_count: int
+    tool_calls: int
+
+
+def load_snapshot(root: Path) -> tuple[Document, ...]:
+    """Load supported text files below a snapshot root in stable path order."""
+    if not root.is_dir():
+        raise SnapshotError(root, "directory does not exist")
+
+    documents: list[Document] = []
+    for path in sorted(root.rglob("*")):
+        relative_path = path.relative_to(root)
+        if not path.is_file() or any(part.startswith(".") for part in relative_path.parts):
+            continue
+        if path.suffix.lower() not in _SUPPORTED_SUFFIXES:
+            continue
+        if _is_sensitive_path(relative_path) or _is_duplicate_database_export(path):
+            continue
+        try:
+            content = path.read_text(encoding="utf-8").strip()
+        except UnicodeDecodeError as error:
+            raise SnapshotError(path, "file is not valid UTF-8") from error
+        if not content or _is_sensitive_content(content):
+            continue
+        documents.append(Document(relative_path, _title_for(path, content), content))
+
+    if not documents:
+        raise SnapshotError(root, "no supported non-empty documents found")
+    return tuple(documents)
+
+
+def build_context(
+    strategy: Strategy,
+    documents: tuple[Document, ...],
+    query: str,
+    top_k: int,
+) -> ContextPack:
+    """Build a context pack for one strategy and query."""
+    match strategy:
+        case Strategy.RAW:
+            selected = tuple(
+                Chunk(document.path, document.title, document.content, 0.0)
+                for document in documents
+            )
+            tool_calls = 0
+        case Strategy.RAG | Strategy.MCP_REPLAY:
+            selected = retrieve(documents, query, top_k)
+            tool_calls = 1 if strategy is Strategy.MCP_REPLAY else 0
+        case unreachable:
+            assert_never(unreachable)
+    return ContextPack(
+        "\n\n".join(_render_chunk(chunk) for chunk in selected),
+        tuple(str(chunk.path) for chunk in selected),
+        len(selected),
+        tool_calls,
+    )
+
+
+def retrieve(documents: tuple[Document, ...], query: str, top_k: int) -> tuple[Chunk, ...]:
+    """Retrieve top lexical chunks as a deterministic RAG baseline."""
+    if top_k < 1:
+        return ()
+    query_terms = Counter(tokenize(query))
+    if not query_terms:
+        return ()
+    document_frequency = Counter(
+        token
+        for document in documents
+        for token in set(tokenize(document.title)) | set(tokenize(document.content))
+    )
+    term_weights = {
+        token: math.log((1.0 + len(documents)) / (1.0 + document_frequency[token])) + 1.0
+        for token in query_terms
+    }
+    best_by_document: dict[Path, Chunk] = {}
+    for document in documents:
+        title_terms = set(tokenize(document.title))
+        for content in chunk_text(document.content):
+            content_terms = Counter(tokenize(content))
+            overlap = sum(
+                min(count, content_terms[token]) * term_weights[token]
+                for token, count in query_terms.items()
+            )
+            title_overlap = sum(term_weights[token] for token in query_terms if token in title_terms)
+            score = overlap + (0.5 * title_overlap)
+            if score > 0:
+                candidate = Chunk(document.path, document.title, content, score)
+                current = best_by_document.get(document.path)
+                if current is None or candidate.score > current.score:
+                    best_by_document[document.path] = candidate
+    return tuple(
+        sorted(best_by_document.values(), key=lambda chunk: (-chunk.score, str(chunk.path)))[:top_k]
+    )
+
+
+def _title_for(path: Path, content: str) -> str:
+    heading = re.search(r"(?m)^#\s+(.+?)\s*$", content)
+    return heading.group(1).strip() if heading else path.stem
+
+
+def _is_sensitive_path(path: Path) -> bool:
+    return any(
+        token == sensitive_term or token.startswith(sensitive_term) or sensitive_term in token.split("_")
+        for part in path.parts
+        for token in _TOKEN_PATTERN.findall(part.casefold())
+        for sensitive_term in _SENSITIVE_PATH_TERMS
+    )
+
+
+def _is_sensitive_content(content: str) -> bool:
+    return bool(_PRIVATE_KEY_PATTERN.search(content) or _CREDENTIAL_ASSIGNMENT_PATTERN.search(content))
+
+
+def _is_duplicate_database_export(path: Path) -> bool:
+    name = path.name
+    if not name.casefold().endswith("_all.csv"):
+        return False
+    regular_name = f"{name[:-len('_all.csv')]}.csv"
+    return path.with_name(regular_name).exists()
+
+
+def tokenize(text: str) -> tuple[str, ...]:
+    return tuple(_TOKEN_ALIASES.get(token, token) for token in _TOKEN_PATTERN.findall(text.lower()))
+
+
+def chunk_text(content: str, size: int = 1800, overlap: int = 200) -> tuple[str, ...]:
+    """Split document content into overlapping retrieval units."""
+    chunks: list[str] = []
+    start = 0
+    while start < len(content):
+        end = min(len(content), start + size)
+        chunk = content[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end == len(content):
+            break
+        start = end - overlap
+    return tuple(chunks)
+
+
+def _render_chunk(chunk: Chunk) -> str:
+    return f"## {chunk.title}\nsource_path: {chunk.path}\n\n{chunk.content}"

--- a/tools/llm-benchmark/gold_set.py
+++ b/tools/llm-benchmark/gold_set.py
@@ -1,0 +1,120 @@
+"""Typed parser for the Markdown benchmark gold set."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class GoldSetError(Exception):
+    """Raised when a benchmark case cannot be parsed."""
+
+    __slots__ = ("case_id", "path", "reason")
+
+    path: Path
+    case_id: str
+    reason: str
+
+    def __init__(self, path: Path, case_id: str, reason: str) -> None:
+        super().__init__(reason)
+        self.path = path
+        self.case_id = case_id
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"gold-set error at {self.path} ({self.case_id}): {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkCase:
+    """A parsed benchmark case with one or more conversational turns."""
+
+    case_id: str
+    status: str
+    category: str
+    turns: tuple[str, ...]
+    expected_answer: str
+    source_ids: tuple[str, ...]
+
+
+def load_cases(path: Path) -> tuple[BenchmarkCase, ...]:
+    """Parse G-series cases from the Markdown gold-set document."""
+    try:
+        markdown = path.read_text(encoding="utf-8")
+    except FileNotFoundError as error:
+        raise GoldSetError(path, "unknown", "file does not exist") from error
+    sections = [
+        match.group(0)
+        for match in re.finditer(r"(?ms)^###\s+G-\d+\b.*?(?=^###\s+G-\d+\b|\Z)", markdown)
+    ]
+    cases: list[BenchmarkCase] = []
+    for section in sections:
+        case_id = re.match(r"^###\s+(G-\d+)", section)
+        if case_id is None:
+            raise GoldSetError(path, "unknown", "case heading is malformed")
+        identifier = case_id.group(1)
+        turns = _turns(section)
+        if not turns:
+            raise GoldSetError(path, identifier, "question or conversation turns are missing")
+        cases.append(
+            BenchmarkCase(
+                identifier,
+                _field(section, "상태"),
+                _field(section, "유형"),
+                turns,
+                _expected_answer(section),
+                _source_ids(section),
+            )
+        )
+    if not cases:
+        raise GoldSetError(path, "unknown", "no G-series cases found")
+    return tuple(cases)
+
+
+def _field(section: str, label: str) -> str:
+    match = re.search(rf"(?m)^-\s+{re.escape(label)}:\s*(.+?)\s*$", section)
+    return match.group(1).replace("`", "").strip() if match else ""
+
+
+def _turns(section: str) -> tuple[str, ...]:
+    question = re.search(r"(?m)^-\s+질문:\s*`([^`]+)`", section)
+    if question:
+        return (question.group(1).strip(),)
+    return tuple(
+        turn.strip()
+        for turn in re.findall(r"(?m)^\s*사용자:\s*(.+?)\s*$", section)
+        if turn.strip()
+    )
+
+
+def _expected_answer(section: str) -> str:
+    match = re.search(
+        r"(?ms)^-\s+기대 답변:\s*\n(?P<body>.*?)(?=^\s*-\s+(?:정답 문서|관련 문서|실패 판정|기준 문서|최종 확정 조건)|\Z)",
+        section,
+    )
+    if match is None:
+        return ""
+    return "\n".join(line.lstrip().removeprefix("> ") for line in match.group("body").splitlines()).strip()
+
+
+def _source_ids(section: str) -> tuple[str, ...]:
+    ids: list[str] = []
+    collecting_nested = False
+    for line in section.splitlines():
+        direct = re.match(r"^\s*-\s+page ID:\s*`?([A-Za-z0-9][A-Za-z0-9-]*)`?\s*$", line)
+        if direct is not None:
+            ids.append(direct.group(1))
+            collecting_nested = False
+            continue
+        if re.match(r"^\s*-\s+page ID:\s*$", line):
+            collecting_nested = True
+            continue
+        if collecting_nested:
+            nested = re.match(r"^\s+-\s+`?([A-Za-z0-9][A-Za-z0-9-]*)`?\s*$", line)
+            if nested is not None:
+                ids.append(nested.group(1))
+                continue
+            if line.strip() and not line.startswith((" ", "\t")):
+                collecting_nested = False
+    return tuple(ids)

--- a/tools/llm-benchmark/nim_client.py
+++ b/tools/llm-benchmark/nim_client.py
@@ -1,0 +1,242 @@
+"""NVIDIA NIM OpenAI-compatible streaming client for benchmark runs."""
+
+from __future__ import annotations
+
+import socket
+import time
+from dataclasses import dataclass
+from typing import Final, Literal
+
+import httpx2
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_LIMITS: Final[httpx2.Limits] = httpx2.Limits(
+    max_connections=200,
+    max_keepalive_connections=40,
+    keepalive_expiry=30.0,
+)
+_SOCKET_OPTIONS: Final[list[tuple[int, int, int]]] = [
+    (socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),
+]
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+
+
+class NimSettings(BaseSettings):
+    """NIM settings parsed from the process environment at the boundary."""
+
+    model_config = SettingsConfigDict(env_prefix="NIM_", extra="ignore", frozen=True)
+
+    base_url: str = "https://integrate.api.nvidia.com/v1"
+    api_key: str = ""
+    model: str = ""
+    embedding_model: str = "nvidia/nemotron-3-embed-1b"
+    embedding_query_instruction: str = ""
+    temperature: float = 0.0
+    max_tokens: int = 512
+    embedding_timeout_s: float = Field(default=30.0, gt=0)
+    embedding_batch_size: int = Field(default=32, ge=1, le=128)
+    read_timeout_s: float = Field(default=90.0, gt=0)
+    http_retries: int = Field(default=0, ge=0)
+    reasoning_effort: ReasoningEffort | None = None
+    enable_thinking: bool | None = None
+
+
+class ChatMessage(BaseModel):
+    """One OpenAI-compatible chat message."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+class ChatRequest(BaseModel):
+    """A deterministic streaming request sent to NIM."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    model: str
+    messages: tuple[ChatMessage, ...]
+    temperature: float
+    max_tokens: int
+    stream: Literal[True] = True
+    reasoning_effort: ReasoningEffort | None = None
+    chat_template_kwargs: dict[str, bool] | None = None
+
+
+class _Delta(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    content: str | None = None
+
+
+class _Choice(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    delta: _Delta
+
+
+class _StreamChunk(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    choices: tuple[_Choice, ...] = Field(default_factory=tuple)
+
+
+class NimConfigurationError(Exception):
+    """Raised when required NIM settings are absent."""
+
+    __slots__ = ("field",)
+
+    field: str
+
+    def __init__(self, field: str) -> None:
+        super().__init__(field)
+        self.field = field
+
+    def __str__(self) -> str:
+        return f"NIM_{self.field.upper()} is required"
+
+
+class NimRequestError(Exception):
+    """Raised when NIM returns an unsuccessful HTTP response."""
+
+    __slots__ = ("detail", "status_code")
+
+    status_code: int
+    detail: str
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(status_code, detail)
+        self.status_code = status_code
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"NIM request failed with HTTP {self.status_code}: {self.detail}"
+
+
+class NimTransportError(Exception):
+    """Raised when the NIM endpoint cannot be reached."""
+
+    __slots__ = ("reason",)
+
+    reason: str
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"NIM transport error: {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class NimResult:
+    """One completed streaming response and its latency measurements."""
+
+    text: str
+    ttft_ms: float
+    total_ms: float
+
+
+class NimClient:
+    """Small synchronous client with tuned HTTP/2 and streaming timeouts."""
+
+    def __init__(self, settings: NimSettings) -> None:
+        if not settings.api_key:
+            raise NimConfigurationError("api_key")
+        if not settings.model:
+            raise NimConfigurationError("model")
+        timeout = httpx2.Timeout(connect=10.0, read=settings.read_timeout_s, write=10.0, pool=10.0)
+        transport = httpx2.HTTPTransport(
+            http2=True,
+            retries=settings.http_retries,
+            limits=_LIMITS,
+            socket_options=_SOCKET_OPTIONS,
+        )
+        self._client = httpx2.Client(
+            transport=transport,
+            timeout=timeout,
+            base_url=settings.base_url.rstrip("/"),
+            headers={"Authorization": f"Bearer {settings.api_key}"},
+            follow_redirects=True,
+            event_hooks={"request": [_mark_request], "response": [_mark_response]},
+        )
+        self._settings = settings
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._client.close()
+
+    def generate(self, messages: tuple[ChatMessage, ...]) -> NimResult:
+        """Stream one answer and measure first visible content and completion."""
+        request = ChatRequest(
+            model=self._settings.model,
+            messages=messages,
+            temperature=self._settings.temperature,
+            max_tokens=self._settings.max_tokens,
+            reasoning_effort=self._settings.reasoning_effort,
+            chat_template_kwargs=(
+                None
+                if self._settings.enable_thinking is None
+                else {"enable_thinking": self._settings.enable_thinking}
+            ),
+        )
+        started = time.perf_counter()
+        try:
+            response_context = self._client.stream(
+                "POST",
+                "/chat/completions",
+                json=request.model_dump(mode="json", exclude_none=True),
+            )
+            with response_context as response:
+                if response.status_code >= 400:
+                    response.read()
+                response.raise_for_status()
+                fragments: list[str] = []
+                first_content_at: float | None = None
+                for line in response.iter_lines():
+                    payload = parse_sse_line(line)
+                    if payload is None:
+                        continue
+                    chunk = _StreamChunk.model_validate_json(payload)
+                    fragment = _fragment(chunk)
+                    if not fragment:
+                        continue
+                    if first_content_at is None:
+                        first_content_at = time.perf_counter()
+                    fragments.append(fragment)
+        except httpx2.HTTPStatusError as error:
+            response = error.response
+            response.read()
+            raise NimRequestError(response.status_code, response.text[:500]) from error
+        except (httpx2.ConnectError, httpx2.TimeoutException) as error:
+            raise NimTransportError(str(error)) from error
+        finished = time.perf_counter()
+        if first_content_at is None:
+            raise NimTransportError("NIM returned no visible answer content")
+        return NimResult(
+            "".join(fragments),
+            (first_content_at - started) * 1000,
+            (finished - started) * 1000,
+        )
+
+
+def parse_sse_line(line: str) -> str | None:
+    """Return a non-terminal Server-Sent Events data payload."""
+    if not line.startswith("data:"):
+        return None
+    payload = line.removeprefix("data:").strip()
+    return None if not payload or payload == "[DONE]" else payload
+
+
+def _fragment(chunk: _StreamChunk) -> str:
+    return "".join(choice.delta.content or "" for choice in chunk.choices)
+
+
+def _mark_request(request: httpx2.Request) -> None:
+    request.extensions["benchmark_started_at"] = time.perf_counter()
+
+
+def _mark_response(response: httpx2.Response) -> None:
+    response.extensions["benchmark_response_seen_at"] = time.perf_counter()

--- a/tools/llm-benchmark/run_ab_benchmark.py
+++ b/tools/llm-benchmark/run_ab_benchmark.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "httpx2[http2,brotli,zstd]",
+#     "pydantic",
+#     "pydantic-settings",
+#     "rich",
+#     "typer",
+# ]
+# ///
+
+# ruff: noqa: B008  # Typer uses Option calls as the CLI declaration syntax.
+
+# ─── How to run ───
+# 1. Install uv (if not installed):
+#      curl -LsSf https://astral.sh/uv/install.sh | sh
+# 2. Run directly (no venv, no pip install needed):
+#      uv run tools/llm-benchmark/run_ab_benchmark.py --help
+# 3. Or make executable and run:
+#      chmod +x tools/llm-benchmark/run_ab_benchmark.py && ./tools/llm-benchmark/run_ab_benchmark.py --help
+# ──────────────────
+
+from __future__ import annotations
+
+from contextlib import closing
+from pathlib import Path
+from typing import Final, TextIO, assert_never
+
+import typer
+from ab_schedule import StrategyLabel, Trial, build_schedule
+from benchmark_core import Document, SnapshotError, Strategy, load_snapshot
+from gold_set import BenchmarkCase, GoldSetError, load_cases
+from nim_client import ChatMessage, NimClient, NimConfigurationError, NimSettings
+from pydantic import ValidationError
+from rich.console import Console
+from run_benchmark import _run_case
+
+_DEFAULT_SNAPSHOT = Path(".benchmark-data/notion-export")
+_DEFAULT_GOLD_SET = Path("docs/llm-search-benchmark-gold-set.md")
+_DEFAULT_OUTPUT = Path(".benchmark-data/ab-results.jsonl")
+_DEFAULT_CASES: Final[tuple[str, ...]] = (
+    "G-001",
+    "G-002",
+    "G-003",
+    "G-004",
+    "G-005",
+    "G-006",
+    "G-009",
+    "G-010",
+    "G-011",
+    "G-012",
+)
+
+
+def main(
+    snapshot_dir: Path = typer.Option(_DEFAULT_SNAPSHOT, help="Notion Markdown/CSV export directory."),
+    gold_set: Path = typer.Option(_DEFAULT_GOLD_SET, help="Benchmark gold-set Markdown file."),
+    output: Path = typer.Option(_DEFAULT_OUTPUT, help="Paired A/B JSONL result output path."),
+    case: str | None = typer.Option(None, help="Comma-separated case IDs; defaults to 10 single-turn cases."),
+    repeats: int = typer.Option(10, min=1, help="Paired repeats per selected case."),
+    top_k: int = typer.Option(5, min=1, help="Number of lexical chunks for B/RAG."),
+    seed: int = typer.Option(20260901, help="Seed for balanced A/B order randomization."),
+    warmup: int = typer.Option(2, min=0, help="Unrecorded warm-up calls before the paired trials."),
+    plan_only: bool = typer.Option(False, help="Print the balanced schedule without calling NIM."),
+) -> None:
+    """Run paired Raw-versus-RAG trials with balanced randomized order."""
+    console = Console()
+    cases = load_cases(gold_set)
+    selected_cases = _select_cases(cases, case)
+    schedule = build_schedule(tuple(item.case_id for item in selected_cases), repeats, seed)
+    if plan_only:
+        _print_schedule(console, schedule)
+        return
+    documents = load_snapshot(snapshot_dir)
+    settings = _load_settings(console)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    case_by_id = {item.case_id: item for item in selected_cases}
+    with output.open("w", encoding="utf-8") as stream, closing(NimClient(settings)) as client:
+        _warmup(client, warmup)
+        for trial in schedule:
+            _run_strategy_pair(stream, client, trial, case_by_id[trial.case_id], documents, top_k)
+    console.print(f"[green]results written:[/green] {output} ({len(schedule)} paired trials)")
+
+
+def _run_strategy_pair(
+    stream: TextIO,
+    client: NimClient,
+    trial: Trial,
+    benchmark_case: BenchmarkCase,
+    documents: tuple[Document, ...],
+    top_k: int,
+) -> None:
+    for label in (trial.first_strategy, trial.second_strategy):
+        _run_case(stream, client, trial.repeat, benchmark_case, documents, _strategy_for(label), top_k)
+
+
+def _strategy_for(label: StrategyLabel) -> Strategy:
+    match label:
+        case "raw":
+            return Strategy.RAW
+        case "rag":
+            return Strategy.RAG
+        case unreachable:
+            assert_never(unreachable)
+
+
+def _warmup(client: NimClient, count: int) -> None:
+    messages = (ChatMessage(role="user", content="warm-up request; answer with OK"),)
+    for _ in range(count):
+        client.generate(messages)
+
+
+def _load_settings(console: Console) -> NimSettings:
+    try:
+        return NimSettings()
+    except ValidationError as error:
+        console.print("[red]invalid NIM environment:[/red]", error)
+        raise typer.Exit(code=2) from error
+
+
+def _select_cases(cases: tuple[BenchmarkCase, ...], selection: str | None) -> tuple[BenchmarkCase, ...]:
+    wanted = _DEFAULT_CASES if selection is None else tuple(item.strip() for item in selection.split(",") if item.strip())
+    case_by_id = {item.case_id: item for item in cases}
+    missing = tuple(case_id for case_id in wanted if case_id not in case_by_id)
+    if missing:
+        raise typer.BadParameter(f"unknown case ID(s): {', '.join(missing)}")
+    return tuple(case_by_id[case_id] for case_id in wanted)
+
+
+def _print_schedule(console: Console, schedule: tuple[Trial, ...]) -> None:
+    raw_first = sum(trial.first_strategy == "raw" for trial in schedule)
+    console.print(f"planned paired trials: {len(schedule)}; raw-first={raw_first}; rag-first={len(schedule) - raw_first}")
+
+
+if __name__ == "__main__":
+    try:
+        typer.run(main)
+    except (GoldSetError, SnapshotError, NimConfigurationError) as error:
+        Console().print(f"[red]{error}[/red]")
+        raise typer.Exit(code=2) from error

--- a/tools/llm-benchmark/run_benchmark.py
+++ b/tools/llm-benchmark/run_benchmark.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "httpx2[http2,brotli,zstd]",
+#     "pydantic",
+#     "pydantic-settings",
+#     "rich",
+#     "typer",
+# ]
+# ///
+
+# ruff: noqa: B008  # Typer uses Option calls as the CLI declaration syntax.
+
+# ─── How to run ───
+# 1. Install uv (if not installed):
+#      curl -LsSf https://astral.sh/uv/install.sh | sh
+# 2. Run directly (no venv, no pip install needed):
+#      uv run tools/llm-benchmark/run_benchmark.py --help
+# 3. Or make executable and run:
+#      chmod +x tools/llm-benchmark/run_benchmark.py && ./tools/llm-benchmark/run_benchmark.py --help
+# ──────────────────
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import closing
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, TextIO, assert_never
+
+import typer
+from benchmark_core import (
+    ContextPack,
+    Document,
+    SnapshotError,
+    Strategy,
+    build_context,
+    load_snapshot,
+)
+from gold_set import BenchmarkCase, GoldSetError, load_cases
+from nim_client import (
+    ChatMessage,
+    NimClient,
+    NimConfigurationError,
+    NimRequestError,
+    NimSettings,
+    NimTransportError,
+)
+from pydantic import ValidationError
+from rich.console import Console
+
+_DEFAULT_SNAPSHOT = Path(".benchmark-data/notion-export")
+_DEFAULT_GOLD_SET = Path("docs/llm-search-benchmark-gold-set.md")
+_DEFAULT_OUTPUT = Path(".benchmark-data/results.jsonl")
+_SYSTEM_INSTRUCTIONS: Final[str] = """당신은 Knot 팀 문서 검색 평가용 답변자입니다.
+반드시 제공된 문서 컨텍스트만 근거로 답하세요.
+근거가 없으면 찾지 못했다고 말하고, 문서가 충돌하면 각 주장을 나열한 뒤 최종 결정을 단정하지 마세요.
+답변 끝에는 사용한 source_path를 [source: 경로] 형식으로 표시하세요.
+"""
+
+
+class RunMode(StrEnum):
+    """CLI strategy selection."""
+
+    ALL = "all"
+    RAW = "raw"
+    RAG = "rag"
+    MCP_REPLAY = "mcp-replay"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkRecord:
+    """One JSONL-compatible observation from a benchmark turn."""
+
+    case_id: str
+    repeat: int
+    turn: int
+    strategy: str
+    question: str
+    answer: str
+    source_paths: tuple[str, ...]
+    retrieved_count: int
+    tool_calls: int
+    context_chars: int
+    search_ms: float
+    model_ttft_ms: float | None
+    model_total_ms: float | None
+    ttft_ms: float | None
+    total_ms: float | None
+    dry_run: bool
+    error: str | None
+    embedding_ms: float = 0.0
+    vector_db_ms: float = 0.0
+
+
+def main(
+    snapshot_dir: Path = typer.Option(_DEFAULT_SNAPSHOT, help="Notion Markdown/CSV export directory."),
+    gold_set: Path = typer.Option(_DEFAULT_GOLD_SET, help="Benchmark gold-set Markdown file."),
+    output: Path = typer.Option(_DEFAULT_OUTPUT, help="JSONL result output path."),
+    strategy: RunMode = typer.Option(RunMode.ALL, help="Strategy to run."),
+    case: str | None = typer.Option(None, help="Comma-separated case IDs, for example G-001,G-007."),
+    repeats: int = typer.Option(1, min=1, help="Number of independent runs per case and strategy."),
+    top_k: int = typer.Option(5, min=1, help="Number of lexical chunks for RAG and MCP replay."),
+    dry_run: bool = typer.Option(False, help="Load and plan requests without calling NIM."),
+    list_cases: bool = typer.Option(False, help="Print parsed case IDs and exit."),
+) -> None:
+    """Run comparable Raw, RAG, and MCP replay NIM benchmark requests."""
+    console = Console()
+    cases = load_cases(gold_set)
+    if list_cases:
+        _print_cases(console, cases)
+        return
+    documents = load_snapshot(snapshot_dir)
+    selected_cases = _select_cases(cases, case)
+    selected_strategies = _strategies(strategy)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    settings = None if dry_run else _load_settings(console)
+    with output.open("w", encoding="utf-8") as stream:
+        if settings is None:
+            _write_dry_run(console, stream, selected_cases, documents, selected_strategies, top_k)
+            return
+        with closing(NimClient(settings)) as client:
+            for repeat_number in range(1, repeats + 1):
+                for selected_strategy in selected_strategies:
+                    for benchmark_case in selected_cases:
+                        _run_case(
+                            stream,
+                            client,
+                            repeat_number,
+                            benchmark_case,
+                            documents,
+                            selected_strategy,
+                            top_k,
+                        )
+    console.print(f"[green]results written:[/green] {output}")
+
+
+def _run_case(
+    stream: TextIO,
+    client: NimClient,
+    repeat_number: int,
+    benchmark_case: BenchmarkCase,
+    documents: tuple[Document, ...],
+    strategy: Strategy,
+    top_k: int,
+) -> None:
+    history: list[ChatMessage] = []
+    for turn_number, question in enumerate(benchmark_case.turns, start=1):
+        search_started = time.perf_counter()
+        context = build_context(strategy, documents, question, top_k)
+        search_ms = (time.perf_counter() - search_started) * 1000
+        messages = _messages(question, context, tuple(history))
+        try:
+            result = client.generate(messages)
+            record = BenchmarkRecord(
+                benchmark_case.case_id,
+                repeat_number,
+                turn_number,
+                strategy.value,
+                question,
+                result.text,
+                context.source_paths,
+                context.retrieved_count,
+                context.tool_calls,
+                len(context.text),
+                search_ms,
+                result.ttft_ms,
+                result.total_ms,
+                search_ms + result.ttft_ms,
+                search_ms + result.total_ms,
+                False,
+                None,
+            )
+            history.extend(
+                (
+                    ChatMessage(role="user", content=question),
+                    ChatMessage(role="assistant", content=result.text),
+                )
+            )
+        except (NimRequestError, NimTransportError) as error:
+            record = BenchmarkRecord(
+                benchmark_case.case_id,
+                repeat_number,
+                turn_number,
+                strategy.value,
+                question,
+                "",
+                context.source_paths,
+                context.retrieved_count,
+                context.tool_calls,
+                len(context.text),
+                search_ms,
+                None,
+                None,
+                None,
+                None,
+                False,
+                str(error),
+            )
+        _write_record(stream, record)
+
+
+def _messages(
+    question: str,
+    context: ContextPack,
+    history: tuple[ChatMessage, ...],
+) -> tuple[ChatMessage, ...]:
+    prompt = f"""<documents>\n{context.text or '(검색된 문서 없음)'}\n</documents>\n\n질문: {question}"""
+    return (ChatMessage(role="system", content=_SYSTEM_INSTRUCTIONS), *history, ChatMessage(role="user", content=prompt))
+
+
+def _write_dry_run(
+    console: Console,
+    stream: TextIO,
+    cases: tuple[BenchmarkCase, ...],
+    documents: tuple[Document, ...],
+    strategies: tuple[Strategy, ...],
+    top_k: int,
+) -> None:
+    for selected_strategy in strategies:
+        for benchmark_case in cases:
+            for turn_number, question in enumerate(benchmark_case.turns, start=1):
+                search_started = time.perf_counter()
+                context = build_context(selected_strategy, documents, question, top_k)
+                search_ms = (time.perf_counter() - search_started) * 1000
+                _write_record(
+                    stream,
+                    BenchmarkRecord(
+                        benchmark_case.case_id,
+                        0,
+                        turn_number,
+                        selected_strategy.value,
+                        question,
+                        "",
+                        context.source_paths,
+                        context.retrieved_count,
+                        context.tool_calls,
+                        len(context.text),
+                        search_ms,
+                        None,
+                        None,
+                        None,
+                        None,
+                        True,
+                        None,
+                    ),
+                )
+    console.print(f"[yellow]dry-run complete:[/yellow] {len(cases)} cases, {len(strategies)} strategies")
+
+
+def _write_record(stream: TextIO, record: BenchmarkRecord) -> None:
+    stream.write(json.dumps(asdict(record), ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _load_settings(console: Console) -> NimSettings:
+    try:
+        return NimSettings()
+    except ValidationError as error:
+        console.print("[red]invalid NIM environment:[/red]", error)
+        raise typer.Exit(code=2) from error
+
+
+def _select_cases(cases: tuple[BenchmarkCase, ...], selection: str | None) -> tuple[BenchmarkCase, ...]:
+    if selection is None:
+        return cases
+    wanted = frozenset(item.strip() for item in selection.split(",") if item.strip())
+    selected = tuple(benchmark_case for benchmark_case in cases if benchmark_case.case_id in wanted)
+    if len(selected) != len(wanted):
+        missing = ", ".join(sorted(wanted - {item.case_id for item in selected}))
+        raise typer.BadParameter(f"unknown case ID(s): {missing}")
+    return selected
+
+
+def _strategies(mode: RunMode) -> tuple[Strategy, ...]:
+    match mode:
+        case RunMode.ALL:
+            return (Strategy.RAW, Strategy.RAG, Strategy.MCP_REPLAY)
+        case RunMode.RAW:
+            return (Strategy.RAW,)
+        case RunMode.RAG:
+            return (Strategy.RAG,)
+        case RunMode.MCP_REPLAY:
+            return (Strategy.MCP_REPLAY,)
+        case unreachable:
+            assert_never(unreachable)
+
+
+def _print_cases(console: Console, cases: tuple[BenchmarkCase, ...]) -> None:
+    for benchmark_case in cases:
+        console.print(f"{benchmark_case.case_id}\t{benchmark_case.category}\t{len(benchmark_case.turns)} turn(s)")
+
+
+if __name__ == "__main__":
+    try:
+        typer.run(main)
+    except (GoldSetError, SnapshotError, NimConfigurationError) as error:
+        Console().print(f"[red]{error}[/red]")
+        raise typer.Exit(code=2) from error

--- a/tools/llm-benchmark/test_ab_schedule.py
+++ b/tools/llm-benchmark/test_ab_schedule.py
@@ -1,0 +1,36 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = ["pytest"]
+# ///
+
+# ─── How to run ───
+# 1. Install uv (if not installed):
+#      curl -LsSf https://astral.sh/uv/install.sh | sh
+# 2. Run directly (no venv, no pip install needed):
+#      uv run --with pytest pytest tools/llm-benchmark/test_ab_schedule.py
+# ──────────────────
+
+from __future__ import annotations
+
+from ab_schedule import build_schedule
+
+
+def test_build_schedule_pairs_each_case_and_balances_first_strategy() -> None:
+    schedule = build_schedule(("G-001", "G-002", "G-003", "G-004"), repeats=20, seed=7)
+
+    assert len(schedule) == 80
+    assert {(trial.case_id, trial.repeat) for trial in schedule} == {
+        (case_id, repeat)
+        for case_id in ("G-001", "G-002", "G-003", "G-004")
+        for repeat in range(1, 21)
+    }
+    assert abs(sum(trial.first_strategy == "raw" for trial in schedule) - 40) <= 4
+
+
+def test_build_schedule_is_reproducible_for_same_seed() -> None:
+    arguments = (("G-001", "G-002"), 5, 11)
+
+    first = build_schedule(arguments[0], repeats=arguments[1], seed=arguments[2])
+    second = build_schedule(arguments[0], repeats=arguments[1], seed=arguments[2])
+
+    assert first == second

--- a/tools/llm-benchmark/test_benchmark_core.py
+++ b/tools/llm-benchmark/test_benchmark_core.py
@@ -1,0 +1,109 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = ["pytest"]
+# ///
+
+# ─── How to run ───
+# 1. Install uv (if not installed):
+#      curl -LsSf https://astral.sh/uv/install.sh | sh
+# 2. Run directly (no venv, no pip install needed):
+#      uv run --with pytest pytest tools/llm-benchmark/test_benchmark_core.py
+# ──────────────────
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchmark_core import Strategy, build_context, load_snapshot
+from gold_set import load_cases
+
+
+def test_load_snapshot_reads_supported_files_and_skips_hidden_files(tmp_path: Path) -> None:
+    (tmp_path / "decision.md").write_text("# PostgreSQL\nUse PostgreSQL.", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("Redis session store", encoding="utf-8")
+    (tmp_path / ".private.md").write_text("must not load", encoding="utf-8")
+    (tmp_path / "Key & 비밀번호").mkdir()
+    (tmp_path / "Key & 비밀번호" / "credentials.md").write_text("do not send", encoding="utf-8")
+    (tmp_path / "private-key.md").write_text(
+        "-----BEGIN PRIVATE KEY-----\nnot a real key\n-----END PRIVATE KEY-----",
+        encoding="utf-8",
+    )
+    (tmp_path / "config.md").write_text("password: should-not-leave-the-loader", encoding="utf-8")
+    (tmp_path / "table.csv").write_text("name,value\nalpha,1\n", encoding="utf-8")
+    (tmp_path / "table_all.csv").write_text("value,name\n1,alpha\n", encoding="utf-8")
+
+    documents = load_snapshot(tmp_path)
+
+    assert [document.path.name for document in documents] == ["decision.md", "notes.txt", "table.csv"]
+    assert documents[0].title == "PostgreSQL"
+
+
+def test_load_cases_reads_single_and_follow_up_questions(tmp_path: Path) -> None:
+    gold_set = tmp_path / "gold.md"
+    gold_set.write_text(
+        """# Gold set
+
+### G-001 — 사실
+- 상태: `confirmed`
+- 유형: `fact`
+- 질문: `DB 뭐 써?`
+- 기대 답변:
+
+  > PostgreSQL
+- page ID: `page-1`
+
+### G-002 — 후속
+- 상태: `confirmed`
+- 유형: `follow_up`
+- 대화:
+
+  ```text
+  사용자: DB 뭐 써?
+  AI: PostgreSQL입니다.
+  사용자: 왜?
+  ```
+- page ID: `page-1`
+""",
+        encoding="utf-8",
+    )
+
+    cases = load_cases(gold_set)
+
+    assert cases[0].case_id == "G-001"
+    assert cases[0].turns == ("DB 뭐 써?",)
+    assert cases[0].source_ids == ("page-1",)
+    assert cases[0].category == "fact"
+    assert cases[1].turns == ("DB 뭐 써?", "왜?")
+
+
+def test_load_cases_reads_unquoted_and_multiple_page_ids(tmp_path: Path) -> None:
+    gold_set = tmp_path / "gold.md"
+    gold_set.write_text(
+        """### G-001
+- 질문: `규칙 뭐야?`
+- page ID:
+  - `page-1`
+  - `page-2`
+""",
+        encoding="utf-8",
+    )
+
+    cases = load_cases(gold_set)
+
+    assert cases[0].source_ids == ("page-1", "page-2")
+
+
+def test_build_context_retrieves_relevant_chunks_and_marks_mcp_call(tmp_path: Path) -> None:
+    (tmp_path / "db.md").write_text("PostgreSQL 관계형 데이터베이스\n" + ("배경 문장 " * 400), encoding="utf-8")
+    (tmp_path / "redis.md").write_text("Redis 중앙 세션 저장소", encoding="utf-8")
+    documents = load_snapshot(tmp_path)
+
+    rag_context = build_context(Strategy.RAG, documents, "PostgreSQL 뭐 써?", top_k=1)
+    mcp_context = build_context(Strategy.MCP_REPLAY, documents, "Redis 세션", top_k=1)
+
+    assert rag_context.retrieved_count == 1
+    assert "PostgreSQL" in rag_context.text
+    assert "Redis" not in rag_context.text
+    assert len(set(rag_context.source_paths)) == 1
+    assert mcp_context.tool_calls == 1
+    assert "Redis" in mcp_context.text

--- a/tools/llm-benchmark/test_nim_client.py
+++ b/tools/llm-benchmark/test_nim_client.py
@@ -1,0 +1,107 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = ["httpx2[http2,brotli,zstd]", "pydantic", "pydantic-settings", "pytest"]
+# ///
+
+# ─── How to run ───
+# 1. Install uv (if not installed):
+#      curl -LsSf https://astral.sh/uv/install.sh | sh
+# 2. Run directly (no venv, no pip install needed):
+#      uv run --with httpx2 --with pydantic --with pydantic-settings --with pytest pytest tools/llm-benchmark/test_nim_client.py
+# ──────────────────
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from time import sleep
+
+import pytest
+from nim_client import (
+    ChatMessage,
+    NimClient,
+    NimRequestError,
+    NimSettings,
+    NimTransportError,
+    parse_sse_line,
+)
+
+
+def test_parse_sse_line_returns_json_payload_only() -> None:
+    assert parse_sse_line("event: message") is None
+    assert parse_sse_line("data:") is None
+    assert parse_sse_line("data: [DONE]") is None
+    assert parse_sse_line('data: {"choices": []}') == '{"choices": []}'
+
+
+class _ForbiddenHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        body = b'{"error":"forbidden"}'
+        self.send_response(403)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: str) -> None:
+        return
+
+
+class _SlowBodyHandler(_ForbiddenHandler):
+    def do_POST(self) -> None:
+        body = b'data: {"choices": []}\n\n'
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        sleep(0.2)
+        try:
+            self.wfile.write(body)
+        except BrokenPipeError:
+            return
+
+
+def test_streaming_http_error_preserves_provider_status_and_detail() -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ForbiddenHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    client = NimClient(
+        NimSettings(
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            api_key="test-key",
+            model="test-model",
+        )
+    )
+    try:
+        with pytest.raises(NimRequestError) as raised:
+            client.generate((ChatMessage(role="user", content="ping"),))
+    finally:
+        client.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail == '{"error":"forbidden"}'
+
+
+def test_streaming_read_timeout_turns_slow_provider_into_transport_error() -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SlowBodyHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    client = NimClient(
+        NimSettings(
+            base_url=f"http://127.0.0.1:{server.server_port}/v1",
+            api_key="test-key",
+            model="test-model",
+            read_timeout_s=0.05,
+        )
+    )
+    try:
+        with pytest.raises(NimTransportError, match="timed out"):
+            client.generate((ChatMessage(role="user", content="ping"),))
+    finally:
+        client.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)


### PR DESCRIPTION
## 관련 이슈

Refs #272

## 작업 내용

- Notion Markdown·CSV 스냅샷을 안전하게 읽고 민감 경로·credential 문서를 제외하는 공통 파서를 추가했습니다.
- Raw·기본 검색·MCP replay 경계를 같은 질문과 옵션으로 실행하는 벤치마크 runner를 추가했습니다.
- NIM OpenAI-compatible streaming adapter에서 모델·프롬프트·생성 옵션·timeout과 TTFT·완료 시간을 기록하도록 구성했습니다.
- 균형 무작위 A/B 실행 스케줄과 provider HTTP 오류·stream timeout 회귀 테스트를 추가했습니다.
- 로컬 benchmark 결과·원본 export가 Git에 들어가지 않도록 ignore 경계를 추가했습니다.

### 참고 사항

- 검증: `test_ab_schedule.py`, `test_benchmark_core.py`, `test_nim_client.py` 9개 통과
- 실제 Hosted NIM smoke test와 실제 Notion MCP-live 비교는 후속 하위 이슈 범위입니다.
- 관련 하위 작업은 후속 stacked PR에서 `#273`~`#275`로 분리합니다.
