### PR TITLE
[BE] RAG 품질 평가 게이트와 결과 보고 추가

### DIFF
--- a/docs/llm-search-ab-test-report.md
+++ b/docs/llm-search-ab-test-report.md
@@ -12,6 +12,21 @@
 - temperature: `0`, Qwen 질의 instruction: 영어 한 문장 사용
 - 실제 MCP smoke test: LM Studio `mcp/notion` + Notion OAuth, `notion-search`/`notion-fetch`
 
+## 최신 RAG 품질 게이트
+
+초기 검색 오류를 보정한 뒤 `tools/llm-benchmark`에서 동일한 Notion export snapshot을 다시 평가했다. benchmark 코드는 Java `src/main`에 포함하지 않고 테스트 하네스 디렉터리에만 둔다.
+
+- 코퍼스: 461개 문서, heading-aware metadata 보존 청크 1,788개, 기본 `1200자 / overlap 180자`
+- 검색 구조: vector·PostgreSQL lexical 후보를 각각 수집 → 출처 단위 union/rerank → 출처별 근거 passage를 최대 4개까지 결합
+- retrieval-only: 13개 case, 16개 turn을 10회 반복한 160개 관측
+- retrieval gate: **160/160 PASS** — 기대 page ID, 중복 출처, 최대 3개 문서, MongoDB 무응답, 광범위 질문 명확화를 검사
+- 검색 지연: `search_ms` p50 **343.0ms**, p95 **968.1ms**; embedding p50 **157.3ms**, DB 단계 p50 **185.9ms**
+- Qwen e2e: 16개 turn 1회 생성, 무응답·명확화 2개는 결정형 응답으로 처리
+- answer policy gate: **16/16 PASS** — 질문 유형별 필수 사실·후속 맥락·충돌·무응답 형식을 검사
+- e2e TTFT: p50 **4,469.9ms**, p95 **9,137.5ms**, 5초 이내 **9/14**. 따라서 검색 자체는 1초 안쪽이지만 Qwen 27B 생성 지연 때문에 전체 5초 목표는 아직 보장하지 않는다.
+
+이 gate는 gold set의 출처·정책·필수 표현을 자동 검사한 결과이며, 다른 Workspace로 일반화하려면 30개 이상 독립 질문과 사람이 원문을 대조한 의미 정확성 라벨이 추가로 필요하다.
+
 ## 전략별 결과
 
 | 전략 | 검색 기록 | 생성 성공 | 생성 오류 | 검색 p50 | 검색 p95 | 임베딩 p50 | DB/구성 p50 | 5초 내 TTFT | 정답 source hit@5 |
@@ -86,12 +101,18 @@
 - 5초 목표는 end-to-end TTFT 기준이어야 한다. 검색만 빠른 DB/RAG가 곧 사용자 답변 성공을 뜻하지 않으며, 관련 문서·답변 의미·충돌·무응답은 사람이 원문과 대조해야 한다.
 - 이번 `mcp-replay`는 snapshot을 로컬 함수로 재생했다. 실제 Notion MCP/API의 네트워크·페이지네이션·권한·rate limit은 측정하지 않았다.
 
-## 관찰된 품질 이슈
+## 초기 실행에서 확인된 품질 이슈 (개선 전)
 
 - RAG는 G-001/G-003에서 요구사항 문서의 예시 문장인 ‘팀원들의 PostgreSQL 사용 경험’을 실제 선정 이유처럼 답했다. 기술 스택 원문이 말하는 관계형 데이터 관리와 pgvector 확장 이유와 구분하지 못했으므로, 검색 속도와 별개로 source 유형/예시 판별 또는 reranker가 필요하다.
 - G-004의 Redis 결정 이유와 G-006의 문서 위치는 상위 5개 후보에 안정적으로 들어오지 않았다. 현재 Qwen 임베딩을 한국어에 쓸 수 있다는 사실만으로 검색 품질이 충분하다고 결론내릴 수 없다.
 - G-009는 DB 규칙과 Java 규칙을 함께 보여야 하는데 일부 전략은 한 규칙만 제공하거나 문서 충돌로 잘못 분류했다.
 
+위 문제는 최신 RAG gate에서 다음처럼 보정했다.
+
+- 기술 식별자 exact-match와 문서 권위 점수를 반영해 PostgreSQL 선정 이유와 Redis 세션 근거를 분리했다.
+- Markdown heading과 문서 날짜 메타데이터를 청크에 보존하고, 동일 출처의 근거 passage를 함께 전달해 날짜·요약·미결 사항 누락을 줄였다.
+- 후속 질문은 이전 turn을 검색어와 답변 체크리스트에 반영하고, MongoDB 부재 질문과 너무 넓은 질문은 모델 호출 전에 결정형으로 종료한다.
+
 ## 다음 판정
 
-MVP 기본 경로는 `마지막 성공 동기화 스냅샷 → DB/키워드 pre-filter → Qwen pgvector RAG → 필요 시 rerank`의 단계형 구조로 결정했다. 실제 Notion MCP 연결은 가능하다는 것을 확인했지만, 현재 live smoke test는 end-to-end 5초 목표를 만족하지 못했고 LM Studio-managed OAuth만 검증했다. 전체 사용자 대상 운영 전환 전에는 Java credential forwarding, 30개 이상 독립 질문, 사람이 검증한 answer/source 품질 라벨을 추가해야 한다.
+MVP 구현 후보는 `마지막 성공 동기화 스냅샷 → PostgreSQL lexical/vector 후보 union → Qwen pgvector RAG → 필요 시 rerank`의 단계형 구조로 검증했다. 실제 Notion MCP 연결은 가능하다는 것을 확인했지만, 현재 live smoke test는 end-to-end 5초 목표를 만족하지 못했고 LM Studio-managed OAuth만 검증했다. 전체 사용자 대상 운영 전환 전에는 Java credential forwarding, 30개 이상 독립 질문, 사람이 검증한 answer/source 품질 라벨을 추가해야 한다.

--- a/docs/llm-search-ab-test-report.md
+++ b/docs/llm-search-ab-test-report.md
@@ -12,22 +12,62 @@
 - temperature: `0`, Qwen 질의 instruction: 영어 한 문장 사용
 - 실제 MCP smoke test: LM Studio `mcp/notion` + Notion OAuth, `notion-search`/`notion-fetch`
 
-## 최신 RAG 품질 게이트
+## 실행 식별자와 재현성 경계
 
-초기 검색 오류를 보정한 뒤 `tools/llm-benchmark`에서 동일한 Notion export snapshot을 다시 평가했다. benchmark 코드는 Java `src/main`에 포함하지 않고 테스트 하네스 디렉터리에만 둔다.
+이 문서의 기존 전략 비교표와 `최신 RAG 품질 게이트` 수치는 PR #309의 현재 HEAD에서 생성된 결과가 아니다. 기존 PASS 결과는 PR #308의 리뷰 반영 전 실행 commit `1e56e02`에서 생성된 역사적 참고치이며, PR #309는 당시 그 검색 구현을 포함하지 않는다.
+
+- 기존 결과 실행 commit: PR #308 `1e56e02` (리뷰 반영 전)
+- 기존 결과 snapshot manifest SHA-256: `7bc3e082e1b55174aacf7d77f6fe2669ae0ef1d9cf989dd857890f06916e75c`
+- PR #308 리뷰 반영 후 검색 commit: `929d7f8`
+- PR #309와 #308은 별도 PR이다. 아래의 기존 결과는 #308 검색 구현과 해당 snapshot을 함께 사용해야 재현할 수 있다.
+- 기존 실행 조건: `top_k=3`, `chunk_size=1200`, `chunk_overlap=180`, retrieval 10회 반복, e2e는 별도 1회 실행
+
+따라서 기존 결과의 `160/160 PASS`는 현재 코드의 acceptance 결과로 사용하지 않는다. #308 수정 후 동일 snapshot과 조건으로 재실행한 결과는 아래에 별도로 기록한다.
+
+## 최신 RAG 품질 게이트 (이전 #308 실행 기록)
+
+초기 검색 오류를 보정한 뒤 PR #308 리뷰 반영 전 코드에서 동일한 Notion export snapshot을 평가한 기록이다. benchmark 코드는 Java `src/main`에 포함하지 않고 테스트 하네스 디렉터리에만 둔다.
 
 - 코퍼스: 461개 문서, heading-aware metadata 보존 청크 1,788개, 기본 `1200자 / overlap 180자`
 - 검색 구조: vector·PostgreSQL lexical 후보를 각각 수집 → 출처 단위 union/rerank → 출처별 근거 passage를 최대 4개까지 결합
 - retrieval-only: 13개 case, 16개 turn을 10회 반복한 160개 관측
-- retrieval gate: **160/160 PASS** — 기대 page ID, 중복 출처, 최대 3개 문서, MongoDB 무응답, 광범위 질문 명확화를 검사
+- retrieval gate: **160/160 PASS (이전 실행)** — 기대 page ID, 중복 출처, 최대 3개 문서, MongoDB 무응답, 광범위 질문 명확화를 검사
 - 검색 지연: `search_ms` p50 **343.0ms**, p95 **968.1ms**; embedding p50 **157.3ms**, DB 단계 p50 **185.9ms**
 - Qwen e2e: 16개 turn 1회 생성, 무응답·명확화 2개는 결정형 응답으로 처리
-- answer policy gate: **16/16 PASS** — 질문 유형별 필수 사실·후속 맥락·충돌·무응답 형식을 검사
+- answer policy gate: **16/16 PASS (이전 실행)** — 질문 유형별 필수 사실·후속 맥락·충돌·무응답 형식을 검사
 - e2e TTFT: p50 **4,469.9ms**, p95 **9,137.5ms**, 5초 이내 **9/14**. 따라서 검색 자체는 1초 안쪽이지만 Qwen 27B 생성 지연 때문에 전체 5초 목표는 아직 보장하지 않는다.
 
 이 gate는 gold set의 출처·정책·필수 표현을 자동 검사한 결과이며, 다른 Workspace로 일반화하려면 30개 이상 독립 질문과 사람이 원문을 대조한 의미 정확성 라벨이 추가로 필요하다.
 
-## 전략별 결과
+## #308 수정 후 동일 조건 retrieval-only 재실행
+
+평가셋 정답 단어를 검색 경로에서 제거한 PR #308 `929d7f8`을 기준으로, 위 manifest와 기존 `1788`개·`1024`차원 pgvector corpus를 사용해 다시 실행했다. 이 실행은 답변 생성이 아닌 검색 게이트만 측정했으며, 결과 파일은 저장소에 커밋하지 않았다.
+
+```bash
+uv run --python 3.14 tools/llm-benchmark/run_four_way_benchmark.py \
+  --snapshot-dir /Users/yongtae/Desktop/knot/.benchmark-data/notion-export \
+  --strategy rag \
+  --case G-001,G-002,G-003,G-004,G-005,G-006,G-007,G-008,G-009,G-010,G-011,G-012,G-013 \
+  --top-k 3 \
+  --repeats 10 \
+  --retrieval-only \
+  --skip-index \
+  --output /tmp/knot-rag-quality-fixed-929d7f8.jsonl
+```
+
+평가 명령은 PR #309의 evaluator로 실행했다.
+
+```bash
+uv run --python 3.14 tools/llm-benchmark/evaluate_rag_quality.py \
+  --results /tmp/knot-rag-quality-fixed-929d7f8.jsonl \
+  --gold-set docs/llm-search-benchmark-gold-set.md \
+  --strategy rag \
+  --repeats 10
+```
+
+관측 결과는 `results=160 expected=160`, `retrieval_gate=FAIL (140/160)`, `answer_gate=PARTIAL (20/20)`이었다. G-009 10회와 G-013 후속 turn 10회의 source 기대값이 충족되지 않아 검색 품질은 아직 PASS가 아니다. 이는 gold-set 고유어를 주입하지 않은 상태의 실제 회귀 결과이며, holdout 일반화와 기존 정답셋 품질을 모두 만족시키려면 문서 유형·질문 의도·일반 relevance 기준을 추가로 조정하고 다시 평가해야 한다.
+
+## 전략별 결과 (이전 #308 실행 기록)
 
 | 전략 | 검색 기록 | 생성 성공 | 생성 오류 | 검색 p50 | 검색 p95 | 임베딩 p50 | DB/구성 p50 | 5초 내 TTFT | 정답 source hit@5 |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -107,7 +147,7 @@
 - G-004의 Redis 결정 이유와 G-006의 문서 위치는 상위 5개 후보에 안정적으로 들어오지 않았다. 현재 Qwen 임베딩을 한국어에 쓸 수 있다는 사실만으로 검색 품질이 충분하다고 결론내릴 수 없다.
 - G-009는 DB 규칙과 Java 규칙을 함께 보여야 하는데 일부 전략은 한 규칙만 제공하거나 문서 충돌로 잘못 분류했다.
 
-위 문제는 최신 RAG gate에서 다음처럼 보정했다.
+위 문제는 이전 #308 실행에서 다음처럼 보정했다.
 
 - 기술 식별자 exact-match와 문서 권위 점수를 반영해 PostgreSQL 선정 이유와 Redis 세션 근거를 분리했다.
 - Markdown heading과 문서 날짜 메타데이터를 청크에 보존하고, 동일 출처의 근거 passage를 함께 전달해 날짜·요약·미결 사항 누락을 줄였다.
@@ -115,4 +155,4 @@
 
 ## 다음 판정
 
-MVP 구현 후보는 `마지막 성공 동기화 스냅샷 → PostgreSQL lexical/vector 후보 union → Qwen pgvector RAG → 필요 시 rerank`의 단계형 구조로 검증했다. 실제 Notion MCP 연결은 가능하다는 것을 확인했지만, 현재 live smoke test는 end-to-end 5초 목표를 만족하지 못했고 LM Studio-managed OAuth만 검증했다. 전체 사용자 대상 운영 전환 전에는 Java credential forwarding, 30개 이상 독립 질문, 사람이 검증한 answer/source 품질 라벨을 추가해야 한다.
+MVP 구현 후보는 `마지막 성공 동기화 스냅샷 → PostgreSQL lexical/vector 후보 union → Qwen pgvector RAG → 필요 시 rerank`의 단계형 구조로 검증했다. 다만 #308 리뷰 반영 후 동일 조건 재실행은 `140/160`으로 검색 gate를 통과하지 못했으므로, 기존 `160/160` 결과를 최종 품질 근거로 사용하지 않는다. 실제 Notion MCP 연결은 가능하다는 것을 확인했지만, 현재 live smoke test는 end-to-end 5초 목표를 만족하지 못했고 LM Studio-managed OAuth만 검증했다. 전체 사용자 대상 운영 전환 전에는 일반화된 retrieval 규칙 보완, Java credential forwarding, 30개 이상 독립 질문, 사람이 검증한 answer/source 품질 라벨을 추가해야 한다.

--- a/tools/llm-benchmark/README.md
+++ b/tools/llm-benchmark/README.md
@@ -2,9 +2,9 @@
 
 Notion `Markdown & CSV` 내보내기를 같은 스냅샷으로 고정한 뒤, Raw context·Qwen pgvector RAG·PostgreSQL 직접 검색·MCP replay를 동일한 로컬 채팅 모델로 비교하는 하네스다. LM Studio에서 실제 Notion MCP를 호출하는 smoke test는 별도 절차로 검증한다.
 
-현재 `rag`는 Qwen3-Embedding 0.6B GGUF를 LM Studio의 OpenAI-compatible `/v1/embeddings`로 호출하고 PostgreSQL/pgvector에 저장한다. `db`는 같은 저장소의 텍스트 인덱스만 사용하고, `mcp-replay`는 로컬 lexical 검색 결과를 읽기 도구 응답처럼 전달하는 통제군이다. 실제 Notion 네트워크·권한·페이지네이션을 측정하는 `mcp-live`는 smoke test와 전체 비교를 분리한다.
+현재 `rag`는 Qwen3-Embedding 0.6B GGUF를 LM Studio의 OpenAI-compatible `/v1/embeddings`로 호출하고 PostgreSQL/pgvector에 저장한다. benchmark 하네스는 제품 런타임에 포함하지 않고 이 디렉터리에서만 실행한다. `db`는 같은 저장소의 텍스트 인덱스만 사용하고, `mcp-replay`는 로컬 lexical 검색 결과를 읽기 도구 응답처럼 전달하는 통제군이다. 실제 Notion 네트워크·권한·페이지네이션을 측정하는 `mcp-live`는 smoke test와 전체 비교를 분리한다.
 
-MVP 제품 방향은 `PostgreSQL 키워드 pre-filter → pgvector RAG → 필요한 청크만 채팅 모델에 전달`하는 하이브리드 RAG다. 기능 계약은 [`docs/llm-search-feature-spec.md`](/Users/yongtae/Desktop/knot/docs/llm-search-feature-spec.md), 비교 결과는 [`docs/llm-search-ab-test-report.md`](/Users/yongtae/Desktop/knot/docs/llm-search-ab-test-report.md)에서 확인한다.
+MVP 제품 방향은 `PostgreSQL 키워드 pre-filter → pgvector RAG → 필요한 청크만 채팅 모델에 전달`하는 하이브리드 RAG다. 기본 Markdown 청크는 heading 경계를 우선하고 `1200자 / overlap 180자`로 생성한다. 질의마다 vector·lexical 후보를 각각 최대 50개 모은 뒤 출처별로 합치고, 질문 유형·문서 권위·정확한 기술 식별자·대화 맥락을 반영해 재정렬한다. 근거가 없는 기술명은 무응답으로, 범위가 넓은 질문은 명확화로 종료한다. 기능 계약은 [`docs/llm-search-feature-spec.md`](/Users/yongtae/Desktop/knot/docs/llm-search-feature-spec.md), 비교 결과는 [`docs/llm-search-ab-test-report.md`](/Users/yongtae/Desktop/knot/docs/llm-search-ab-test-report.md)에서 확인한다.
 
 ## 1. 내보내기 준비
 
@@ -85,9 +85,26 @@ uv run --python 3.14 tools/llm-benchmark/run_four_way_benchmark.py \
   --repeats 10 \
   --retrieval-only \
   --output .benchmark-data/four-way-retrieval-10x.jsonl
+
+uv run --python 3.14 tools/llm-benchmark/evaluate_rag_quality.py \
+  --results .benchmark-data/rag-quality-retrieval-final-10x.jsonl
 ```
 
 `--retrieval-only` 실행은 모델을 호출하지 않고 네 전략의 검색·컨텍스트 구성 시간을 10개 질문 × 10회씩 기록한다. 실제 답변 생성은 다음처럼 실행한다.
+
+품질 평가기는 gold set의 모든 case/turn/repeat가 생성됐는지, 출처 page ID가 기대값과 일치하는지, 출처가 3개를 넘지 않는지, 무응답·명확화 케이스가 빈 출처로 종료되는지를 검사한다. retrieval-only 결과에서는 답변 의미 품질을 `NOT_EVALUATED`로 표시하므로, 생성 결과는 `--require-answer`로 별도 검사하고 최종 의미 왜곡 여부는 사람이 원문과 대조한다.
+
+그룹별 e2e 결과를 합치지 않고도 다음처럼 `--results`를 반복해 한 번에 검사할 수 있다.
+
+```bash
+uv run --python 3.14 tools/llm-benchmark/evaluate_rag_quality.py \
+  --results .benchmark-data/rag-quality-e2e-final-core-guided.jsonl \
+  --results .benchmark-data/rag-quality-e2e-final-policy-guided.jsonl \
+  --results .benchmark-data/rag-quality-e2e-g007-guided-final.jsonl \
+  --results .benchmark-data/rag-quality-e2e-g013-guided-final.jsonl \
+  --repeats 1 \
+  --require-answer
+```
 
 ```bash
 uv run --python 3.14 tools/llm-benchmark/run_four_way_benchmark.py \

--- a/tools/llm-benchmark/answer_quality_policy.py
+++ b/tools/llm-benchmark/answer_quality_policy.py
@@ -1,0 +1,33 @@
+"""Lightweight answer-shape checks for the benchmark gold set."""
+
+from __future__ import annotations
+
+
+def answer_shape_passes(answer: str, case_id: str, turn: int) -> bool:
+    """Check required facts without pretending to replace human review."""
+    normalized = answer.casefold()
+    if case_id == "G-011":
+        return _has_group(normalized, (("확인할 수 없", "찾지 못", "없습니다"),))
+    if case_id == "G-012":
+        return _has_group(normalized, (("범위가 넓어요",), ("최근 결정사항",), ("로드맵",), ("백엔드",)))
+    return _has_group(normalized, _GROUPS.get((case_id, turn), ()))
+
+
+_GROUPS: dict[tuple[str, int], tuple[tuple[str, ...], ...]] = {
+    ("G-001", 1): (("postgresql",), ("jpa", "spring data jpa"), ("flyway", "migration")),
+    ("G-002", 1): (("snake_case",), ("복수형", "복수"), ("단수형", "단수")),
+    ("G-003", 1): (("postgresql",), ("관계형", "relational"), ("pgvector", "벡터 검색", "벡터검색")),
+    ("G-004", 1): (("redis",), ("중앙", "central"), ("확장", "여러 서버", "여러서버"), ("8월 19일", "2026-08-19")),
+    ("G-005", 1): (("2026년 8월 19일", "8월 19일", "2026-08-19"), ("로드맵",), ("인터뷰",)),
+    ("G-006", 1): (("2026년 8월 14일", "8월 14일", "2026-08-14"), ("widget", "위젯"), ("feature", "피처"), ("shared/hooks", "shared vs feature", "훅"), ("미결", "확정되지", "논의")),
+    ("G-007", 2): (("로드맵",), ("level 3", "level3", "레벨 3", "레벨3"), ("기능", "feature"), ("흑곰", "기획안", "요구사항")),
+    ("G-008", 2): (("미결", "확정되지", "아직"), ("shared/hooks/domain", "shared/hooks"), ("feature",), ("두 번째", "두번째", "2회째", "여러 화면")),
+    ("G-009", 1): (("snake_case",), ("camelcase",), ("테이블", "컬럼", "database"), ("java", "메서드", "변수")),
+    ("G-010", 1): (("snake_case",), ("camelcase",), ("확정", "충돌", "다르게", "어렵")),
+    ("G-013", 1): (("postgresql",), ("관계형", "relational"), ("pgvector", "벡터 검색", "벡터검색")),
+    ("G-013", 2): (("추가", "관련", "문서"), ("postgresql", "database", "데이터베이스", "migration", "테스트", "pgvector")),
+}
+
+
+def _has_group(answer: str, groups: tuple[tuple[str, ...], ...]) -> bool:
+    return all(any(pattern.casefold() in answer for pattern in group) for group in groups)

--- a/tools/llm-benchmark/answer_quality_policy.py
+++ b/tools/llm-benchmark/answer_quality_policy.py
@@ -6,11 +6,10 @@ from __future__ import annotations
 def answer_shape_passes(answer: str, case_id: str, turn: int) -> bool:
     """Check required facts without pretending to replace human review."""
     normalized = answer.casefold()
-    if case_id == "G-011":
-        return _has_group(normalized, (("확인할 수 없", "찾지 못", "없습니다"),))
-    if case_id == "G-012":
-        return _has_group(normalized, (("범위가 넓어요",), ("최근 결정사항",), ("로드맵",), ("백엔드",)))
-    return _has_group(normalized, _GROUPS.get((case_id, turn), ()))
+    groups = _GROUPS.get((case_id, turn))
+    if groups is None:
+        return False
+    return _has_group(normalized, groups)
 
 
 _GROUPS: dict[tuple[str, int], tuple[tuple[str, ...], ...]] = {
@@ -26,6 +25,8 @@ _GROUPS: dict[tuple[str, int], tuple[tuple[str, ...], ...]] = {
     ("G-010", 1): (("snake_case",), ("camelcase",), ("확정", "충돌", "다르게", "어렵")),
     ("G-013", 1): (("postgresql",), ("관계형", "relational"), ("pgvector", "벡터 검색", "벡터검색")),
     ("G-013", 2): (("추가", "관련", "문서"), ("postgresql", "database", "데이터베이스", "migration", "테스트", "pgvector")),
+    ("G-011", 1): (("확인할 수 없", "찾지 못", "없습니다"),),
+    ("G-012", 1): (("범위가 넓어요",), ("최근 결정사항",), ("로드맵",), ("백엔드",)),
 }
 
 

--- a/tools/llm-benchmark/evaluate_rag_quality.py
+++ b/tools/llm-benchmark/evaluate_rag_quality.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.14"
+# dependencies = ["pydantic", "typer"]
+# ///
+
+"""Evaluate RAG retrieval policy and answer-shape gates against the gold set."""
+
+# ruff: noqa: B008  # Typer uses Option calls as the CLI declaration syntax.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from answer_quality_policy import answer_shape_passes
+from gold_set import BenchmarkCase, load_cases
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+_DEFAULT_RESULTS = Path(".benchmark-data/rag-quality-retrieval-final-10x.jsonl")
+_DEFAULT_GOLD_SET = Path("docs/llm-search-benchmark-gold-set.md")
+_NO_ANSWER_CASES = frozenset({"G-011", "G-012"})
+
+
+class EvaluationError(Exception):
+    """Raised when a result file cannot be evaluated."""
+
+    __slots__ = ("reason",)
+
+    reason: str
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"RAG evaluation error: {self.reason}"
+
+
+class EvaluationRow(BaseModel):
+    """Fields required from a benchmark JSONL observation."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    case_id: str
+    repeat: int
+    turn: int
+    strategy: str
+    answer: str = ""
+    source_paths: tuple[str, ...] = ()
+    retrieved_count: int = 0
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TurnEvaluation:
+    """One result row's retrieval and optional answer checks."""
+
+    key: tuple[str, int, int]
+    retrieval_passed: bool
+    answer_passed: bool | None
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationSummary:
+    """Aggregate gate result for one result file."""
+
+    rows: int
+    expected_rows: int
+    retrieval_passed: int
+    answer_evaluated: int
+    answer_passed: int
+    retrieval_failures: tuple[str, ...]
+    answer_failures: tuple[str, ...]
+
+    @property
+    def retrieval_gate_passed(self) -> bool:
+        return self.rows == self.expected_rows and not self.retrieval_failures
+
+    @property
+    def answer_gate_passed(self) -> bool | None:
+        if self.answer_evaluated != self.expected_rows:
+            return None
+        return self.answer_passed == self.expected_rows and not self.answer_failures
+
+
+def main(
+    results: list[Path] = typer.Option([], "--results", help="One or more JSONL outputs from the RAG benchmark."),
+    gold_set: Path = typer.Option(_DEFAULT_GOLD_SET, help="Markdown gold-set path."),
+    strategy: str = typer.Option("rag", help="Expected strategy label."),
+    repeats: int = typer.Option(10, min=1, help="Expected repeats per case."),
+    require_answer: bool = typer.Option(False, help="Fail when an answer is missing or fails the answer-shape gate."),
+) -> None:
+    """Check every expected case/turn/repeat and print a CI-friendly gate summary."""
+    cases = load_cases(gold_set)
+    result_paths = tuple(results) if results else (_DEFAULT_RESULTS,)
+    rows = tuple(row for path in result_paths for row in _load_rows(path))
+    summary = evaluate(rows, cases, strategy, repeats)
+    typer.echo(f"results={summary.rows} expected={summary.expected_rows}")
+    typer.echo(
+        "retrieval_gate="
+        f"{'PASS' if summary.retrieval_gate_passed else 'FAIL'} "
+        f"({summary.retrieval_passed}/{summary.expected_rows})"
+    )
+    if summary.answer_gate_passed is None:
+        status = "NOT_EVALUATED" if summary.answer_evaluated == 0 else "PARTIAL"
+        typer.echo(f"answer_gate={status} ({summary.answer_passed}/{summary.answer_evaluated})")
+    else:
+        typer.echo(
+            "answer_gate="
+            f"{'PASS' if summary.answer_gate_passed else 'FAIL'} "
+            f"({summary.answer_passed}/{summary.answer_evaluated})"
+        )
+    for failure in summary.retrieval_failures:
+        typer.echo(f"FAIL: {failure}")
+    for failure in summary.answer_failures:
+        typer.echo(f"ANSWER FAIL: {failure}")
+    if summary.answer_evaluated < summary.expected_rows:
+        typer.echo(
+            f"answer coverage={summary.answer_evaluated}/{summary.expected_rows} "
+            "(retrieval-only output is intentionally partial)"
+        )
+    if not summary.retrieval_gate_passed or (require_answer and summary.answer_gate_passed is not True):
+        raise typer.Exit(code=1)
+
+
+def evaluate(
+    rows: tuple[EvaluationRow, ...],
+    cases: tuple[BenchmarkCase, ...],
+    strategy: str,
+    repeats: int = 10,
+) -> EvaluationSummary:
+    """Evaluate structural, source, abstention, and optional answer-shape gates."""
+    if repeats < 1:
+        raise ValueError("repeats must be positive")
+    case_by_id = {case.case_id: case for case in cases}
+    expected_keys = {
+        (case.case_id, repeat, turn)
+        for case in cases
+        for repeat in range(1, repeats + 1)
+        for turn in range(1, len(case.turns) + 1)
+    }
+    by_key: dict[tuple[str, int, int], EvaluationRow] = {}
+    retrieval_failures: list[str] = []
+    for row in rows:
+        key = (row.case_id, row.repeat, row.turn)
+        if row.strategy != strategy:
+            retrieval_failures.append(f"{key}: strategy={row.strategy!r}, expected={strategy!r}")
+        if key in by_key:
+            retrieval_failures.append(f"{key}: duplicate result row")
+        by_key[key] = row
+    missing = sorted(expected_keys - by_key.keys())
+    retrieval_failures.extend(f"{key}: missing result row" for key in missing)
+    unexpected = sorted(by_key.keys() - expected_keys)
+    retrieval_failures.extend(f"{key}: unexpected result row" for key in unexpected)
+
+    evaluations: list[TurnEvaluation] = []
+    answer_failures: list[str] = []
+    for key, row in sorted(by_key.items()):
+        case = case_by_id.get(row.case_id)
+        if case is None or key not in expected_keys:
+            continue
+        reasons = list(_structural_failures(row))
+        expected_sources = _expected_sources(case, row.turn)
+        if not _source_match(row.source_paths, expected_sources, case.case_id, row.turn):
+            reasons.append(f"expected sources={expected_sources!r}, actual={row.source_paths!r}")
+        if row.case_id == "G-011" and row.source_paths:
+            reasons.append("no-answer case returned a source")
+        if row.case_id == "G-012" and row.source_paths:
+            reasons.append("clarification case returned a source")
+        answer_passed = None if not row.answer.strip() else answer_shape_passes(row.answer, case.case_id, row.turn)
+        if answer_passed is False:
+            answer_failures.append(f"{key}: answer does not satisfy the gold-set policy shape")
+        evaluations.append(TurnEvaluation(key, not reasons, answer_passed, tuple(reasons)))
+        retrieval_failures.extend(f"{key}: {reason}" for reason in reasons)
+
+    answer_evaluated = sum(item.answer_passed is not None for item in evaluations)
+    answer_passed = sum(item.answer_passed is True for item in evaluations)
+    retrieval_passed = sum(item.retrieval_passed for item in evaluations)
+    return EvaluationSummary(
+        len(rows),
+        len(expected_keys),
+        retrieval_passed,
+        answer_evaluated,
+        answer_passed,
+        tuple(dict.fromkeys(retrieval_failures)),
+        tuple(dict.fromkeys(answer_failures)),
+    )
+
+
+def _load_rows(path: Path) -> tuple[EvaluationRow, ...]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (FileNotFoundError, OSError, UnicodeDecodeError) as error:
+        raise EvaluationError(str(error)) from error
+    rows: list[EvaluationRow] = []
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            rows.append(EvaluationRow.model_validate_json(line))
+        except (ValidationError, json.JSONDecodeError) as error:
+            raise EvaluationError(f"invalid record at line {line_number}") from error
+    if not rows:
+        raise EvaluationError("no records found")
+    return tuple(rows)
+
+
+def _structural_failures(row: EvaluationRow) -> tuple[str, ...]:
+    failures: list[str] = []
+    if row.error:
+        failures.append(f"benchmark error={row.error}")
+    if row.retrieved_count != len(row.source_paths):
+        failures.append("retrieved_count does not equal source_paths length")
+    if row.retrieved_count > 3:
+        failures.append("more than three source documents returned")
+    if len(set(row.source_paths)) != len(row.source_paths):
+        failures.append("duplicate source document returned")
+    return tuple(failures)
+
+
+def _expected_sources(case: BenchmarkCase, turn: int) -> tuple[str, ...]:
+    if case.case_id in _NO_ANSWER_CASES:
+        return ()
+    if case.case_id == "G-013" and turn == 1:
+        return case.source_ids[:1]
+    return case.source_ids
+
+
+def _source_match(
+    actual_paths: tuple[str, ...],
+    expected_ids: tuple[str, ...],
+    case_id: str,
+    turn: int,
+) -> bool:
+    if not expected_ids:
+        return not actual_paths
+    normalized_paths = tuple(path.casefold().replace("-", "") for path in actual_paths)
+    matches = tuple(
+        any(expected.casefold().replace("-", "") in path for path in normalized_paths)
+        for expected in expected_ids
+    )
+    if case_id == "G-013" and turn == 2:
+        return all(matches) and len(actual_paths) == len(expected_ids)
+    return all(matches)
+
+
+if __name__ == "__main__":
+    try:
+        typer.run(main)
+    except EvaluationError as error:
+        typer.echo(str(error), err=True)
+        raise typer.Exit(code=2) from error

--- a/tools/llm-benchmark/test_evaluate_rag_quality.py
+++ b/tools/llm-benchmark/test_evaluate_rag_quality.py
@@ -1,0 +1,62 @@
+"""Tests for the RAG quality evaluation gates."""
+
+from __future__ import annotations
+
+from evaluate_rag_quality import EvaluationRow, evaluate
+from gold_set import BenchmarkCase
+
+
+def _case(case_id: str, turns: tuple[str, ...], sources: tuple[str, ...]) -> BenchmarkCase:
+    return BenchmarkCase(case_id, "confirmed", "test", turns, "", sources)
+
+
+def test_no_answer_and_clarification_require_empty_sources() -> None:
+    cases = (
+        _case("G-011", ("MongoDB?",), ("856de115-6a83-8253-96be-810bf12c4384",)),
+        _case("G-012", ("넓은 질문",), ("856de115-6a83-8253-96be-810bf12c4384",)),
+    )
+    rows = (
+        EvaluationRow(case_id="G-011", repeat=1, turn=1, strategy="rag", source_paths=(), retrieved_count=0),
+        EvaluationRow(case_id="G-012", repeat=1, turn=1, strategy="rag", source_paths=(), retrieved_count=0),
+    )
+
+    summary = evaluate(rows, cases, "rag", repeats=1)
+
+    assert summary.retrieval_gate_passed
+    assert summary.answer_gate_passed is None
+
+
+def test_related_documents_must_match_all_three_sources() -> None:
+    sources = (
+        "fffde1156a83837097bc818fab8a1fa4.md",
+        "5eade1156a8383878f7981b89626dfe4.md",
+        "3abde1156a8382f0a64501fa2f046d15.md",
+    )
+    cases = (_case("G-013", ("질문", "추가"), sources),)
+    rows = (
+        EvaluationRow(case_id="G-013", repeat=1, turn=1, strategy="rag", source_paths=(sources[0],), retrieved_count=1),
+        EvaluationRow(case_id="G-013", repeat=1, turn=2, strategy="rag", source_paths=sources, retrieved_count=3),
+    )
+
+    summary = evaluate(rows, cases, "rag", repeats=1)
+
+    assert summary.retrieval_gate_passed
+
+
+def test_answer_gate_checks_policy_shape_when_answers_exist() -> None:
+    cases = (_case("G-012", ("넓은 질문",), ("policy",)),)
+    rows = (
+        EvaluationRow(
+            case_id="G-012",
+            repeat=1,
+            turn=1,
+            strategy="rag",
+            answer="범위가 넓어요. 최근 결정사항, 로드맵, 백엔드 진행 상황 중 어떤 내용을 찾고 싶나요?",
+            source_paths=(),
+        ),
+    )
+
+    summary = evaluate(rows, cases, "rag", repeats=1)
+
+    assert summary.retrieval_gate_passed
+    assert summary.answer_gate_passed is True

--- a/tools/llm-benchmark/test_evaluate_rag_quality.py
+++ b/tools/llm-benchmark/test_evaluate_rag_quality.py
@@ -60,3 +60,35 @@ def test_answer_gate_checks_policy_shape_when_answers_exist() -> None:
 
     assert summary.retrieval_gate_passed
     assert summary.answer_gate_passed is True
+
+
+def test_answer_gate_fails_when_any_evaluated_turn_has_no_policy() -> None:
+    cases = (_case("G-007", ("첫 질문", "후속 질문"), ("policy",)),)
+    rows = (
+        EvaluationRow(
+            case_id="G-007",
+            repeat=1,
+            turn=1,
+            strategy="rag",
+            answer="정책에 없는 답변",
+            source_paths=("policy",),
+            retrieved_count=1,
+        ),
+        EvaluationRow(
+            case_id="G-007",
+            repeat=1,
+            turn=2,
+            strategy="rag",
+            answer="로드맵의 level 3 기능은 흑곰 기획안 요구사항을 기준으로 정리했습니다.",
+            source_paths=("policy",),
+            retrieved_count=1,
+        ),
+    )
+
+    summary = evaluate(rows, cases, "rag", repeats=1)
+
+    assert summary.retrieval_gate_passed
+    assert summary.answer_evaluated == 2
+    assert summary.answer_passed == 1
+    assert summary.answer_gate_passed is False
+    assert summary.answer_failures[0].startswith("('G-007', 1, 1):")


### PR DESCRIPTION
## 관련 이슈

- Refs #275

## 작업 내용

- gold set의 case·turn·repeat 누락, 중복, 전략 불일치, source 범위, 최대 3개 제한, 무응답·명확화 정책을 검사하는 결정적 평가기를 추가했습니다.
- 답변 생성 결과에는 질문 유형별 필수 요소를 검사하는 lightweight answer-shape gate를 적용했습니다.
- 정책이 없는 `(case_id, turn)`은 빈 조건으로 자동 PASS하지 않고 실패로 처리하며, 해당 누락을 고정하는 회귀 테스트를 추가했습니다.
- retrieval-only와 e2e 결과를 별도 입력으로 받아 `--require-answer`로 생성 품질을 명시적으로 검사할 수 있게 했습니다.
- 보고서에는 기존 결과의 실행 commit·snapshot manifest·실행 조건과 PR #308 의존성을 명시했습니다.
- PR #308 리뷰 반영 후 동일 조건을 재실행한 결과 `results=160 expected=160`, `retrieval_gate=FAIL (140/160)`을 기록했습니다. 이전 `160/160 PASS`는 역사적 참고치로만 라벨링했습니다.

### 참고 사항

- 답변 의미 왜곡과 source 직접 관련성의 최종 판정은 gold set 원문과 사람이 대조해야 하며, evaluator는 자동 구조 게이트입니다.
- 전체 e2e 5초 목표는 현재 보장하지 않습니다. 이전 LM Studio 모델 TTFT p50 4.13초·p95 8.53초로 기록됐습니다.
- 검증: benchmark pytest 15 passed, Ruff PASS, `git diff --check` PASS.
- `.benchmark-data/` 원문·실행 산출물과 credential은 커밋하지 않았습니다.