### PR TITLE
[BE] MCP replay·실시간 Notion 검색 비교 구현

### DIFF
--- a/tools/llm-benchmark/access_context.py
+++ b/tools/llm-benchmark/access_context.py
@@ -1,0 +1,69 @@
+"""Comparable context builders for raw, SQL, vector, and MCP-replay access."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, assert_never
+
+from benchmark_core import Chunk, ContextPack, Document, Strategy, build_context
+from nim_embedding_client import NimEmbeddingClient
+from pgvector_rag import retrieve_pgvector_context
+from pgvector_store import PgVectorStore, StoredChunk
+
+AccessLabel = Literal["raw", "rag", "db", "mcp-replay"]
+
+
+@dataclass(frozen=True, slots=True)
+class AccessContextTiming:
+    """Context pack and component timings for one access strategy."""
+
+    context: ContextPack
+    embedding_ms: float
+    database_ms: float
+
+
+def build_access_context(
+    label: AccessLabel,
+    question: str,
+    documents: tuple[Document, ...],
+    store: PgVectorStore,
+    embedding_client: NimEmbeddingClient,
+    corpus_key: str,
+    top_k: int,
+) -> AccessContextTiming:
+    """Build one strategy's context while separating embedding and database time."""
+    match label:
+        case "raw":
+            started = time.perf_counter()
+            context = build_context(Strategy.RAW, documents, question, top_k)
+            return AccessContextTiming(context, 0.0, (time.perf_counter() - started) * 1000)
+        case "mcp-replay":
+            started = time.perf_counter()
+            context = build_context(Strategy.MCP_REPLAY, documents, question, top_k)
+            return AccessContextTiming(context, 0.0, (time.perf_counter() - started) * 1000)
+        case "db":
+            started = time.perf_counter()
+            rows = store.search_keyword(corpus_key, question, top_k)
+            context = _stored_context(rows, 0)
+            return AccessContextTiming(context, 0.0, (time.perf_counter() - started) * 1000)
+        case "rag":
+            timing = retrieve_pgvector_context(question, store, embedding_client, corpus_key, top_k)
+            return AccessContextTiming(timing.context, timing.embedding_ms, timing.vector_db_ms)
+        case unreachable:
+            assert_never(unreachable)
+
+
+def _stored_context(rows: tuple[StoredChunk, ...], tool_calls: int) -> ContextPack:
+    chunks = tuple(Chunk(Path(row.source_path), row.title, row.content, row.score) for row in rows)
+    return ContextPack(
+        "\n\n".join(_render_chunk(chunk) for chunk in chunks),
+        tuple(row.source_path for row in rows),
+        len(rows),
+        tool_calls,
+    )
+
+
+def _render_chunk(chunk: Chunk) -> str:
+    return f"## {chunk.title}\nsource_path: {chunk.path}\n\n{chunk.content}"

--- a/tools/llm-benchmark/multi_schedule.py
+++ b/tools/llm-benchmark/multi_schedule.py
@@ -1,0 +1,57 @@
+"""Balanced randomized schedules for multi-strategy benchmark trials."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from access_context import AccessLabel
+
+
+class ScheduleError(Exception):
+    """Raised when a multi-strategy schedule cannot be constructed."""
+
+    __slots__ = ("reason",)
+
+    reason: str
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"multi-strategy schedule error: {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class MultiTrial:
+    """One case/repeat with every selected strategy in a randomized order."""
+
+    case_id: str
+    repeat: int
+    order: tuple[AccessLabel, ...]
+
+
+def build_schedule(
+    case_ids: tuple[str, ...],
+    strategies: tuple[AccessLabel, ...],
+    repeats: int,
+    seed: int,
+) -> tuple[MultiTrial, ...]:
+    """Create a reproducible schedule that runs each strategy once per pair."""
+    if not case_ids:
+        raise ScheduleError("at least one case is required")
+    if not strategies:
+        raise ScheduleError("at least one strategy is required")
+    if len(set(strategies)) != len(strategies):
+        raise ScheduleError("strategies must be unique")
+    if repeats < 1:
+        raise ScheduleError("repeats must be positive")
+    rng = random.Random(seed)
+    schedule: list[MultiTrial] = []
+    for repeat in range(1, repeats + 1):
+        for case_id in case_ids:
+            order = list(strategies)
+            rng.shuffle(order)
+            schedule.append(MultiTrial(case_id, repeat, tuple(order)))
+    return tuple(schedule)

--- a/tools/llm-benchmark/run_four_way_benchmark.py
+++ b/tools/llm-benchmark/run_four_way_benchmark.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "httpx2[http2,brotli,zstd]",
+#     "pgvector",
+#     "psycopg[binary]",
+#     "pydantic",
+#     "pydantic-settings",
+#     "rich",
+#     "typer",
+# ]
+# ///
+
+# ruff: noqa: B008  # Typer uses Option calls as the CLI declaration syntax.
+
+"""Run comparable Raw, RAG, DB-direct, and MCP-replay trials."""
+
+from __future__ import annotations
+
+import time
+from contextlib import ExitStack, closing
+from pathlib import Path
+from typing import Final, TextIO
+
+import typer
+from access_context import AccessContextTiming, AccessLabel, build_access_context
+from benchmark_core import ContextPack, Document, SnapshotError, load_snapshot
+from gold_set import BenchmarkCase, GoldSetError, load_cases
+from multi_schedule import MultiTrial, build_schedule
+from nim_client import (
+    ChatMessage,
+    NimClient,
+    NimConfigurationError,
+    NimRequestError,
+    NimSettings,
+    NimTransportError,
+)
+from nim_embedding_client import NimEmbeddingClient
+from pgvector_index import chunk_documents, index_corpus
+from pgvector_store import PgVectorStore, PgVectorStoreError
+from pydantic import ValidationError
+from rich.console import Console
+from run_benchmark import BenchmarkRecord, _messages, _write_record
+
+_DEFAULT_SNAPSHOT = Path(".benchmark-data/notion-export")
+_DEFAULT_GOLD_SET = Path("docs/llm-search-benchmark-gold-set.md")
+_DEFAULT_OUTPUT = Path(".benchmark-data/four-way-results.jsonl")
+_DEFAULT_DATABASE_URL = "postgresql://knot_benchmark:knot_benchmark@localhost:55432/knot_benchmark"
+_DEFAULT_CORPUS_KEY: Final[str] = "notion-export"
+_DEFAULT_CASES: Final[tuple[str, ...]] = (
+    "G-001",
+    "G-002",
+    "G-003",
+    "G-004",
+    "G-005",
+    "G-006",
+    "G-009",
+    "G-010",
+    "G-011",
+    "G-012",
+)
+_ALL_STRATEGIES: Final[tuple[AccessLabel, ...]] = ("raw", "rag", "db", "mcp-replay")
+
+
+class RunMode(str):
+    """CLI strategy selection values."""
+
+    ALL = "all"
+    RAW = "raw"
+    RAG = "rag"
+    DB = "db"
+    MCP_REPLAY = "mcp-replay"
+
+
+def main(
+    snapshot_dir: Path = typer.Option(_DEFAULT_SNAPSHOT, help="Notion Markdown/CSV export directory."),
+    gold_set: Path = typer.Option(_DEFAULT_GOLD_SET, help="Markdown gold-set path."),
+    output: Path = typer.Option(_DEFAULT_OUTPUT, help="JSONL output path."),
+    database_url: str = typer.Option(_DEFAULT_DATABASE_URL, envvar="PGVECTOR_DATABASE_URL"),
+    corpus_key: str = typer.Option(_DEFAULT_CORPUS_KEY, help="Logical corpus identity in pgvector."),
+    case: str | None = typer.Option(None, help="Comma-separated case IDs; defaults to ten single-turn cases."),
+    strategy: str = typer.Option(RunMode.ALL, help="all, raw, rag, db, or mcp-replay."),
+    repeats: int = typer.Option(10, min=1, help="Repeats per case."),
+    top_k: int = typer.Option(5, min=1, help="Distinct source documents per retrieved context."),
+    seed: int = typer.Option(20260901, help="Randomization seed."),
+    warmup: int = typer.Option(1, min=0, help="Unrecorded chat warm-up calls."),
+    chunk_size: int = typer.Option(700, min=100, help="Passage chunk size in characters."),
+    chunk_overlap: int = typer.Option(100, min=0, help="Passage overlap in characters."),
+    max_generation_context_chars: int = typer.Option(120_000, min=1, help="Reject oversized model contexts."),
+    retrieval_only: bool = typer.Option(False, help="Measure access latency without calling the chat model."),
+    skip_index: bool = typer.Option(False, help="Reuse the existing persisted Qwen pgvector corpus."),
+) -> None:
+    """Run a fixed model comparison with balanced multi-strategy ordering."""
+    console = Console()
+    selected = _select_strategies(strategy)
+    documents = load_snapshot(snapshot_dir)
+    cases = _select_cases(load_cases(gold_set), case)
+    schedule = build_schedule(tuple(item.case_id for item in cases), selected, repeats, seed)
+    settings = _load_settings(console)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with ExitStack() as stack:
+        store = stack.enter_context(closing(PgVectorStore(database_url)))
+        embedding_client = stack.enter_context(closing(NimEmbeddingClient(settings)))
+        chat_client = None if retrieval_only else stack.enter_context(closing(NimClient(settings)))
+        if not skip_index:
+            index_corpus(store, embedding_client, chunk_documents(documents, chunk_size, chunk_overlap), corpus_key, console)
+        else:
+            console.print(f"using existing pgvector corpus: {store.count(corpus_key)} chunks")
+        if chat_client is not None:
+            _warmup(chat_client, warmup)
+        with output.open("w", encoding="utf-8") as stream:
+            case_by_id = {item.case_id: item for item in cases}
+            for trial in schedule:
+                for label in trial.order:
+                    _run_observation(
+                        stream,
+                        chat_client,
+                        embedding_client,
+                        store,
+                        trial,
+                        case_by_id[trial.case_id],
+                        documents,
+                        corpus_key,
+                        top_k,
+                        label,
+                        max_generation_context_chars,
+                        retrieval_only,
+                    )
+    console.print(f"[green]results written:[/green] {output} ({len(schedule)} pairs × {len(selected)} strategies)")
+
+
+def _run_observation(
+    stream: TextIO,
+    chat_client: NimClient | None,
+    embedding_client: NimEmbeddingClient,
+    store: PgVectorStore,
+    trial: MultiTrial,
+    benchmark_case: BenchmarkCase,
+    documents: tuple[Document, ...],
+    corpus_key: str,
+    top_k: int,
+    label: AccessLabel,
+    max_generation_context_chars: int,
+    retrieval_only: bool,
+) -> None:
+    history: list[ChatMessage] = []
+    for turn_number, question in enumerate(benchmark_case.turns, start=1):
+        started = time.perf_counter()
+        context = ContextPack("", (), 0, 0)
+        timing = AccessContextTiming(context, 0.0, 0.0)
+        try:
+            timing = build_access_context(label, question, documents, store, embedding_client, corpus_key, top_k)
+            context = timing.context
+            search_ms = (time.perf_counter() - started) * 1000
+            if retrieval_only:
+                _write_record(stream, _record(benchmark_case, trial, turn_number, label, question, context, search_ms, timing, None, None, None, None))
+                continue
+            if chat_client is None:
+                raise NimTransportError("chat client is not configured")
+            if len(context.text) > max_generation_context_chars:
+                raise NimTransportError(
+                    f"context exceeds generation limit: {len(context.text)} > {max_generation_context_chars} characters"
+                )
+            result = chat_client.generate(_messages(question, context, tuple(history)))
+            _write_record(stream, _record(benchmark_case, trial, turn_number, label, question, context, search_ms, timing, result.text, result.ttft_ms, result.total_ms, None))
+            history.extend((ChatMessage(role="user", content=question), ChatMessage(role="assistant", content=result.text)))
+        except (NimRequestError, NimTransportError, PgVectorStoreError) as error:
+            search_ms = (time.perf_counter() - started) * 1000
+            _write_record(stream, _record(benchmark_case, trial, turn_number, label, question, context, search_ms, timing, "", None, None, str(error)))
+
+
+def _record(
+    benchmark_case: BenchmarkCase,
+    trial: MultiTrial,
+    turn_number: int,
+    label: AccessLabel,
+    question: str,
+    context: ContextPack,
+    search_ms: float,
+    timing: AccessContextTiming,
+    answer: str | None,
+    model_ttft_ms: float | None,
+    model_total_ms: float | None,
+    error: str | None,
+) -> BenchmarkRecord:
+    return BenchmarkRecord(
+        benchmark_case.case_id,
+        trial.repeat,
+        turn_number,
+        label,
+        question,
+        answer or "",
+        context.source_paths,
+        context.retrieved_count,
+        context.tool_calls,
+        len(context.text),
+        search_ms,
+        model_ttft_ms,
+        model_total_ms,
+        None if model_ttft_ms is None else search_ms + model_ttft_ms,
+        None if model_total_ms is None else search_ms + model_total_ms,
+        False,
+        error,
+        timing.embedding_ms,
+        timing.database_ms,
+    )
+
+
+def _select_strategies(value: str) -> tuple[AccessLabel, ...]:
+    if value == RunMode.ALL:
+        return _ALL_STRATEGIES
+    if value == "raw":
+        return ("raw",)
+    if value == "rag":
+        return ("rag",)
+    if value == "db":
+        return ("db",)
+    if value == "mcp-replay":
+        return ("mcp-replay",)
+    raise typer.BadParameter(f"unknown strategy: {value}")
+
+
+def _select_cases(cases: tuple[BenchmarkCase, ...], selection: str | None) -> tuple[BenchmarkCase, ...]:
+    wanted = _DEFAULT_CASES if selection is None else tuple(item.strip() for item in selection.split(",") if item.strip())
+    case_by_id = {item.case_id: item for item in cases}
+    missing = tuple(case_id for case_id in wanted if case_id not in case_by_id)
+    if missing:
+        raise typer.BadParameter(f"unknown case ID(s): {', '.join(missing)}")
+    return tuple(case_by_id[case_id] for case_id in wanted)
+
+
+def _warmup(client: NimClient, count: int) -> None:
+    messages = (ChatMessage(role="user", content="warm-up request; answer with OK"),)
+    for _ in range(count):
+        client.generate(messages)
+
+
+def _load_settings(console: Console) -> NimSettings:
+    try:
+        return NimSettings()
+    except ValidationError as error:
+        console.print("[red]invalid NIM environment:[/red]", error)
+        raise typer.Exit(code=2) from error
+
+
+if __name__ == "__main__":
+    try:
+        typer.run(main)
+    except (GoldSetError, SnapshotError, NimConfigurationError) as error:
+        Console().print(f"[red]{error}[/red]")
+        raise typer.Exit(code=2) from error


### PR DESCRIPTION
## 관련 이슈

Refs #274

## 작업 내용

- Raw·pgvector RAG·PostgreSQL 직접 검색·MCP replay를 같은 스냅샷과 질문으로 실행하는 네 전략 비교 경로를 추가했습니다.
- MCP replay를 읽기 도구 응답 경계로 모델 입력에 전달하고, 전략별 검색·임베딩·DB·도구 호출 시간을 기록합니다.
- 반복·warm-up·전략 순서를 균형화하는 다중 실행 스케줄과 Raw 컨텍스트 초과 보호를 추가했습니다.
- Docker pgvector 인덱스와 NIM 스트리밍 경계를 조합한 retrieval-only/e2e 실행 옵션을 제공합니다.

### 참고 사항

- 검증: 해당 변경 파일 `ruff check`와 `py_compile` 통과
- 현재 MCP는 로컬 스냅샷 lexical replay입니다. 실제 Notion API의 네트워크·페이지네이션·권한·rate limit은 후속 live 검증 범위입니다.
- 이 PR은 `be/feature/#273` 위에 쌓은 하위 PR입니다.
