### PR TITLE
[FE] 쿠키 인증, csrf 토큰 요청 로직 구현

### DIFF
--- a/frontend/src/shared/api/httpClient/csrfToken.ts
+++ b/frontend/src/shared/api/httpClient/csrfToken.ts
@@ -1,0 +1,48 @@
+import { getCsrfTokenApi } from "@api/fetch/api/v1/auth/csrf";
+
+/**
+ * CSRF 토큰 저장소.
+ *
+ * 서버는 `XSRF-TOKEN` 쿠키와 이 헤더 값을 비교해 우리 화면에서 온 요청인지 판별해요.
+ * API가 다른 오리진이라 그 쿠키를 읽을 수 없어서 값을 발급 API로 받아옵니다.
+ *
+ * 쓰는 곳은 두 군데예요. axios 요청은 httpClient 인터셉터가 자동으로,
+ * SSE 요청은 네이티브 fetch 호출부가 직접 가져다 씁니다.
+ */
+
+/** 이 메서드들만 CSRF 토큰을 요구해요. */
+const MUTATING_METHODS = ["post", "put", "patch", "delete"];
+
+export const CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+
+let csrfToken: string | undefined;
+
+/** 발급 중인 요청. 변경 요청이 동시에 나가도 발급은 한 번만 하려고 들고 있어요. */
+let csrfTokenRequest: Promise<string> | undefined;
+
+export const isMutatingRequest = (method?: string) =>
+  MUTATING_METHODS.includes((method ?? "get").toLowerCase());
+
+const loadCsrfToken = () => {
+  csrfTokenRequest =
+    csrfTokenRequest ??
+    getCsrfTokenApi()
+      .then(({ token }) => {
+        csrfToken = token;
+
+        return token;
+      })
+      .finally(() => {
+        csrfTokenRequest = undefined;
+      });
+
+  return csrfTokenRequest;
+};
+
+export const getCsrfToken = async () => csrfToken ?? (await loadCsrfToken());
+
+export const reloadCsrfToken = () => {
+  csrfToken = undefined;
+
+  return loadCsrfToken();
+};

--- a/frontend/src/shared/api/httpClient/index.ts
+++ b/frontend/src/shared/api/httpClient/index.ts
@@ -1,79 +1,38 @@
-import type { InternalAxiosRequestConfig } from "axios";
 import axios from "axios";
+import type { InternalAxiosRequestConfig } from "axios";
+import {
+  CSRF_HEADER_NAME,
+  getCsrfToken,
+  isMutatingRequest,
+  reloadCsrfToken,
+} from "@/shared/api/httpClient/csrfToken";
+import { AUTH_CSRF_API_PATH } from "@api/fetch/api/v1/auth/csrf";
 
-const TIMEOUT_DURATION = 10_000;
-
-/** CSRF 토큰을 발급받는 경로. 응답 본문으로 토큰을 주고 `XSRF-TOKEN` 쿠키도 함께 내려줘요. */
-const CSRF_API_PATH = "/api/v1/auth/csrf";
-
-const CSRF_HEADER_NAME = "X-XSRF-TOKEN";
-
-/** 서버 상태를 바꾸는 메서드. 이 요청들만 CSRF 토큰을 요구해요. */
-const MUTATING_METHODS = ["post", "put", "patch", "delete"];
-
-interface CsrfTokenResponse {
-  token: string;
-}
-
-/** 403을 만나 토큰을 새로 받고 한 번 다시 보낸 요청인지 표시해요. 무한 재시도를 막습니다. */
 interface RetriableConfig extends InternalAxiosRequestConfig {
   isCsrfRetried?: boolean;
 }
 
+const TIMEOUT_DURATION = 10_000;
+
 export const httpClient = axios.create({
   baseURL: process.env.API_BASE_URL,
   timeout: TIMEOUT_DURATION,
-
-  /**
-   * 인증 쿠키를 함께 보냅니다.
-   *
-   * 로그인 상태는 `__Host-KNOT_ACCESS_TOKEN` 쿠키로만 유지되고 자바스크립트가 읽을 수
-   * 없어요. 이 값이 없으면 쿠키가 실리지 않아 인증이 필요한 요청이 전부 401이 됩니다.
-   */
   withCredentials: true,
 });
 
-/**
- * 서버가 준 CSRF 토큰. 요청마다 새로 받지 않도록 들고 있어요.
- *
- * 로그인처럼 인증 상태가 바뀌면 서버가 토큰을 새로 만들어서 이 값이 낡을 수 있습니다.
- * 그때는 403이 오는데, 아래 응답 인터셉터가 다시 받아 한 번 더 보냅니다.
- */
-let csrfToken: string | undefined;
-
-const loadCsrfToken = async () => {
-  const { data } = await httpClient.get<CsrfTokenResponse>(CSRF_API_PATH);
-  csrfToken = data.token;
-
-  return csrfToken;
-};
-
-const isMutatingRequest = (method?: string) =>
-  MUTATING_METHODS.includes((method ?? "get").toLowerCase());
-
-/**
- * 상태를 바꾸는 요청에 CSRF 토큰을 헤더로 붙입니다.
- *
- * 서버는 이 헤더와 `XSRF-TOKEN` 쿠키를 비교해 우리 화면에서 온 요청인지 판별해요.
- * 쿠키는 브라우저가 알아서 보내지만, 프론트와 API의 도메인이 달라
- * 자바스크립트가 그 쿠키를 읽을 수 없습니다. 그래서 값을 `/api/v1/auth/csrf`로 받아 씁니다.
- *
- * 조회 요청은 상태를 바꾸지 않아 토큰이 필요 없고, 토큰을 받아오는 요청 자신도
- * 조회라 여기서 걸리지 않습니다.
- */
 httpClient.interceptors.request.use(async (config) => {
   if (!isMutatingRequest(config.method)) return config;
 
-  config.headers.set(CSRF_HEADER_NAME, csrfToken ?? (await loadCsrfToken()));
+  config.headers.set(CSRF_HEADER_NAME, await getCsrfToken());
 
   return config;
 });
 
 /**
- * CSRF 토큰이 낡아 403이 오면 새로 받아 한 번만 다시 보냅니다.
+ * 토큰이 낡아 403이 오면 새로 받아 한 번만 다시 보냅니다.
  *
- * 토큰을 받아오는 요청 자체가 실패한 경우와 이미 한 번 다시 보낸 요청은 건너뜁니다.
- * 그러지 않으면 계속 실패하는 상황에서 요청이 끝없이 반복돼요.
+ * 발급 요청 자신과 이미 재시도한 요청은 제외해요.
+ * 401은 로그인 화면 이동 같은 공통 처리가 정해지지 않아 각 호출부가 받습니다.
  */
 httpClient.interceptors.response.use(undefined, async (error: unknown) => {
   if (!axios.isAxiosError(error)) throw error;
@@ -82,13 +41,13 @@ httpClient.interceptors.response.use(undefined, async (error: unknown) => {
   const canRetry =
     error.response?.status === 403 &&
     config !== undefined &&
-    config.url !== CSRF_API_PATH &&
+    config.url !== AUTH_CSRF_API_PATH &&
     !config.isCsrfRetried;
 
   if (!canRetry) throw error;
 
   config.isCsrfRetried = true;
-  await loadCsrfToken();
+  await reloadCsrfToken();
 
   return httpClient.request(config);
 });

--- a/frontend/src/shared/api/httpClient/test.ts
+++ b/frontend/src/shared/api/httpClient/test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GetCsrfTokenResponseDto } from "@api/dto/auth";
+import { AUTH_CSRF_API_PATH } from "@api/fetch/api/v1/auth/csrf";
+import { csrfTokenResponse } from "@api/mock/responses/auth";
+import { mockServer } from "@api/mock/server";
+import { http, HttpResponse } from "msw";
+
+/** 인터셉터 동작만 보는 임시 경로예요 */
+const CSRF_TEST_PATH = "/__csrf-test";
+
+const CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+
+const expectedToken = new GetCsrfTokenResponseDto(csrfTokenResponse).token;
+
+/**
+ * 토큰 저장소가 모듈 스코프라 테스트끼리 토큰이 샙니다.
+ * 매번 새 모듈로 가져와 저장소를 비운 상태에서 시작해요.
+ */
+const importHttpClient = async () => {
+  vi.resetModules();
+
+  const [{ httpClient }, { getCsrfToken }] = await Promise.all([
+    import("./index"),
+    import("@/shared/api/httpClient/csrfToken"),
+  ]);
+
+  return { httpClient, getCsrfToken };
+};
+
+/** 토큰 발급 요청이 몇 번 나갔는지 세는 핸들러를 깔아요 */
+const trackCsrfRequest = () => {
+  const count = { value: 0 };
+
+  mockServer.use(
+    http.get(`*${AUTH_CSRF_API_PATH}`, () => {
+      count.value += 1;
+
+      return HttpResponse.json(csrfTokenResponse);
+    }),
+  );
+
+  return count;
+};
+
+/** 변경 요청이 받은 CSRF 헤더를 순서대로 모아요 */
+const trackMutatingRequest = (status = 200) => {
+  const headers: (string | null)[] = [];
+
+  mockServer.use(
+    http.post(`*${CSRF_TEST_PATH}`, ({ request }) => {
+      headers.push(request.headers.get(CSRF_HEADER_NAME));
+
+      return HttpResponse.json({}, { status });
+    }),
+  );
+
+  return headers;
+};
+
+describe("httpClient 인증·CSRF 요청 계약", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("인증 쿠키를 함께 보내도록 withCredentials가 켜져 있다", async () => {
+    const { httpClient } = await importHttpClient();
+
+    expect(httpClient.defaults.withCredentials).toBe(true);
+  });
+
+  it("조회 요청에는 CSRF 토큰 헤더를 붙이지 않는다", async () => {
+    const { httpClient } = await importHttpClient();
+    const headers: (string | null)[] = [];
+    mockServer.use(
+      http.get(`*${CSRF_TEST_PATH}`, ({ request }) => {
+        headers.push(request.headers.get(CSRF_HEADER_NAME));
+
+        return HttpResponse.json({});
+      }),
+    );
+
+    await httpClient.get(CSRF_TEST_PATH);
+
+    expect(headers).toEqual([null]);
+  });
+
+  it.each(["post", "put", "patch", "delete"] as const)(
+    "%s 요청에는 CSRF 토큰 헤더를 붙인다",
+    async (method) => {
+      const { httpClient } = await importHttpClient();
+      const headers: (string | null)[] = [];
+      mockServer.use(
+        http[method](`*${CSRF_TEST_PATH}`, ({ request }) => {
+          headers.push(request.headers.get(CSRF_HEADER_NAME));
+
+          return HttpResponse.json({});
+        }),
+      );
+
+      await httpClient({ method, url: CSRF_TEST_PATH });
+
+      expect(headers).toEqual([expectedToken]);
+    },
+  );
+
+  it("토큰이 없는 상태의 변경 요청은 토큰을 먼저 받아서 보낸다", async () => {
+    const { httpClient } = await importHttpClient();
+    const csrfCount = trackCsrfRequest();
+    const headers = trackMutatingRequest();
+
+    await httpClient.post(CSRF_TEST_PATH);
+
+    expect(csrfCount.value).toBe(1);
+    expect(headers).toEqual([expectedToken]);
+  });
+
+  it("한 번 받아둔 토큰은 다음 변경 요청에서 다시 받지 않는다", async () => {
+    const { httpClient } = await importHttpClient();
+    const csrfCount = trackCsrfRequest();
+    trackMutatingRequest();
+
+    await httpClient.post(CSRF_TEST_PATH);
+    await httpClient.post(CSRF_TEST_PATH);
+
+    expect(csrfCount.value).toBe(1);
+  });
+
+  it("변경 요청이 동시에 나가도 토큰은 한 번만 받는다", async () => {
+    const { httpClient } = await importHttpClient();
+    const csrfCount = trackCsrfRequest();
+    trackMutatingRequest();
+
+    await Promise.all([
+      httpClient.post(CSRF_TEST_PATH),
+      httpClient.post(CSRF_TEST_PATH),
+      httpClient.post(CSRF_TEST_PATH),
+    ]);
+
+    expect(csrfCount.value).toBe(1);
+  });
+
+  it("403이면 토큰을 새로 받아 새 토큰으로 한 번 다시 보낸다", async () => {
+    const { httpClient } = await importHttpClient();
+    const reissuedToken = "reissued-csrf-token";
+    let isReissued = false;
+    mockServer.use(
+      http.get(`*${AUTH_CSRF_API_PATH}`, () => {
+        const token = isReissued ? reissuedToken : csrfTokenResponse.token;
+        isReissued = true;
+
+        return HttpResponse.json({ token });
+      }),
+    );
+    const headers: (string | null)[] = [];
+    mockServer.use(
+      http.post(`*${CSRF_TEST_PATH}`, ({ request }) => {
+        headers.push(request.headers.get(CSRF_HEADER_NAME));
+
+        return request.headers.get(CSRF_HEADER_NAME) === reissuedToken
+          ? HttpResponse.json({ ok: true })
+          : HttpResponse.json({}, { status: 403 });
+      }),
+    );
+
+    const response = await httpClient.post(CSRF_TEST_PATH);
+
+    expect(response.data).toEqual({ ok: true });
+    expect(headers).toEqual([expectedToken, reissuedToken]);
+  });
+
+  it("403이 계속되면 재시도는 한 번으로 끝난다", async () => {
+    const { httpClient } = await importHttpClient();
+    trackCsrfRequest();
+    const headers = trackMutatingRequest(403);
+
+    await expect(httpClient.post(CSRF_TEST_PATH)).rejects.toThrow();
+
+    expect(headers).toHaveLength(2);
+  });
+
+  it("토큰 발급 요청 자체가 403이면 다시 시도하지 않는다", async () => {
+    const { httpClient } = await importHttpClient();
+    let csrfCount = 0;
+    mockServer.use(
+      http.get(`*${AUTH_CSRF_API_PATH}`, () => {
+        csrfCount += 1;
+
+        return HttpResponse.json({}, { status: 403 });
+      }),
+    );
+    const headers = trackMutatingRequest();
+
+    await expect(httpClient.post(CSRF_TEST_PATH)).rejects.toThrow();
+
+    expect(csrfCount).toBe(1);
+    expect(headers).toHaveLength(0);
+  });
+
+  it("SSE처럼 axios를 쓰지 않는 요청도 같은 토큰을 꺼내 쓸 수 있다", async () => {
+    const { getCsrfToken } = await importHttpClient();
+    const csrfCount = trackCsrfRequest();
+
+    const token = await getCsrfToken();
+
+    expect(token).toBe(expectedToken);
+    expect(csrfCount.value).toBe(1);
+  });
+});


### PR DESCRIPTION
## 관련 이슈

closes #302


## 작업 내용

  쿠키 기반 인증과 CSRF 토큰 처리를 `httpClient` 한 곳으로 모았습니다.
  앞으로 추가되는 API는 요청 함수만 작성하면 인증·CSRF가 자동으로 붙습니다.

  ## 왜 필요한가

  우리 서버는 로그인 상태를 `__Host-KNOT_ACCESS_TOKEN` **쿠키**로 유지합니다.
  쿠키는 브라우저가 자동으로 붙여주는데, 이 자동 첨부가 곧 CSRF 취약점이 됩니다.
  다른 사이트가 몰래 보낸 요청에도 우리 쿠키가 실려 나가기 때문입니다.

  그래서 서버는 **모든 변경 요청(POST·PUT·PATCH·DELETE)** 에
  `X-XSRF-TOKEN` 헤더를 요구합니다. 없으면 403입니다.

  - 쿠키는 브라우저가 자동으로 붙임 → 공격자도 공짜로 얻음
  - 헤더는 **우리 오리진의 JS만** 넣을 수 있음 → 공격자는 못 채움

  서버는 쿠키의 `XSRF-TOKEN`과 헤더의 `X-XSRF-TOKEN`이 같은지 대조합니다.

  프론트와 API가 다른 도메인이라 우리는 그 쿠키를 JS로 읽을 수 없어서,
  같은 값을 `GET /api/v1/auth/csrf` 응답 본문으로 따로 받아 씁니다.


  ## 동작 흐름

  ### 시나리오 A — 앱을 켜고 첫 변경 요청 (예: 새 대화 생성)

  토큰이 아직 없으므로, 요청 인터셉터가 **원래 요청을 붙잡아 둔 채**
  토큰을 먼저 받아온 뒤 헤더에 넣어 내보냅니다.

  ```
  createChatSessionApi() → httpClient({ method: "post", ... })
     │
     ├─▶ 요청 인터셉터
     │     변경 요청인가? → POST 이므로 통과
     │     await getCsrfToken()
     │        토큰 없음 → 발급 요청 시작
     │           │
     │           └─▶ GET /api/v1/auth/csrf   ← 요청이 하나 먼저 나감
     │                 이 요청도 같은 httpClient를 타지만 GET이라
     │                 인터셉터 첫 줄에서 통과 (무한 재귀 없음)
     │                 응답 { token: "a1b2" } → 저장
     │
     │     헤더에 X-XSRF-TOKEN: a1b2 설정
     │     return config      ← 여기까지 원래 POST는 대기 중이었음
     │
     ├─▶ 전송
     │     withCredentials: true 라서 Cookie 헤더가 자동으로 붙음
     │     Cookie: __Host-KNOT_ACCESS_TOKEN=...; XSRF-TOKEN=a1b2
     │
     └─▶ 서버
           쿠키 XSRF-TOKEN(a1b2) == 헤더 X-XSRF-TOKEN(a1b2)  ✅
           access token으로 신원 확인                          ✅  → 201
  ```

  - **두 번째 변경 요청부터**는 토큰이 이미 있어 발급 없이 헤더만 붙습니다.
  - **동시에 여러 개가 나가면** 첫 번째가 만든 발급 Promise를 나머지가 함께
    기다립니다. 발급 요청은 1회만 나갑니다.
  - **조회(GET) 요청**은 인터셉터 첫 줄에서 바로 통과합니다. 토큰도 받지 않습니다.

  ### 시나리오 B — 들고 있던 토큰이 낡아 403

  로그인 등으로 서버가 토큰을 새로 만들면 우리가 캐시한 값이 낡습니다.
  이때 새로 받아 **딱 한 번만** 다시 보냅니다.

  ```
  POST 전송 (낡은 토큰 첨부)
     │
     └─▶ 서버 403
           │
           └─▶ 응답 인터셉터 — 네 조건을 모두 만족해야 재시도
                 403인가                  ✅
                 config가 있나            ✅
                 발급 요청 자신인가        ❌  자신이면 재시도해도 또 403 → 무한루프
                 이미 재시도했나           ❌  두 번째부터는 여기서 멈춤
                      ↓
                 config.isCsrfRetried = true   ← 이 객체가 재요청에 그대로 실려감
                 await reloadCsrfToken()       ← 낡은 토큰 버리고 새로 받기
                 httpClient.request(config)    ← 재전송
                      │
                      └─▶ 재요청도 요청 인터셉터를 다시 타므로
                          새 토큰이 자동으로 헤더에 들어갑니다
                            │
                            ├─ 성공 → 끝
                            └─ 또 403 → isCsrfRetried가 true라 재시도 안 함
                                        → 그대로 실패 전파
  ```

  ## 파일 구성

  | 파일 | 책임 |
  | --- | --- |
  | `httpClient/csrfToken` | 토큰 발급·보관·갱신 |
  | `httpClient/index.ts` | axios 인스턴스와 인터셉터 두 개 |

  토큰 저장소를 분리한 이유는 **소비자가 둘이기 때문**입니다.
  채팅 답변(SSE)은 서버 timeout이 30초라 이 axios 인스턴스를 쓰지 않고
  네이티브 fetch로 보냅니다. 그러면 인터셉터를 타지 않으므로
  `getCsrfToken()`을 직접 불러 헤더에 넣어야 합니다.

  ```
          [ csrfToken — 토큰 저장소 ]
               ↓                ↓
        요청 인터셉터      getCsrfToken()
        (axios 자동)        (SSE 수동)
  ```