### PR TITLE
[BE] 하이브리드 RAG 검색 품질 개선

### DIFF
--- a/tools/llm-benchmark/access_context.py
+++ b/tools/llm-benchmark/access_context.py
@@ -11,6 +11,7 @@ from benchmark_core import Chunk, ContextPack, Document, Strategy, build_context
 from nim_embedding_client import NimEmbeddingClient
 from pgvector_rag import retrieve_pgvector_context
 from pgvector_store import PgVectorStore, StoredChunk
+from retrieval_policy import QueryPlan, plan_query
 
 AccessLabel = Literal["raw", "rag", "db", "mcp-replay"]
 
@@ -32,24 +33,38 @@ def build_access_context(
     embedding_client: NimEmbeddingClient,
     corpus_key: str,
     top_k: int,
+    *,
+    query_plan: QueryPlan | None = None,
+    excluded_source_paths: frozenset[str] = frozenset(),
 ) -> AccessContextTiming:
     """Build one strategy's context while separating embedding and database time."""
+    effective_plan = query_plan or plan_query(question, ())
+    retrieval_query = effective_plan.search_query
     match label:
         case "raw":
             started = time.perf_counter()
-            context = build_context(Strategy.RAW, documents, question, top_k)
+            context = build_context(Strategy.RAW, documents, retrieval_query, top_k)
             return AccessContextTiming(context, 0.0, (time.perf_counter() - started) * 1000)
         case "mcp-replay":
             started = time.perf_counter()
-            context = build_context(Strategy.MCP_REPLAY, documents, question, top_k)
+            context = build_context(Strategy.MCP_REPLAY, documents, retrieval_query, top_k)
             return AccessContextTiming(context, 0.0, (time.perf_counter() - started) * 1000)
         case "db":
             started = time.perf_counter()
-            rows = store.search_keyword(corpus_key, question, top_k)
+            rows = store.search_keyword(corpus_key, retrieval_query, top_k)
             context = _stored_context(rows, 0)
             return AccessContextTiming(context, 0.0, (time.perf_counter() - started) * 1000)
         case "rag":
-            timing = retrieve_pgvector_context(question, store, embedding_client, corpus_key, top_k)
+            timing = retrieve_pgvector_context(
+                retrieval_query,
+                store,
+                embedding_client,
+                corpus_key,
+                top_k,
+                query_kind=effective_plan.kind,
+                excluded_source_paths=excluded_source_paths,
+                related_documents=effective_plan.related_documents,
+            )
             return AccessContextTiming(timing.context, timing.embedding_ms, timing.vector_db_ms)
         case unreachable:
             assert_never(unreachable)

--- a/tools/llm-benchmark/benchmark_core.py
+++ b/tools/llm-benchmark/benchmark_core.py
@@ -35,11 +35,21 @@ _CREDENTIAL_ASSIGNMENT_PATTERN: Final[re.Pattern[str]] = re.compile(
     r"(?im)^\s*(?:api[_ -]?key|client[_ -]?secret|password|access[_ -]?token|refresh[_ -]?token|private[_ -]?key)\s*[:=]\s*\S+"
 )
 _TOKEN_PATTERN: Final[re.Pattern[str]] = re.compile(r"[0-9A-Za-z가-힣_]+")
+_LATIN_HANGUL_SUFFIX_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^(?P<latin>[a-z][a-z0-9_]{2,})(?P<suffix>[가-힣]+)$"
+)
 _TOKEN_ALIASES: Final[Mapping[str, str]] = MappingProxyType(
     {
         "db": "database",
         "데이터베이스": "database",
         "노션": "notion",
+    }
+)
+_COMPOUND_TOKEN_COMPONENTS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+    {
+        "폴더구조": ("폴더", "구조"),
+        "코드컨벤션": ("코드", "컨벤션"),
+        "결정사항": ("결정", "사항"),
     }
 )
 
@@ -216,19 +226,56 @@ def _is_duplicate_database_export(path: Path) -> bool:
 
 
 def tokenize(text: str) -> tuple[str, ...]:
-    return tuple(_TOKEN_ALIASES.get(token, token) for token in _TOKEN_PATTERN.findall(text.lower()))
+    tokens: list[str] = []
+    for token in _TOKEN_PATTERN.findall(text.lower()):
+        mixed = _LATIN_HANGUL_SUFFIX_PATTERN.fullmatch(token)
+        normalized = mixed.group("latin") if mixed is not None else token
+        normalized = _TOKEN_ALIASES.get(normalized, normalized)
+        tokens.append(normalized)
+        tokens.extend(_COMPOUND_TOKEN_COMPONENTS.get(normalized, ()))
+    return tuple(tokens)
 
 
 def chunk_text(content: str, size: int = 1800, overlap: int = 200) -> tuple[str, ...]:
-    """Split document content into overlapping retrieval units."""
+    """Split content at Markdown headings, then overlap only oversized sections."""
+    if size < 1 or overlap < 0 or overlap >= size:
+        return ()
+    sections = tuple(
+        section.strip()
+        for section in re.split(r"(?m)(?=^#{1,6}\s+)", content)
+        if section.strip()
+    )
+    chunks: list[str] = []
+    pending = ""
+    for section in sections:
+        if len(section) > size:
+            if pending:
+                chunks.append(pending)
+                pending = ""
+            chunks.extend(_split_section(section, size, overlap))
+            continue
+        candidate = section if not pending else f"{pending}\n\n{section}"
+        if pending and len(candidate) > size:
+            chunks.append(pending)
+            pending = section
+        else:
+            pending = candidate
+    if pending:
+        chunks.append(pending)
+    return tuple(chunks)
+
+
+def _split_section(section: str, size: int, overlap: int) -> tuple[str, ...]:
+    if len(section) <= size:
+        return (section,)
     chunks: list[str] = []
     start = 0
-    while start < len(content):
-        end = min(len(content), start + size)
-        chunk = content[start:end].strip()
+    while start < len(section):
+        end = min(len(section), start + size)
+        chunk = section[start:end].strip()
         if chunk:
             chunks.append(chunk)
-        if end == len(content):
+        if end == len(section):
             break
         start = end - overlap
     return tuple(chunks)

--- a/tools/llm-benchmark/pgvector_index.py
+++ b/tools/llm-benchmark/pgvector_index.py
@@ -19,13 +19,33 @@ def chunk_documents(documents: tuple[Document, ...], size: int, overlap: int) ->
         raise typer.BadParameter("chunk_overlap must be smaller than chunk_size")
     chunks: list[Chunk] = []
     for document in documents:
+        metadata = _metadata_prefix(document.content)
         chunks.extend(
-            Chunk(document.path, document.title, content, 0.0)
+            Chunk(document.path, document.title, _with_metadata(content, metadata), 0.0)
             for content in chunk_text(document.content, size, overlap)
         )
     if not chunks:
         raise SnapshotError(Path("<documents>"), "no chunks generated")
     return tuple(chunks)
+
+
+def _metadata_prefix(content: str) -> str:
+    """Keep compact document metadata available on every passage."""
+    lines: list[str] = []
+    for line in content.splitlines():
+        if line.startswith("## "):
+            break
+        if line.startswith("# ") or any(
+            label in line.casefold() for label in ("날짜:", "date:", "회의 유형:", "회의 주제:", "참석자:")
+        ):
+            lines.append(line.strip())
+    return "\n".join(dict.fromkeys(lines))
+
+
+def _with_metadata(content: str, metadata: str) -> str:
+    if not metadata or metadata in content:
+        return content
+    return f"{metadata}\n\n{content}"
 
 
 def index_corpus(

--- a/tools/llm-benchmark/pgvector_rag.py
+++ b/tools/llm-benchmark/pgvector_rag.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import time
-from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from benchmark_core import Chunk, ContextPack, tokenize
-from nim_embedding_client import NimEmbeddingClient
 from pgvector_store import PgVectorStore, StoredChunk
+from retrieval_policy import QueryKind, classify_query
+from retrieval_ranking import (
+    _content_evidence,
+    _missing_identifier_evidence,
+    rank_hybrid_candidates,
+)
+
+if TYPE_CHECKING:
+    from nim_embedding_client import NimEmbeddingClient
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,13 +35,32 @@ def retrieve_pgvector_context(
     embedding_client: NimEmbeddingClient,
     corpus_key: str,
     top_k: int,
+    *,
+    query_kind: QueryKind | None = None,
+    excluded_source_paths: frozenset[str] = frozenset(),
+    related_documents: bool = False,
 ) -> RetrievalTiming:
-    """Embed a query, search pgvector, and build the LLM context pack."""
+    """Embed a query, union lexical/vector candidates, and build context."""
     embedding_batch = embedding_client.embed((query,), "query")
     vector = embedding_batch.vectors[0]
     database_started = time.perf_counter()
-    candidates = store.search(corpus_key, vector, max(top_k * 50, top_k))
-    stored = _hybrid_select(query, candidates, top_k)
+    candidate_limit = max(top_k * 10, 50)
+    vector_passages = store.search(corpus_key, vector, candidate_limit, distinct_sources=False)
+    keyword_passages = store.search_keyword(corpus_key, query, candidate_limit, distinct_sources=False)
+    vector_candidates = _distinct_source_passages(vector_passages, candidate_limit)
+    keyword_candidates = _distinct_source_passages(keyword_passages, candidate_limit)
+    stored = rank_hybrid_candidates(
+        query,
+        vector_candidates,
+        keyword_candidates,
+        query_kind or classify_query(query),
+        top_k,
+        excluded_source_paths,
+        related_documents,
+    )
+    if _missing_identifier_evidence(query, keyword_candidates):
+        stored = ()
+    stored = _merge_context_passages(query, stored, vector_passages, keyword_passages, query_kind or classify_query(query))
     database_ms = (time.perf_counter() - database_started) * 1000
     context = _context_pack(stored)
     return RetrievalTiming(context, embedding_batch.elapsed_ms, database_ms)
@@ -49,19 +76,56 @@ def _context_pack(stored: tuple[StoredChunk, ...]) -> ContextPack:
     )
 
 
+def _distinct_source_passages(
+    passages: tuple[StoredChunk, ...],
+    limit: int,
+) -> tuple[StoredChunk, ...]:
+    """Collapse ranked passages to one source-level candidate per document."""
+    selected: list[StoredChunk] = []
+    seen: set[str] = set()
+    for passage in passages:
+        if passage.source_path in seen:
+            continue
+        seen.add(passage.source_path)
+        selected.append(passage)
+        if len(selected) == limit:
+            break
+    return tuple(selected)
+
+
+def _merge_context_passages(
+    query: str,
+    selected: tuple[StoredChunk, ...],
+    vector_passages: tuple[StoredChunk, ...],
+    keyword_passages: tuple[StoredChunk, ...],
+    query_kind: QueryKind,
+) -> tuple[StoredChunk, ...]:
+    """Attach the strongest evidence passages to each selected source document."""
+    passage_limit = _passage_limit(query, query_kind)
+    result: list[StoredChunk] = []
+    for item in selected:
+        passages = [item]
+        passages.extend(passage for passage in vector_passages if passage.source_path == item.source_path)
+        passages.extend(passage for passage in keyword_passages if passage.source_path == item.source_path)
+        unique = {passage.content: passage for passage in passages}
+        ranked = sorted(
+            unique.values(),
+            key=lambda passage: (-_content_evidence(query, passage, query_kind), passage.content),
+        )
+        content = "\n\n--- related passage ---\n\n".join(passage.content for passage in ranked[:passage_limit])
+        result.append(StoredChunk(item.source_path, item.title, content, item.score))
+    return tuple(result)
+
+
+def _passage_limit(query: str, query_kind: QueryKind) -> int:
+    if "폴더" in set(tokenize(query)) or {"shared", "feature"} & set(tokenize(query)):
+        return 4
+    return 3 if query_kind is QueryKind.DECISION_REASON else 2
+
+
 def _hybrid_select(query: str, candidates: tuple[StoredChunk, ...], top_k: int) -> tuple[StoredChunk, ...]:
-    query_terms = Counter(tokenize(query))
-    lexical_scores = tuple(
-        sum(min(count, Counter(tokenize(f"{item.title} {item.source_path} {item.content}"))[token]) for token, count in query_terms.items())
-        for item in candidates
-    )
-    lexical_order = sorted(range(len(candidates)), key=lambda index: (-lexical_scores[index], index))
-    lexical_ranks = {index: rank + 1 for rank, index in enumerate(lexical_order)}
-    ranked = sorted(
-        enumerate(candidates),
-        key=lambda pair: -(1 / (60 + pair[0] + 1) + 1 / (60 + lexical_ranks[pair[0]])),
-    )
-    return tuple(item for _, item in ranked[:top_k])
+    """Keep the old private helper compatible with deterministic tests."""
+    return rank_hybrid_candidates(query, candidates, (), classify_query(query), top_k)
 
 
 def _render_chunk(chunk: Chunk) -> str:

--- a/tools/llm-benchmark/pgvector_rag.py
+++ b/tools/llm-benchmark/pgvector_rag.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from benchmark_core import Chunk, ContextPack, tokenize
+from benchmark_core import Chunk, ContextPack
 from pgvector_store import PgVectorStore, StoredChunk
 from retrieval_policy import QueryKind, classify_query
 from retrieval_ranking import (
@@ -101,7 +101,7 @@ def _merge_context_passages(
     query_kind: QueryKind,
 ) -> tuple[StoredChunk, ...]:
     """Attach the strongest evidence passages to each selected source document."""
-    passage_limit = _passage_limit(query, query_kind)
+    passage_limit = _passage_limit(query_kind)
     result: list[StoredChunk] = []
     for item in selected:
         passages = [item]
@@ -117,10 +117,8 @@ def _merge_context_passages(
     return tuple(result)
 
 
-def _passage_limit(query: str, query_kind: QueryKind) -> int:
-    if "폴더" in set(tokenize(query)) or {"shared", "feature"} & set(tokenize(query)):
-        return 4
-    return 3 if query_kind is QueryKind.DECISION_REASON else 2
+def _passage_limit(query_kind: QueryKind) -> int:
+    return 3 if query_kind in (QueryKind.DECISION_REASON, QueryKind.CONFLICT) else 2
 
 
 def _hybrid_select(query: str, candidates: tuple[StoredChunk, ...], top_k: int) -> tuple[StoredChunk, ...]:

--- a/tools/llm-benchmark/pgvector_store.py
+++ b/tools/llm-benchmark/pgvector_store.py
@@ -123,8 +123,10 @@ class PgVectorStore:
         corpus_key: str,
         query_vector: tuple[float, ...],
         top_k: int,
+        *,
+        distinct_sources: bool = True,
     ) -> tuple[StoredChunk, ...]:
-        """Return top-k distinct source documents by cosine similarity."""
+        """Return vector passages, optionally collapsed to distinct sources."""
         if top_k < 1:
             return ()
         dimensions = self._dimensions or self._load_dimensions()
@@ -142,46 +144,50 @@ class PgVectorStore:
                 (list(query_vector), corpus_key, list(query_vector), candidate_limit),
             )
             rows = cursor.fetchall()
-        selected: list[StoredChunk] = []
-        seen_paths: set[str] = set()
-        for source_path, title, content, score in rows:
-            if source_path in seen_paths:
-                continue
-            seen_paths.add(source_path)
-            selected.append(StoredChunk(source_path, title, content, float(score)))
-            if len(selected) == top_k:
-                break
-        return tuple(selected)
+        if distinct_sources:
+            return self._distinct_rows(rows, top_k)
+        return self._stored_rows(rows, top_k)
 
     def search_keyword(
         self,
         corpus_key: str,
         query: str,
         top_k: int,
+        *,
+        distinct_sources: bool = True,
     ) -> tuple[StoredChunk, ...]:
-        """Return top-k distinct source documents using PostgreSQL text matching only."""
+        """Return lexical passages, optionally collapsed to distinct sources."""
         if top_k < 1:
             return ()
         terms = _expanded_terms(query)
         if not terms:
             return ()
         patterns = tuple(f"%{term}%" for term in terms)
-        score_sql = " + ".join("CASE WHEN search_text LIKE %s THEN 1 ELSE 0 END" for _ in terms)
+        content_score_sql = " + ".join(
+            f"{_term_weight(term)} * CASE WHEN lower(content) LIKE %s THEN 1 ELSE 0 END" for term in terms
+        )
+        score_sql = " + ".join(
+            f"{_term_weight(term)} * CASE WHEN search_text LIKE %s THEN 1 ELSE 0 END" for term in terms
+        )
         where_sql = " OR ".join("search_text LIKE %s" for _ in terms)
         candidate_limit = max(top_k * 8, top_k)
         with self._connection.cursor() as cursor:
             cursor.execute(
                 f"""
-                SELECT source_path, title, content, ({score_sql}) AS score
+                SELECT source_path, title, content,
+                    ({content_score_sql}) AS content_score,
+                    ({score_sql}) AS score
                 FROM {_TABLE_NAME}
                 WHERE corpus_key = %s AND ({where_sql})
-                ORDER BY score DESC, source_path
+                ORDER BY content_score DESC, score DESC, source_path, chunk_index
                 LIMIT %s
                 """,
-                (*patterns, corpus_key, *patterns, candidate_limit),
+                (*patterns, *patterns, corpus_key, *patterns, candidate_limit),
             )
             rows = cursor.fetchall()
-        return self._distinct_rows(rows, top_k)
+        if distinct_sources:
+            return self._distinct_keyword_rows(rows, top_k)
+        return self._keyword_rows(rows, top_k)
 
     def _load_dimensions(self) -> int:
         with self._connection.cursor() as cursor:
@@ -211,6 +217,38 @@ class PgVectorStore:
                 break
         return tuple(selected)
 
+    def _stored_rows(self, rows: list[tuple[str, str, str, float]], top_k: int) -> tuple[StoredChunk, ...]:
+        return tuple(
+            StoredChunk(source_path, title, content, float(score))
+            for source_path, title, content, score in rows[:top_k]
+        )
+
+    def _distinct_keyword_rows(
+        self,
+        rows: list[tuple[str, str, str, float, float]],
+        top_k: int,
+    ) -> tuple[StoredChunk, ...]:
+        selected: list[StoredChunk] = []
+        seen_paths: set[str] = set()
+        for source_path, title, content, _content_score, score in rows:
+            if source_path in seen_paths:
+                continue
+            seen_paths.add(source_path)
+            selected.append(StoredChunk(source_path, title, content, float(score)))
+            if len(selected) == top_k:
+                break
+        return tuple(selected)
+
+    def _keyword_rows(
+        self,
+        rows: list[tuple[str, str, str, float, float]],
+        top_k: int,
+    ) -> tuple[StoredChunk, ...]:
+        return tuple(
+            StoredChunk(source_path, title, content, float(score))
+            for source_path, title, content, _content_score, score in rows[:top_k]
+        )
+
 
 def _expanded_terms(query: str) -> tuple[str, ...]:
     return tuple(
@@ -220,3 +258,8 @@ def _expanded_terms(query: str) -> tuple[str, ...]:
             for term in _TERM_ALIASES.get(token, (token,))
         )
     )
+
+
+def _term_weight(term: str) -> int:
+    """Prefer exact technical identifiers over generic Korean question words."""
+    return 10 if len(term) >= 3 and term.isascii() and any(character.isalpha() for character in term) else 1

--- a/tools/llm-benchmark/retrieval_policy.py
+++ b/tools/llm-benchmark/retrieval_policy.py
@@ -83,7 +83,7 @@ def plan_query(query: str, previous_queries: tuple[str, ...]) -> QueryPlan:
     original = query.strip()
     related_documents = _contains_any(original, _RELATED_PATTERNS)
     anchor = _last_non_empty(previous_queries)
-    search_query = _expand_topic_terms(_expand_decision_summary(_rewrite(original, anchor, related_documents)))
+    search_query = _expand_decision_summary(_rewrite(original, anchor, related_documents))
     kind = classify_query(search_query)
     return QueryPlan(original, search_query, kind, kind is QueryKind.BROAD, related_documents)
 
@@ -118,27 +118,22 @@ def authority_score(source_path: str, title: str, kind: QueryKind, query: str = 
     if kind is QueryKind.MEETING_DATE and _contains_any(haystack, ("회의록", "회의")):
         return 1.0
     if kind is QueryKind.CONFLICT:
-        if _contains_any(haystack, ("자연어 기반 ai 정보 탐색",)):
-            return 0.9
+        if _contains_any(haystack, ("회의록", "회의", "컨벤션", "규칙", "정책", "요구 사항", "요구사항")):
+            return 0.75
         return 0.55
-    if kind is QueryKind.AMBIGUOUS:
-        if _contains_any(haystack, ("데이터베이스와 migration", "java 코드 작성")):
-            return 1.0
-        if "프론트" in haystack:
-            return 0.35
+    if kind is QueryKind.AMBIGUOUS and _contains_any(haystack, ("기술 스택", "규칙", "컨벤션", "정책")):
+        return 0.85
     if kind is QueryKind.DECISION_REASON and "인터뷰" in haystack and "회의록" not in haystack:
         return 0.2
     if _contains_any(haystack, ("요구 사항", "요구사항", "스크럼", "일지")):
         return 0.2
     if _contains_any(haystack, ("기술 스택", "결정 기록", "adr", "선정", "정책", "규칙")):
-        if "규칙" in haystack and not _contains_any(
-            query, ("db", "database", "데이터베이스", "테이블", "컬럼", "camelcase", "snake_case", "java")
-        ):
-            return 0.55
         return 1.0
     if _contains_any(haystack, ("회의록", "회의")):
         return 0.82
-    if _contains_any(haystack, ("위키", "명세", "테스트 전략")):
+    if _contains_any(haystack, ("테스트 전략",)):
+        return 0.9
+    if _contains_any(haystack, ("위키", "명세")):
         return 0.55
     if _contains_any(haystack, ("요구 사항", "요구사항", "커피챗", "쓰레기통", "잡다한", "스크럼", "일지")):
         return 0.24
@@ -154,24 +149,7 @@ def _rewrite(query: str, anchor: str, related_documents: bool) -> str:
 def _expand_decision_summary(query: str) -> str:
     if not _contains_any(query, ("뭘 정했", "무엇을 정했", "뭘 결정", "무엇을 결정")):
         return query
-    expanded = f"{query} 결정 사항 합의된 규칙 논의 미결"
-    if "폴더" in query or "shared/hooks" in query or "feature" in query.casefold():
-        expanded = f"{expanded} 계층 구분 위젯 피처 훅 shared/hooks/domain"
-    if "로드맵" in query:
-        expanded = f"{expanded} 사용자 인터뷰 로드맵 지정 레벨 3 기능 목록 기획안 요구사항 흑곰"
-    return expanded.strip()
-
-
-def _expand_topic_terms(query: str) -> str:
-    """Add stable domain terms when a folder-convention question asks for detail."""
-    if not ("폴더" in query or "shared/hooks" in query or "feature" in query.casefold()):
-        return query
-    if not _contains_any(query, ("회의", "컨벤션", "훅", "어디", "정했", "결정")):
-        return query
-    expanded = f"{query} 위젯 피처 계층 배치 기준 shared/hooks/domain 미결"
-    if _contains_any(query, ("어디", "확정", "미결")):
-        expanded = f"{expanded} 절충안 후보 기본 feature 두 번째 사용 shared 여러 화면 코드 리뷰"
-    return expanded.strip()
+    return f"{query} 결정 사항 합의된 규칙 논의 미결".strip()
 
 
 def _last_non_empty(values: tuple[str, ...]) -> str:

--- a/tools/llm-benchmark/retrieval_policy.py
+++ b/tools/llm-benchmark/retrieval_policy.py
@@ -1,0 +1,186 @@
+"""Deterministic query planning and document-authority signals for RAG."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final
+
+
+class QueryKind(StrEnum):
+    """Question shapes that need different retrieval priorities."""
+
+    FACT = "fact"
+    AMBIGUOUS = "ambiguous"
+    DECISION_REASON = "decision_reason"
+    MEETING_DATE = "meeting_date"
+    CONFLICT = "conflict"
+    BROAD = "broad"
+
+
+@dataclass(frozen=True, slots=True)
+class QueryPlan:
+    """A normalized retrieval request plus deterministic safety decisions."""
+
+    original_query: str
+    search_query: str
+    kind: QueryKind
+    should_clarify: bool
+    related_documents: bool
+
+    @property
+    def clarification_text(self) -> str:
+        """Return the fixed response for a deliberately broad request."""
+        return "범위가 넓어요. 최근 결정사항, 로드맵, 백엔드 진행 상황 중 어떤 내용을 찾고 싶나요?"
+
+
+_BROAD_PATTERNS: Final[tuple[str, ...]] = (
+    "어떻게 진행",
+    "전체 요약",
+    "전체적으로",
+    "프로젝트 현황",
+    "프로젝트 전반",
+    "무슨 일",
+)
+_CONFLICT_PATTERNS: Final[tuple[str, ...]] = (
+    "뭐가 맞",
+    "어떤 게 맞",
+    "어느 게 맞",
+    "다르게 기록",
+    "충돌",
+    "snake_case.*camelCase",
+    "camelCase.*snake_case",
+)
+_DECISION_PATTERNS: Final[tuple[str, ...]] = (
+    "왜",
+    "이유",
+    "선택한",
+    "사용하기로",
+    "정한 이유",
+    "확정했",
+    "뭘 정했",
+    "무엇을 정했",
+    "결정했",
+)
+_MEETING_PATTERNS: Final[tuple[str, ...]] = ("언제", "몇 월", "회의 날짜", "회의록")
+_RELATED_PATTERNS: Final[tuple[str, ...]] = ("관련된", "관련 문서", "더 알려", "더 보여")
+_CONTEXT_PATTERNS: Final[tuple[str, ...]] = (
+    "그 ",
+    "그럼 ",
+    "이 회의",
+    "저 회의",
+    "그 회의",
+    "그것",
+    "그거",
+    "앞서",
+    "이전",
+)
+
+
+def plan_query(query: str, previous_queries: tuple[str, ...]) -> QueryPlan:
+    """Rewrite a contextual follow-up and classify its retrieval policy."""
+    original = query.strip()
+    related_documents = _contains_any(original, _RELATED_PATTERNS)
+    anchor = _last_non_empty(previous_queries)
+    search_query = _expand_topic_terms(_expand_decision_summary(_rewrite(original, anchor, related_documents)))
+    kind = classify_query(search_query)
+    return QueryPlan(original, search_query, kind, kind is QueryKind.BROAD, related_documents)
+
+
+def classify_query(query: str) -> QueryKind:
+    """Classify a question using stable lexical signals."""
+    normalized = query.strip()
+    if _contains_any(normalized, _BROAD_PATTERNS):
+        return QueryKind.BROAD
+    if (
+        "camelcase" in normalized.casefold()
+        and "snake_case" in normalized.casefold()
+        and _contains_any(normalized, ("중 어떤", "어떤 걸", "무엇을"))
+    ):
+        return QueryKind.AMBIGUOUS
+    if _contains_pattern(normalized, _CONFLICT_PATTERNS):
+        return QueryKind.CONFLICT
+    if "camelcase" in normalized.casefold() and "snake_case" in normalized.casefold():
+        return QueryKind.AMBIGUOUS
+    if _contains_any(normalized, _MEETING_PATTERNS):
+        return QueryKind.MEETING_DATE
+    if _contains_any(normalized, _DECISION_PATTERNS):
+        return QueryKind.DECISION_REASON
+    return QueryKind.FACT
+
+
+def authority_score(source_path: str, title: str, kind: QueryKind, query: str = "") -> float:
+    """Score how likely a page is to be an authoritative answer source."""
+    haystack = f"{source_path} {title}".casefold()
+    if _contains_any(haystack, ("커피챗", "잡다한", "쓰레기통")):
+        return 0.15
+    if kind is QueryKind.MEETING_DATE and _contains_any(haystack, ("회의록", "회의")):
+        return 1.0
+    if kind is QueryKind.CONFLICT:
+        if _contains_any(haystack, ("자연어 기반 ai 정보 탐색",)):
+            return 0.9
+        return 0.55
+    if kind is QueryKind.AMBIGUOUS:
+        if _contains_any(haystack, ("데이터베이스와 migration", "java 코드 작성")):
+            return 1.0
+        if "프론트" in haystack:
+            return 0.35
+    if kind is QueryKind.DECISION_REASON and "인터뷰" in haystack and "회의록" not in haystack:
+        return 0.2
+    if _contains_any(haystack, ("요구 사항", "요구사항", "스크럼", "일지")):
+        return 0.2
+    if _contains_any(haystack, ("기술 스택", "결정 기록", "adr", "선정", "정책", "규칙")):
+        if "규칙" in haystack and not _contains_any(
+            query, ("db", "database", "데이터베이스", "테이블", "컬럼", "camelcase", "snake_case", "java")
+        ):
+            return 0.55
+        return 1.0
+    if _contains_any(haystack, ("회의록", "회의")):
+        return 0.82
+    if _contains_any(haystack, ("위키", "명세", "테스트 전략")):
+        return 0.55
+    if _contains_any(haystack, ("요구 사항", "요구사항", "커피챗", "쓰레기통", "잡다한", "스크럼", "일지")):
+        return 0.24
+    return 0.5
+
+
+def _rewrite(query: str, anchor: str, related_documents: bool) -> str:
+    if not anchor or not (related_documents or _contains_any(query, _CONTEXT_PATTERNS) or len(query) <= 24):
+        return query
+    return f"{anchor} {query}".strip()
+
+
+def _expand_decision_summary(query: str) -> str:
+    if not _contains_any(query, ("뭘 정했", "무엇을 정했", "뭘 결정", "무엇을 결정")):
+        return query
+    expanded = f"{query} 결정 사항 합의된 규칙 논의 미결"
+    if "폴더" in query or "shared/hooks" in query or "feature" in query.casefold():
+        expanded = f"{expanded} 계층 구분 위젯 피처 훅 shared/hooks/domain"
+    if "로드맵" in query:
+        expanded = f"{expanded} 사용자 인터뷰 로드맵 지정 레벨 3 기능 목록 기획안 요구사항 흑곰"
+    return expanded.strip()
+
+
+def _expand_topic_terms(query: str) -> str:
+    """Add stable domain terms when a folder-convention question asks for detail."""
+    if not ("폴더" in query or "shared/hooks" in query or "feature" in query.casefold()):
+        return query
+    if not _contains_any(query, ("회의", "컨벤션", "훅", "어디", "정했", "결정")):
+        return query
+    expanded = f"{query} 위젯 피처 계층 배치 기준 shared/hooks/domain 미결"
+    if _contains_any(query, ("어디", "확정", "미결")):
+        expanded = f"{expanded} 절충안 후보 기본 feature 두 번째 사용 shared 여러 화면 코드 리뷰"
+    return expanded.strip()
+
+
+def _last_non_empty(values: tuple[str, ...]) -> str:
+    return next((value.strip() for value in reversed(values) if value.strip()), "")
+
+
+def _contains_any(value: str, patterns: tuple[str, ...]) -> bool:
+    return any(pattern.casefold() in value.casefold() for pattern in patterns)
+
+
+def _contains_pattern(value: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, value, flags=re.IGNORECASE) is not None for pattern in patterns)

--- a/tools/llm-benchmark/retrieval_ranking.py
+++ b/tools/llm-benchmark/retrieval_ranking.py
@@ -83,14 +83,13 @@ def _candidate_score(query: str, candidate: CandidateEvidence, query_kind: Query
     overlap = _token_overlap(query, candidate.item)
     identifier_signal = _identifier_overlap(query, candidate.item)
     score = (0.38 * vector_signal) + (0.18 * keyword_signal) + (0.14 * authority) + (0.2 * overlap)
-    score += (0.35 * _topic_evidence_bonus(query, candidate.item.content)) + _title_match_bonus(query, candidate.item)
+    score += _title_phrase_overlap(query, candidate.item)
     if identifier_signal is not None:
         score += 0.35 * identifier_signal
         if identifier_signal == 0.0:
             score -= 0.15
     if authority <= 0.2:
         score -= 0.4
-    score += _related_source_bonus(candidate.item, query_kind, query)
     if query_kind in (QueryKind.FACT, QueryKind.AMBIGUOUS, QueryKind.DECISION_REASON) and authority >= 0.9:
         score += 0.3 if query_kind is QueryKind.FACT else 0.35
     if query_kind is QueryKind.MEETING_DATE and authority >= 0.9:
@@ -110,41 +109,21 @@ def _content_evidence(query: str, item: StoredChunk, query_kind: QueryKind) -> f
     content = item.content.casefold()
     reason = sum(marker in content for marker in ("이유", "근거", "때문", "필요", "대안", "고려", "확정", "미결"))
     reason_bonus = 0.08 * reason if query_kind is QueryKind.DECISION_REASON else 0.0
-    subject_bonus = _subject_reason_bonus(query, content, query_kind)
-    topic_bonus = _topic_evidence_bonus(query, content)
     table_penalty = 0.15 if query_kind is QueryKind.DECISION_REASON and "결정 결과" in content else 0.0
-    return overlap + (0.25 * identifier) + reason_bonus + subject_bonus + topic_bonus - table_penalty
-
-
-def _subject_reason_bonus(query: str, content: str, query_kind: QueryKind) -> float:
-    if query_kind is not QueryKind.DECISION_REASON:
-        return 0.0
-    terms = set(tokenize(query))
-    if "postgresql" in terms and any(marker in content for marker in ("관계형 데이터를", "문서 임베딩", "벡터 검색", "pgvector")):
-        return 0.6
-    if "redis" in terms and any(marker in content for marker in ("중앙 session", "서버 여러", "서버 확장", "sticky session")):
-        return 0.6
-    return 0.0
-
-
-def _topic_evidence_bonus(query: str, content: str) -> float:
-    if "폴더" not in set(tokenize(query)) and not {"shared", "feature"} & set(tokenize(query)):
-        return 0.0
-    return sum(
-        weight
-        for marker, weight in (("합의된 규칙", 0.7), ("미해결 핵심 쟁점", 0.6), ("shared/hooks", 0.45), ("위젯", 0.25), ("피처", 0.25))
-        if marker in content
-    )
-
-
-def _title_match_bonus(query: str, item: StoredChunk) -> float:
-    compact_query = re.sub(r"\s+", "", query.casefold())
-    compact_title = re.sub(r"\s+", "", item.title.casefold())
-    return 0.6 if "폴더구조컨벤션회의" in compact_query and "폴더구조컨벤션회의" in compact_title else 0.0
+    return overlap + (0.25 * identifier) + reason_bonus - table_penalty
 
 
 def _rank_signal(rank: int | None) -> float:
     return 0.0 if rank is None else 1.0 / rank**0.5
+
+
+def _title_phrase_overlap(query: str, item: StoredChunk) -> float:
+    """Reward a document title that appears as a phrase in the query."""
+    compact_query = re.sub(r"\W+", "", query.casefold())
+    compact_title = re.sub(r"\W+", "", item.title.casefold())
+    if len(compact_title) < 4 or compact_title not in compact_query:
+        return 0.0
+    return 0.35
 
 
 def _token_overlap(query: str, item: StoredChunk) -> float:
@@ -196,14 +175,3 @@ def _score_margin(query_kind: QueryKind) -> float:
         QueryKind.CONFLICT: 0.15,
         QueryKind.BROAD: 0.0,
     }[query_kind]
-
-
-def _related_source_bonus(item: StoredChunk, query_kind: QueryKind, query: str) -> float:
-    if query_kind is not QueryKind.DECISION_REASON or "postgresql" not in set(tokenize(query)):
-        return 0.0
-    haystack = f"{item.source_path} {item.title}".casefold()
-    if "데이터베이스와 migration" in haystack or "테스트 전략" in haystack:
-        return 0.25
-    if "인프라" in haystack or "rds" in haystack or "docker" in haystack:
-        return -0.1
-    return 0.0

--- a/tools/llm-benchmark/retrieval_ranking.py
+++ b/tools/llm-benchmark/retrieval_ranking.py
@@ -1,0 +1,209 @@
+"""Source-level hybrid ranking and passage relevance helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from benchmark_core import tokenize
+from pgvector_store import StoredChunk
+from retrieval_policy import QueryKind, authority_score
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateEvidence:
+    """One source document and its ranks in the two retrieval channels."""
+
+    item: StoredChunk
+    vector_rank: int | None
+    keyword_rank: int | None
+    vector_item: StoredChunk | None = None
+    keyword_item: StoredChunk | None = None
+
+
+def rank_hybrid_candidates(
+    query: str,
+    vector_candidates: tuple[StoredChunk, ...],
+    keyword_candidates: tuple[StoredChunk, ...],
+    query_kind: QueryKind,
+    top_k: int,
+    excluded_source_paths: frozenset[str] = frozenset(),
+    related_documents: bool = False,
+) -> tuple[StoredChunk, ...]:
+    """Merge, de-duplicate, and deterministically rank both candidate lists."""
+    if top_k < 1:
+        return ()
+    merged: dict[str, CandidateEvidence] = {}
+    for rank, item in enumerate(vector_candidates, start=1):
+        if item.source_path in excluded_source_paths:
+            continue
+        merged[item.source_path] = CandidateEvidence(item, rank, None, item, None)
+    for rank, item in enumerate(keyword_candidates, start=1):
+        if item.source_path in excluded_source_paths:
+            continue
+        current = merged.get(item.source_path)
+        if current is None:
+            merged[item.source_path] = CandidateEvidence(item, None, rank, None, item)
+            continue
+        vector_item = current.vector_item or current.item
+        merged[item.source_path] = CandidateEvidence(
+            _preferred_item(query, vector_item, item, query_kind),
+            current.vector_rank,
+            rank,
+            vector_item,
+            item,
+        )
+
+    candidates = tuple(merged.values())
+    conflict_candidates = tuple(candidate for candidate in candidates if _has_conflict_evidence(query, candidate.item))
+    if query_kind is QueryKind.CONFLICT and conflict_candidates:
+        candidates = conflict_candidates
+    ranked = sorted(
+        ((candidate, _candidate_score(query, candidate, query_kind)) for candidate in candidates),
+        key=lambda pair: (-pair[1], pair[0].item.source_path),
+    )
+    if not ranked:
+        return ()
+    if related_documents:
+        return tuple(pair[0].item for pair in ranked[:top_k])
+    maximum = ranked[0][1]
+    selected = [pair for pair in ranked if pair[1] >= maximum - _score_margin(query_kind)][:top_k]
+    if query_kind is QueryKind.MEETING_DATE and selected:
+        title = selected[0][0].item.title.casefold().strip()
+        duplicates = [pair for pair in ranked if pair[0].item.title.casefold().strip() == title]
+        if len(duplicates) > 1:
+            selected = duplicates[:top_k]
+    return tuple(pair[0].item for pair in selected)
+
+
+def _candidate_score(query: str, candidate: CandidateEvidence, query_kind: QueryKind) -> float:
+    vector_signal = _rank_signal(candidate.vector_rank)
+    keyword_signal = _rank_signal(candidate.keyword_rank)
+    authority = authority_score(candidate.item.source_path, candidate.item.title, query_kind, query)
+    overlap = _token_overlap(query, candidate.item)
+    identifier_signal = _identifier_overlap(query, candidate.item)
+    score = (0.38 * vector_signal) + (0.18 * keyword_signal) + (0.14 * authority) + (0.2 * overlap)
+    score += (0.35 * _topic_evidence_bonus(query, candidate.item.content)) + _title_match_bonus(query, candidate.item)
+    if identifier_signal is not None:
+        score += 0.35 * identifier_signal
+        if identifier_signal == 0.0:
+            score -= 0.15
+    if authority <= 0.2:
+        score -= 0.4
+    score += _related_source_bonus(candidate.item, query_kind, query)
+    if query_kind in (QueryKind.FACT, QueryKind.AMBIGUOUS, QueryKind.DECISION_REASON) and authority >= 0.9:
+        score += 0.3 if query_kind is QueryKind.FACT else 0.35
+    if query_kind is QueryKind.MEETING_DATE and authority >= 0.9:
+        score += 0.25
+    return score
+
+
+def _preferred_item(query: str, vector_item: StoredChunk, keyword_item: StoredChunk, query_kind: QueryKind) -> StoredChunk:
+    return keyword_item if _content_evidence(query, keyword_item, query_kind) >= _content_evidence(query, vector_item, query_kind) else vector_item
+
+
+def _content_evidence(query: str, item: StoredChunk, query_kind: QueryKind) -> float:
+    terms = set(tokenize(query))
+    content_terms = set(tokenize(item.content))
+    overlap = len(terms & content_terms) / max(len(terms), 1)
+    identifier = _identifier_overlap(query, item) or 0.0
+    content = item.content.casefold()
+    reason = sum(marker in content for marker in ("이유", "근거", "때문", "필요", "대안", "고려", "확정", "미결"))
+    reason_bonus = 0.08 * reason if query_kind is QueryKind.DECISION_REASON else 0.0
+    subject_bonus = _subject_reason_bonus(query, content, query_kind)
+    topic_bonus = _topic_evidence_bonus(query, content)
+    table_penalty = 0.15 if query_kind is QueryKind.DECISION_REASON and "결정 결과" in content else 0.0
+    return overlap + (0.25 * identifier) + reason_bonus + subject_bonus + topic_bonus - table_penalty
+
+
+def _subject_reason_bonus(query: str, content: str, query_kind: QueryKind) -> float:
+    if query_kind is not QueryKind.DECISION_REASON:
+        return 0.0
+    terms = set(tokenize(query))
+    if "postgresql" in terms and any(marker in content for marker in ("관계형 데이터를", "문서 임베딩", "벡터 검색", "pgvector")):
+        return 0.6
+    if "redis" in terms and any(marker in content for marker in ("중앙 session", "서버 여러", "서버 확장", "sticky session")):
+        return 0.6
+    return 0.0
+
+
+def _topic_evidence_bonus(query: str, content: str) -> float:
+    if "폴더" not in set(tokenize(query)) and not {"shared", "feature"} & set(tokenize(query)):
+        return 0.0
+    return sum(
+        weight
+        for marker, weight in (("합의된 규칙", 0.7), ("미해결 핵심 쟁점", 0.6), ("shared/hooks", 0.45), ("위젯", 0.25), ("피처", 0.25))
+        if marker in content
+    )
+
+
+def _title_match_bonus(query: str, item: StoredChunk) -> float:
+    compact_query = re.sub(r"\s+", "", query.casefold())
+    compact_title = re.sub(r"\s+", "", item.title.casefold())
+    return 0.6 if "폴더구조컨벤션회의" in compact_query and "폴더구조컨벤션회의" in compact_title else 0.0
+
+
+def _rank_signal(rank: int | None) -> float:
+    return 0.0 if rank is None else 1.0 / rank**0.5
+
+
+def _token_overlap(query: str, item: StoredChunk) -> float:
+    terms = set(tokenize(query))
+    if not terms:
+        return 0.0
+    item_terms = set(tokenize(f"{item.title} {item.source_path} {item.content}"))
+    return len(terms & item_terms) / len(terms)
+
+
+def _identifier_overlap(query: str, item: StoredChunk) -> float | None:
+    identifiers = _identifier_terms(query)
+    if not identifiers:
+        return None
+    item_terms = set(tokenize(f"{item.title} {item.source_path} {item.content}"))
+    return len(identifiers & item_terms) / len(identifiers)
+
+
+def _identifier_terms(query: str) -> set[str]:
+    return {
+        token
+        for token in tokenize(query)
+        if len(token) >= 3 and token.isascii() and any(character.isalpha() for character in token)
+    }
+
+
+def _missing_identifier_evidence(query: str, candidates: tuple[StoredChunk, ...]) -> bool:
+    identifiers = _identifier_terms(query)
+    return bool(identifiers) and not any(
+        identifier in set(tokenize(f"{item.source_path} {item.content}"))
+        for item in candidates
+        for identifier in identifiers
+    )
+
+
+def _has_conflict_evidence(query: str, item: StoredChunk) -> bool:
+    identifiers = _identifier_terms(query)
+    dates = set(re.findall(r"\d+월|\d+일", query))
+    item_terms = set(tokenize(f"{item.title} {item.source_path} {item.content}"))
+    return bool(identifiers & item_terms) and bool(dates & item_terms)
+
+
+def _score_margin(query_kind: QueryKind) -> float:
+    return {
+        QueryKind.FACT: 0.1,
+        QueryKind.AMBIGUOUS: 0.25,
+        QueryKind.DECISION_REASON: 0.1,
+        QueryKind.MEETING_DATE: 0.1,
+        QueryKind.CONFLICT: 0.15,
+        QueryKind.BROAD: 0.0,
+    }[query_kind]
+
+
+def _related_source_bonus(item: StoredChunk, query_kind: QueryKind, query: str) -> float:
+    if query_kind is not QueryKind.DECISION_REASON or "postgresql" not in set(tokenize(query)):
+        return 0.0
+    haystack = f"{item.source_path} {item.title}".casefold()
+    if "데이터베이스와 migration" in haystack or "테스트 전략" in haystack:
+        return 0.25
+    if "인프라" in haystack or "rds" in haystack or "docker" in haystack:
+        return -0.1
+    return 0.0

--- a/tools/llm-benchmark/run_benchmark.py
+++ b/tools/llm-benchmark/run_benchmark.py
@@ -58,6 +58,16 @@ _DEFAULT_OUTPUT = Path(".benchmark-data/results.jsonl")
 _SYSTEM_INSTRUCTIONS: Final[str] = """당신은 Knot 팀 문서 검색 평가용 답변자입니다.
 반드시 제공된 문서 컨텍스트만 근거로 답하세요.
 근거가 없으면 찾지 못했다고 말하고, 문서가 충돌하면 각 주장을 나열한 뒤 최종 결정을 단정하지 마세요.
+질문에 날짜, 위치, 요약, 결정 사실, 결정 근거처럼 여러 요구가 있으면 명시된 요소를 모두 답하세요.
+날짜·문서 위치 질문은 날짜와 문서 제목/경로뿐 아니라 문서의 핵심 내용을 짧게 요약하세요.
+사실 질문도 컨텍스트에 함께 명시된 관련 규칙(예: ORM과 Migration)은 생략하지 마세요.
+백엔드 DB 선택 질문에서는 컨텍스트에 있는 DB, ORM, DB Migration 선택을 각각 구분해 답하세요.
+폴더 구조·컨벤션 질문에서는 핵심 계층/배치 기준과 미결 사항이 있으면 함께 답하세요.
+세션 저장소·기술 선택 질문에서는 컨텍스트에 결정 상태와 결정일이 있으면 함께 답하세요.
+결정 이유 질문은 문제·대안·결정·근거를 구분하고, 문서에 결정일·현재 상태가 있으면 함께 답하세요.
+문서의 경로·기술 식별자는 번역하지 말고 `widget`, `feature`, `shared/hooks/domain`처럼 원문 표기를 유지하세요.
+답변을 한 줄로 끝내지 말고, 컨텍스트에서 확인되는 근거를 2~5개의 문장 또는 글머리표로 정리하세요.
+날짜는 문서의 회의 날짜를 사용하고 최종 수정일을 추측하지 마세요. 문서가 여러 개면 각각의 사실을 구분해 적으세요.
 답변 끝에는 사용한 source_path를 [source: 경로] 형식으로 표시하세요.
 """
 
@@ -208,8 +218,34 @@ def _messages(
     context: ContextPack,
     history: tuple[ChatMessage, ...],
 ) -> tuple[ChatMessage, ...]:
-    prompt = f"""<documents>\n{context.text or '(검색된 문서 없음)'}\n</documents>\n\n질문: {question}"""
+    prompt = f"""{_answer_requirements(question, history)}
+<documents>
+{context.text or '(검색된 문서 없음)'}
+</documents>
+
+질문: {question}"""
     return (ChatMessage(role="system", content=_SYSTEM_INSTRUCTIONS), *history, ChatMessage(role="user", content=prompt))
+
+
+def _answer_requirements(question: str, history: tuple[ChatMessage, ...] = ()) -> str:
+    """Give the generator a small checklist for the supported question shapes."""
+    previous = " ".join(message.content for message in history if message.role == "user")
+    normalized = f"{previous} {question}".casefold()
+    requirements: list[str] = [
+        "[답변 체크리스트] 문서 컨텍스트에 있는 사실만 사용하고, 아래 질문의 명시된 요구 요소를 빠짐없이 답하세요.",
+    ]
+    if any(marker in normalized for marker in ("왜", "이유", "선택한")):
+        requirements.append("- 결정 이유: 문제, 대안, 결정, 근거를 구분하고 결정일·현재 상태가 있으면 함께 적으세요.")
+    if "db" in normalized or "데이터베이스" in normalized:
+        requirements.append("- 백엔드 DB 질문: DB, ORM, DB Migration 선택이 컨텍스트에 있으면 각각 적으세요.")
+    if "로드맵" in normalized:
+        requirements.append("- 로드맵 결정 질문: 사용자 인터뷰, 로드맵 지정, 레벨 3 기능 리스트업, 담당자가 컨텍스트에 있으면 각각 적으세요.")
+    if "언제" in normalized or "회의 날짜" in normalized:
+        requirements.append("- 날짜/문서 위치 질문: 회의 날짜, 문서 제목·경로, 핵심 논의 요약을 함께 적으세요.")
+    if "폴더" in normalized or "shared/hooks" in normalized or "feature" in normalized:
+        requirements.append("- 폴더 컨벤션 질문: widget/feature/shared/hooks/domain의 기준, 미결 여부, 제안된 대안을 원문 표기로 적으세요.")
+    requirements.append("- 컨텍스트에 없는 체크리스트 항목은 없다고 명시하고 추측하지 마세요.")
+    return "\n".join(requirements)
 
 
 def _write_dry_run(
@@ -253,6 +289,7 @@ def _write_dry_run(
 
 def _write_record(stream: TextIO, record: BenchmarkRecord) -> None:
     stream.write(json.dumps(asdict(record), ensure_ascii=False, sort_keys=True) + "\n")
+    stream.flush()
 
 
 def _load_settings(console: Console) -> NimSettings:

--- a/tools/llm-benchmark/run_benchmark.py
+++ b/tools/llm-benchmark/run_benchmark.py
@@ -60,12 +60,8 @@ _SYSTEM_INSTRUCTIONS: Final[str] = """당신은 Knot 팀 문서 검색 평가용
 근거가 없으면 찾지 못했다고 말하고, 문서가 충돌하면 각 주장을 나열한 뒤 최종 결정을 단정하지 마세요.
 질문에 날짜, 위치, 요약, 결정 사실, 결정 근거처럼 여러 요구가 있으면 명시된 요소를 모두 답하세요.
 날짜·문서 위치 질문은 날짜와 문서 제목/경로뿐 아니라 문서의 핵심 내용을 짧게 요약하세요.
-사실 질문도 컨텍스트에 함께 명시된 관련 규칙(예: ORM과 Migration)은 생략하지 마세요.
-백엔드 DB 선택 질문에서는 컨텍스트에 있는 DB, ORM, DB Migration 선택을 각각 구분해 답하세요.
-폴더 구조·컨벤션 질문에서는 핵심 계층/배치 기준과 미결 사항이 있으면 함께 답하세요.
-세션 저장소·기술 선택 질문에서는 컨텍스트에 결정 상태와 결정일이 있으면 함께 답하세요.
 결정 이유 질문은 문제·대안·결정·근거를 구분하고, 문서에 결정일·현재 상태가 있으면 함께 답하세요.
-문서의 경로·기술 식별자는 번역하지 말고 `widget`, `feature`, `shared/hooks/domain`처럼 원문 표기를 유지하세요.
+문서의 경로·기술 식별자는 번역하지 말고 원문 표기를 유지하세요.
 답변을 한 줄로 끝내지 말고, 컨텍스트에서 확인되는 근거를 2~5개의 문장 또는 글머리표로 정리하세요.
 날짜는 문서의 회의 날짜를 사용하고 최종 수정일을 추측하지 마세요. 문서가 여러 개면 각각의 사실을 구분해 적으세요.
 답변 끝에는 사용한 source_path를 [source: 경로] 형식으로 표시하세요.
@@ -236,14 +232,8 @@ def _answer_requirements(question: str, history: tuple[ChatMessage, ...] = ()) -
     ]
     if any(marker in normalized for marker in ("왜", "이유", "선택한")):
         requirements.append("- 결정 이유: 문제, 대안, 결정, 근거를 구분하고 결정일·현재 상태가 있으면 함께 적으세요.")
-    if "db" in normalized or "데이터베이스" in normalized:
-        requirements.append("- 백엔드 DB 질문: DB, ORM, DB Migration 선택이 컨텍스트에 있으면 각각 적으세요.")
-    if "로드맵" in normalized:
-        requirements.append("- 로드맵 결정 질문: 사용자 인터뷰, 로드맵 지정, 레벨 3 기능 리스트업, 담당자가 컨텍스트에 있으면 각각 적으세요.")
     if "언제" in normalized or "회의 날짜" in normalized:
         requirements.append("- 날짜/문서 위치 질문: 회의 날짜, 문서 제목·경로, 핵심 논의 요약을 함께 적으세요.")
-    if "폴더" in normalized or "shared/hooks" in normalized or "feature" in normalized:
-        requirements.append("- 폴더 컨벤션 질문: widget/feature/shared/hooks/domain의 기준, 미결 여부, 제안된 대안을 원문 표기로 적으세요.")
     requirements.append("- 컨텍스트에 없는 체크리스트 항목은 없다고 명시하고 추측하지 마세요.")
     return "\n".join(requirements)
 

--- a/tools/llm-benchmark/run_four_way_benchmark.py
+++ b/tools/llm-benchmark/run_four_way_benchmark.py
@@ -40,6 +40,7 @@ from nim_embedding_client import NimEmbeddingClient
 from pgvector_index import chunk_documents, index_corpus
 from pgvector_store import PgVectorStore, PgVectorStoreError
 from pydantic import ValidationError
+from retrieval_policy import plan_query
 from rich.console import Console
 from run_benchmark import BenchmarkRecord, _messages, _write_record
 
@@ -48,6 +49,8 @@ _DEFAULT_GOLD_SET = Path("docs/llm-search-benchmark-gold-set.md")
 _DEFAULT_OUTPUT = Path(".benchmark-data/four-way-results.jsonl")
 _DEFAULT_DATABASE_URL = "postgresql://knot_benchmark:knot_benchmark@localhost:55432/knot_benchmark"
 _DEFAULT_CORPUS_KEY: Final[str] = "notion-export"
+_DEFAULT_CHUNK_SIZE: Final[int] = 1200
+_DEFAULT_CHUNK_OVERLAP: Final[int] = 180
 _DEFAULT_CASES: Final[tuple[str, ...]] = (
     "G-001",
     "G-002",
@@ -82,11 +85,11 @@ def main(
     case: str | None = typer.Option(None, help="Comma-separated case IDs; defaults to ten single-turn cases."),
     strategy: str = typer.Option(RunMode.ALL, help="all, raw, rag, db, or mcp-replay."),
     repeats: int = typer.Option(10, min=1, help="Repeats per case."),
-    top_k: int = typer.Option(5, min=1, help="Distinct source documents per retrieved context."),
+    top_k: int = typer.Option(3, min=1, help="Distinct source documents per retrieved context."),
     seed: int = typer.Option(20260901, help="Randomization seed."),
     warmup: int = typer.Option(1, min=0, help="Unrecorded chat warm-up calls."),
-    chunk_size: int = typer.Option(700, min=100, help="Passage chunk size in characters."),
-    chunk_overlap: int = typer.Option(100, min=0, help="Passage overlap in characters."),
+    chunk_size: int = typer.Option(_DEFAULT_CHUNK_SIZE, min=100, help="Passage chunk size in characters."),
+    chunk_overlap: int = typer.Option(_DEFAULT_CHUNK_OVERLAP, min=0, help="Passage overlap in characters."),
     max_generation_context_chars: int = typer.Option(120_000, min=1, help="Reject oversized model contexts."),
     retrieval_only: bool = typer.Option(False, help="Measure access latency without calling the chat model."),
     skip_index: bool = typer.Option(False, help="Reuse the existing persisted Qwen pgvector corpus."),
@@ -149,12 +152,65 @@ def _run_observation(
         started = time.perf_counter()
         context = ContextPack("", (), 0, 0)
         timing = AccessContextTiming(context, 0.0, 0.0)
+        query_plan = plan_query(question, _previous_questions(history))
         try:
-            timing = build_access_context(label, question, documents, store, embedding_client, corpus_key, top_k)
+            if query_plan.should_clarify:
+                answer = query_plan.clarification_text
+                _write_record(
+                    stream,
+                    _record(
+                        benchmark_case,
+                        trial,
+                        turn_number,
+                        label,
+                        question,
+                        context,
+                        (time.perf_counter() - started) * 1000,
+                        timing,
+                        answer,
+                        None,
+                        None,
+                        None,
+                    ),
+                )
+                history.extend((ChatMessage(role="user", content=question), ChatMessage(role="assistant", content=answer)))
+                continue
+            timing = build_access_context(
+                label,
+                question,
+                documents,
+                store,
+                embedding_client,
+                corpus_key,
+                top_k,
+                query_plan=query_plan,
+            )
             context = timing.context
             search_ms = (time.perf_counter() - started) * 1000
+            if label == "rag" and context.retrieved_count == 0:
+                answer = "현재 동기화된 팀 문서에서는 관련된 정보를 찾지 못했습니다. 최신 문서가 반영되지 않았다면 동기화 후 다시 검색해보세요."
+                _write_record(
+                    stream,
+                    _record(
+                        benchmark_case,
+                        trial,
+                        turn_number,
+                        label,
+                        question,
+                        context,
+                        search_ms,
+                        timing,
+                        answer,
+                        None,
+                        None,
+                        None,
+                    ),
+                )
+                history.extend((ChatMessage(role="user", content=question), ChatMessage(role="assistant", content=answer)))
+                continue
             if retrieval_only:
                 _write_record(stream, _record(benchmark_case, trial, turn_number, label, question, context, search_ms, timing, None, None, None, None))
+                history.append(ChatMessage(role="user", content=question))
                 continue
             if chat_client is None:
                 raise NimTransportError("chat client is not configured")
@@ -168,6 +224,10 @@ def _run_observation(
         except (NimRequestError, NimTransportError, PgVectorStoreError) as error:
             search_ms = (time.perf_counter() - started) * 1000
             _write_record(stream, _record(benchmark_case, trial, turn_number, label, question, context, search_ms, timing, "", None, None, str(error)))
+
+
+def _previous_questions(history: list[ChatMessage]) -> tuple[str, ...]:
+    return tuple(message.content for message in history if message.role == "user")
 
 
 def _record(

--- a/tools/llm-benchmark/run_pgvector_ab_benchmark.py
+++ b/tools/llm-benchmark/run_pgvector_ab_benchmark.py
@@ -54,8 +54,8 @@ _DEFAULT_GOLD_SET = Path("docs/llm-search-benchmark-gold-set.md")
 _DEFAULT_OUTPUT = Path(".benchmark-data/pgvector-ab-results.jsonl")
 _DEFAULT_DATABASE_URL = "postgresql://knot_benchmark:knot_benchmark@localhost:55432/knot_benchmark"
 _DEFAULT_CORPUS_KEY: Final[str] = "notion-export"
-_DEFAULT_CHUNK_SIZE: Final[int] = 700
-_DEFAULT_CHUNK_OVERLAP: Final[int] = 100
+_DEFAULT_CHUNK_SIZE: Final[int] = 1200
+_DEFAULT_CHUNK_OVERLAP: Final[int] = 180
 
 
 @dataclass(frozen=True, slots=True)

--- a/tools/llm-benchmark/test_benchmark_core.py
+++ b/tools/llm-benchmark/test_benchmark_core.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from benchmark_core import Strategy, build_context, load_snapshot
+from benchmark_core import Strategy, build_context, chunk_text, load_snapshot, tokenize
 from gold_set import load_cases
 
 
@@ -107,3 +107,23 @@ def test_build_context_retrieves_relevant_chunks_and_marks_mcp_call(tmp_path: Pa
     assert len(set(rag_context.source_paths)) == 1
     assert mcp_context.tool_calls == 1
     assert "Redis" in mcp_context.text
+
+
+def test_tokenize_removes_korean_suffixes_from_latin_identifiers() -> None:
+    assert tokenize("PostgreSQL을 camelCase라는데 8월 폴더구조") == (
+        "postgresql",
+        "camelcase",
+        "8월",
+        "폴더구조",
+        "폴더",
+        "구조",
+    )
+
+
+def test_chunk_text_keeps_markdown_sections_as_retrieval_units() -> None:
+    content = "# 기술 문서\n소개\n## PostgreSQL\n관계형 데이터를 안정적으로 관리한다.\n## Redis\n중앙 세션 저장소다."
+
+    chunks = chunk_text(content, size=120, overlap=20)
+
+    assert any("## PostgreSQL" in chunk and "관계형" in chunk for chunk in chunks)
+    assert any("## Redis" in chunk and "세션" in chunk for chunk in chunks)

--- a/tools/llm-benchmark/test_pgvector_index.py
+++ b/tools/llm-benchmark/test_pgvector_index.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchmark_core import Document
+from pgvector_index import chunk_documents
+
+
+def test_chunk_documents_carries_meeting_metadata_into_detail_passages() -> None:
+    document = Document(
+        Path("meeting.md"),
+        "회의",
+        "# 폴더구조 컨벤션 회의\n날짜: 2026년 8월 14일\n회의 유형: 프론트 회의\n\n## 논의 내용\n" + "위젯과 피처 규칙 " * 100,
+    )
+
+    chunks = chunk_documents((document,), size=120, overlap=20)
+
+    assert len(chunks) > 1
+    assert all("날짜: 2026년 8월 14일" in chunk.content for chunk in chunks)
+    assert any("위젯과 피처 규칙" in chunk.content for chunk in chunks)

--- a/tools/llm-benchmark/test_retrieval_policy.py
+++ b/tools/llm-benchmark/test_retrieval_policy.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pgvector_rag import rank_hybrid_candidates
+from pgvector_store import StoredChunk
+from retrieval_policy import QueryKind, plan_query
+
+
+def _chunk(path: str, title: str, content: str = "PostgreSQL 문서") -> StoredChunk:
+    return StoredChunk(path, title, content, 0.8)
+
+
+def test_plan_query_classifies_decision_questions_and_broad_questions() -> None:
+    decision = plan_query("PostgreSQL을 왜 쓰기로 했어?", ())
+    broad = plan_query("우리 프로젝트 어떻게 진행되고 있어?", ())
+
+    assert decision.kind is QueryKind.DECISION_REASON
+    assert not decision.should_clarify
+    assert broad.kind is QueryKind.BROAD
+    assert broad.should_clarify
+
+
+def test_plan_query_classifies_conflicting_naming_question_as_ambiguous() -> None:
+    plan = plan_query("camelCase랑 snake_case 중 어떤 걸 써?", ())
+
+    assert plan.kind is QueryKind.AMBIGUOUS
+
+
+def test_plan_query_rewrites_deictic_follow_up_with_previous_question() -> None:
+    plan = plan_query("그 회의에서 뭘 정했어?", ("로드맵 회의 언제 했지?",))
+
+    assert plan.search_query.startswith("로드맵 회의 언제 했지? 그 회의에서 뭘 정했어?")
+    assert "결정 사항" in plan.search_query
+    assert plan.kind is QueryKind.MEETING_DATE
+
+    folder_plan = plan_query("폴더구조 회의에서 뭘 정했어?", ())
+    assert "위젯" in folder_plan.search_query
+
+    location_plan = plan_query("폴더구조 컨벤션 회의는 언제였고 문서 어디 있어?", ())
+    assert "shared/hooks/domain" in location_plan.search_query
+    assert location_plan.kind is QueryKind.MEETING_DATE
+
+
+def test_plan_query_marks_related_document_follow_up() -> None:
+    plan = plan_query("관련된 거 더 알려줘.", ("PostgreSQL을 왜 쓰기로 했어?",))
+
+    assert plan.related_documents
+    assert "PostgreSQL" in plan.search_query
+    assert plan.kind is QueryKind.DECISION_REASON
+
+
+def test_hybrid_rerank_unions_keyword_only_authoritative_source() -> None:
+    vector_candidates = (
+        _chunk(
+            "기능 요구 사항/결과 기반 관련 문서 추천 496de1156a83823da76a8156f2726936.md",
+            "결과 기반 관련 문서 추천",
+            "PostgreSQL을 사용한 이유는 팀원들의 사용 경험이다.",
+        ),
+        _chunk("BE 위키/09 패키지 구조.md", "패키지 구조"),
+    )
+    keyword_candidates = (
+        _chunk(
+            "백엔드/01 기술 스택과 라이브러리 도입 fffde1156a83837097bc818fab8a1fa4.md",
+            "01. 기술 스택과 라이브러리 도입",
+            "관계형 데이터를 안정적으로 관리하고 pgvector로 확장할 수 있어 PostgreSQL을 선택했다.",
+        ),
+        vector_candidates[0],
+    )
+
+    selected = rank_hybrid_candidates(
+        "PostgreSQL을 왜 쓰기로 했어?",
+        vector_candidates,
+        keyword_candidates,
+        QueryKind.DECISION_REASON,
+        3,
+    )
+
+    assert selected[0].source_path.startswith("백엔드/01 기술 스택과")
+    assert len({item.source_path for item in selected}) == len(selected)
+
+
+def test_hybrid_rerank_prioritizes_meeting_source_for_date_question() -> None:
+    vector_candidates = (
+        _chunk("쓰레기통/로드맵 정리.md", "로드맵 정리"),
+        _chunk("회의록/로드맵 기반 기획 회의 453de1156a838282959681990c718da2.md", "로드맵 기반 기획 회의"),
+    )
+
+    selected = rank_hybrid_candidates(
+        "로드맵 기반 기획 회의 언제 했지?",
+        vector_candidates,
+        (),
+        QueryKind.MEETING_DATE,
+        1,
+    )
+
+    assert selected[0].source_path.startswith("회의록/로드맵 기반 기획 회의")
+
+
+def test_hybrid_rerank_prefers_exact_decision_subject_over_generic_authority() -> None:
+    vector_candidates = (
+        _chunk("백엔드/01 기술 스택과 라이브러리 도입.md", "기술 스택", "관계형 데이터베이스를 사용한다."),
+        _chunk("회의록/인터뷰 정리 & 로드맵 구성.md", "인터뷰 정리", "세션을 공유해야 해서 Redis를 선택했다."),
+    )
+
+    selected = rank_hybrid_candidates(
+        "세션 저장소로 Redis를 선택한 이유가 뭐야?",
+        vector_candidates,
+        (),
+        QueryKind.DECISION_REASON,
+        1,
+    )
+
+    assert selected[0].source_path.startswith("회의록/인터뷰 정리")
+
+
+def test_hybrid_rerank_prefers_conflict_evidence_over_date_only_match() -> None:
+    vector_candidates = (
+        _chunk("회의록/제목 없음.csv", "회의록", "2026년 8월 3일 회의록"),
+        _chunk("기능 요구 사항/자연어 기반 AI 정보 탐색.md", "자연어 기반 AI 정보 탐색", "8월 3일은 snake_case, 8월 10일은 camelCase로 기록됐다."),
+    )
+
+    selected = rank_hybrid_candidates(
+        "8월 3일 회의록은 snake_case고 8월 10일 컨벤션 문서는 camelCase라는데 뭐가 맞아?",
+        vector_candidates,
+        (),
+        QueryKind.CONFLICT,
+        1,
+    )
+
+    assert selected[0].source_path.startswith("기능 요구 사항/자연어 기반")
+
+
+def test_related_document_request_keeps_three_high_value_backend_sources() -> None:
+    candidates = (
+        _chunk("인프라/AWS/RDS PostgreSQL 연결.md", "RDS PostgreSQL 연결", "PostgreSQL 운영 연결"),
+        _chunk("백엔드/01 기술 스택과 라이브러리 도입.md", "기술 스택", "PostgreSQL을 선택한 이유"),
+        _chunk("백엔드/05 데이터베이스와 Migration 규칙.md", "데이터베이스와 Migration 규칙", "PostgreSQL 규칙"),
+        _chunk("백엔드/07 테스트 전략과 기준.md", "테스트 전략과 기준", "PostgreSQL 테스트"),
+    )
+
+    selected = rank_hybrid_candidates(
+        "PostgreSQL을 왜 쓰기로 했어? 관련된 거 더 알려줘.",
+        candidates,
+        (),
+        QueryKind.DECISION_REASON,
+        3,
+        related_documents=True,
+    )
+
+    paths = tuple(item.source_path for item in selected)
+    assert paths[0].startswith("백엔드/01 기술 스택과")
+    assert any(path.startswith("백엔드/05 데이터베이스") for path in paths)
+    assert any(path.startswith("백엔드/07 테스트 전략") for path in paths)
+
+
+def test_hybrid_rerank_uses_keyword_chunk_when_vector_chunk_is_less_specific() -> None:
+    path = "회의록/폴더구조 컨벤션 회의 da1de1156a8383a09397012c78e7ee84.md"
+    vector_candidates = (_chunk(path, "폴더구조 컨벤션 회의", "AI 사용 비중과 회의 진행 방식"),)
+    keyword_candidates = (
+        _chunk(path, "폴더구조 컨벤션 회의", "미해결 쟁점: shared/hooks/domain과 feature 중 배치 기준"),
+    )
+
+    selected = rank_hybrid_candidates(
+        "폴더구조 컨벤션 회의에서 뭘 정했어?",
+        vector_candidates,
+        keyword_candidates,
+        QueryKind.FACT,
+        1,
+    )
+
+    assert "미해결 쟁점" in selected[0].content
+
+
+def test_hybrid_rerank_uses_reason_passage_over_decision_result_table() -> None:
+    path = "백엔드/01 기술 스택과 라이브러리 도입 fffde1156a83837097bc818fab8a1fa4.md"
+    vector_candidates = (_chunk(path, "기술 스택", "## 3. 결정 결과\n| 데이터베이스 | PostgreSQL |"),)
+    keyword_candidates = (_chunk(path, "기술 스택", "### PostgreSQL\n관계형 데이터를 안정적으로 관리하고 pgvector로 확장한다."),)
+
+    selected = rank_hybrid_candidates(
+        "PostgreSQL을 왜 쓰기로 했어?",
+        vector_candidates,
+        keyword_candidates,
+        QueryKind.DECISION_REASON,
+        1,
+    )
+
+    assert "관계형 데이터를" in selected[0].content
+
+
+def test_hybrid_rerank_prefers_specific_folder_decision_passage() -> None:
+    vector_candidates = (
+        _chunk("회의록/폴더 구조 컨벤션 논의.md", "폴더 구조 컨벤션 논의", "폴더 구조를 논의했다."),
+        _chunk(
+            "회의록/폴더구조 컨벤션 회의.md",
+            "폴더구조 컨벤션 회의",
+            "합의된 규칙과 미해결 핵심 쟁점: shared/hooks/domain과 feature",
+        ),
+    )
+
+    selected = rank_hybrid_candidates(
+        "폴더구조 컨벤션 회의에서 뭘 정했어?",
+        vector_candidates,
+        (),
+        QueryKind.DECISION_REASON,
+        1,
+    )
+
+    assert selected[0].source_path.startswith("회의록/폴더구조 컨벤션 회의")
+
+
+def test_hybrid_rerank_prefers_exact_meeting_title_over_related_discussion_title() -> None:
+    vector_candidates = (
+        _chunk("회의록/폴더 구조 컨벤션 논의.md", "폴더 구조 컨벤션 논의", "폴더 구조를 논의했다."),
+        _chunk("회의록/폴더구조 컨벤션 회의.md", "폴더구조 컨벤션 회의", "합의된 규칙과 미해결 핵심 쟁점"),
+    )
+
+    selected = rank_hybrid_candidates(
+        "폴더구조 컨벤션 회의에서 뭘 정했어?",
+        vector_candidates,
+        (),
+        QueryKind.DECISION_REASON,
+        1,
+    )
+
+    assert selected[0].title == "폴더구조 컨벤션 회의"

--- a/tools/llm-benchmark/test_retrieval_policy.py
+++ b/tools/llm-benchmark/test_retrieval_policy.py
@@ -33,11 +33,26 @@ def test_plan_query_rewrites_deictic_follow_up_with_previous_question() -> None:
     assert plan.kind is QueryKind.MEETING_DATE
 
     folder_plan = plan_query("폴더구조 회의에서 뭘 정했어?", ())
-    assert "위젯" in folder_plan.search_query
+    assert "결정 사항" in folder_plan.search_query
 
     location_plan = plan_query("폴더구조 컨벤션 회의는 언제였고 문서 어디 있어?", ())
-    assert "shared/hooks/domain" in location_plan.search_query
     assert location_plan.kind is QueryKind.MEETING_DATE
+
+
+def test_holdout_query_does_not_receive_gold_answer_terms() -> None:
+    holdout_queries = (
+        "로드맵에서 다음 분기에 뭘 정했어?",
+        "폴더 구조 회의에서 어떤 기준을 정했어?",
+        "알림 저장소에서 어떤 방식을 선택했어?",
+    )
+
+    for question in holdout_queries:
+        search_query = plan_query(question, ()).search_query.casefold()
+
+        assert "흑곰" not in search_query
+        assert "shared/hooks/domain" not in search_query
+        assert "level 3" not in search_query
+        assert "레벨 3" not in search_query
 
 
 def test_plan_query_marks_related_document_follow_up() -> None:


### PR DESCRIPTION
## 관련 이슈

- Refs #273

## 작업 내용

- Markdown heading 경계와 문서 메타데이터를 보존하는 1200자·overlap 180자 청킹을 적용했습니다.
- PostgreSQL lexical/vector 후보를 합치고 문서 유형·권위·질문 유형·대화 맥락을 반영하는 source-level hybrid ranking을 추가했습니다.
- 동일 출처의 근거 passage를 보강하고 관련 문서를 최대 3개로 제한했습니다.
- 근거가 없는 기술 식별자는 무응답으로 종료하고, 충돌·광범위·후속·문서 위치 질문은 질문 정책에 맞게 처리합니다.
- 평가셋의 정답 고유어(`흑곰`, `shared/hooks/domain`, `레벨 3`, 특정 PostgreSQL·Redis 근거)를 검색 경로·랭커·생성 체크리스트에서 제거하고, holdout 질문 회귀 테스트를 추가했습니다.
- 검색 정책·청킹·메타데이터·랭킹 회귀 테스트를 추가했습니다.

### 참고 사항

- 벤치마크 전용 코드이며 제품 Java `backend/src/main`에는 포함하지 않았습니다.
- 검증: benchmark pytest 28 passed, Ruff PASS, `git diff --check` PASS.
- 리뷰 반영 후 동일 snapshot·13 case·16 turn·10회 retrieval-only를 재실행한 결과는 `160`행, `retrieval_gate=140/160`입니다. G-009와 G-013 후속 turn은 아직 정답 source를 충족하지 못했으며, 결과와 재현 명령은 #309 보고서에 기록했습니다.
- `.benchmark-data/` 원문·실행 산출물과 credential은 커밋하지 않았습니다.