### PR TITLE
[BE] 로컬 프론트엔드 개발 Origin 허용

### DIFF
--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -189,6 +189,7 @@ jobs:
             > /dev/null <<'UNIT'
           [Service]
           Environment=SPRING_PROFILES_ACTIVE=dev
+          Environment="AUTH_CORS_ALLOWED_ORIGINS=https://dev.knoted.kr,http://localhost:3000"
           EnvironmentFile=/etc/knot/knot-backend-dev.env
           UNIT
 

--- a/backend/src/main/java/com/knot/backend/global/config/CorsProperties.java
+++ b/backend/src/main/java/com/knot/backend/global/config/CorsProperties.java
@@ -1,5 +1,6 @@
 package com.knot.backend.global.config;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -8,5 +9,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Setter
 @ConfigurationProperties(prefix = "auth.cors")
 public class CorsProperties {
-    private String allowedOrigin = "https://knoted.kr";
+    private List<String> allowedOrigins = List.of("https://knoted.kr");
 }

--- a/backend/src/main/java/com/knot/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/knot/backend/global/config/SecurityConfig.java
@@ -46,13 +46,14 @@ public class SecurityConfig {
 
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
-        String allowedOrigin = corsProperties.getAllowedOrigin();
-        if (isInvalidCorsOrigin(allowedOrigin)) {
+        List<String> allowedOrigins = corsProperties.getAllowedOrigins();
+        if (allowedOrigins == null || allowedOrigins.isEmpty() || allowedOrigins.stream()
+                .anyMatch(this::isInvalidCorsOrigin)) {
             throw new AuthException(AuthErrorCode.OAUTH_CONFIGURATION_INVALID);
         }
 
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(allowedOrigin));
+        configuration.setAllowedOrigins(allowedOrigins);
         configuration.setAllowedMethods(
                 List.of(
                         HttpMethod.GET.name(),

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -44,7 +44,7 @@ auth.jwt.nickname-cookie-name=KNOT_NICKNAME_TOKEN
 auth.jwt.secure=${JWT_COOKIE_SECURE:true}
 
 # CORS
-auth.cors.allowed-origin=${AUTH_CORS_ALLOWED_ORIGIN:https://knoted.kr}
+auth.cors.allowed-origins=${AUTH_CORS_ALLOWED_ORIGINS:${AUTH_CORS_ALLOWED_ORIGIN:https://knoted.kr}}
 
 # Workspace invitation
 workspace.invitation.lookup-hash-key=${WORKSPACE_INVITATION_LOOKUP_HASH_KEY:}

--- a/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
+++ b/backend/src/test/java/com/knot/backend/KnotApplicationTests.java
@@ -50,6 +50,7 @@ import tools.jackson.databind.ObjectMapper;
 @TestConstructor(autowireMode = AutowireMode.ALL)
 class KnotApplicationTests {
     private static final String FRONTEND_ORIGIN = "https://knoted.kr";
+    private static final String LOCAL_FRONTEND_ORIGIN = "http://localhost:3000";
     private static final String UNALLOWED_ORIGIN = "https://attacker.example";
     private static final String JWT_COOKIE_NAME = "KNOT_ACCESS_TOKEN";
     private static final String NICKNAME_COOKIE_NAME = "KNOT_NICKNAME_TOKEN";
@@ -306,6 +307,35 @@ class KnotApplicationTests {
 
         // then
         result.andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
+    @Test
+    @DisplayName("localhost 프론트 Origin에서 CSRF 토큰을 조회한다")
+    void csrf_success_localFrontendOrigin() throws Exception {
+        // given
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/api/v1/auth/csrf").header(
+                        HttpHeaders.ORIGIN,
+                        LOCAL_FRONTEND_ORIGIN
+                )
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(
+                        header().string(
+                                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                                LOCAL_FRONTEND_ORIGIN
+                        )
+                )
+                .andExpect(
+                        header().string(
+                                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                                "true"
+                        )
+                );
     }
 
     @Test

--- a/backend/src/test/java/com/knot/backend/global/config/SecurityConfigTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/SecurityConfigTest.java
@@ -11,6 +11,7 @@ import com.knot.backend.auth.presentation.handler.JwtLogoutHandler;
 import com.knot.backend.auth.presentation.handler.OAuth2AuthenticationFailureHandler;
 import com.knot.backend.auth.presentation.handler.OAuth2AuthenticationSuccessHandler;
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -21,8 +22,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 class SecurityConfigTest {
 
     @Test
-    @DisplayName("CORS 설정은 마지막으로 본 워크스페이스 갱신에 필요한 PUT을 허용한다")
-    void corsConfigurationSource_success_allowsPutMethod() {
+    @DisplayName("CORS 설정은 개발 Origin과 마지막으로 본 워크스페이스 갱신에 필요한 PUT을 허용한다")
+    void corsConfigurationSource_success_allowsDevelopmentOriginsAndPutMethod() {
         // given
         SecurityConfig securityConfig = new SecurityConfig(
                 mock(GithubOAuth2UserService.class),
@@ -53,6 +54,10 @@ class SecurityConfigTest {
                 HttpMethod.PUT.name(),
                 HttpMethod.OPTIONS.name()
         );
+        assertThat(configuration.getAllowedOrigins()).containsExactly(
+                "https://dev.knoted.kr",
+                "http://localhost:3000"
+        );
     }
 
     private JwtProperties jwtProperties() {
@@ -67,7 +72,12 @@ class SecurityConfigTest {
 
     private CorsProperties corsProperties() {
         CorsProperties corsProperties = new CorsProperties();
-        corsProperties.setAllowedOrigin("https://knoted.kr");
+        corsProperties.setAllowedOrigins(
+                List.of(
+                        "https://dev.knoted.kr",
+                        "http://localhost:3000"
+                )
+        );
         return corsProperties;
     }
 }

--- a/backend/src/test/java/com/knot/backend/testsupport/TestApplicationProperties.java
+++ b/backend/src/test/java/com/knot/backend/testsupport/TestApplicationProperties.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.TestPropertySource;
 @Retention(RetentionPolicy.RUNTIME)
 @TestPropertySource(properties = {"auth.jwt.secret=test-jwt-secret-012345678901234567890123456789",
         "auth.jwt.secure=false", "auth.jwt.cookie-name=KNOT_ACCESS_TOKEN",
+        "auth.cors.allowed-origins=https://knoted.kr,http://localhost:3000",
         "workspace.invitation.lookup-hash-key=ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA",
         "workspace.invitation.encryption-key=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY",
         "spring.datasource.username=knot", "spring.datasource.password=knot",


### PR DESCRIPTION
## 관련 이슈

- #310

## 작업 내용

- CORS 설정을 복수 Origin으로 확장하고 빈 값과 와일드카드 거부를 유지했습니다.
- 개발 배포에서 `https://dev.knoted.kr`와 `http://localhost:3000`을 명시적으로 허용했습니다.
- localhost의 CSRF 토큰 조회와 기존 허용·비허용 Origin 회귀를 테스트했습니다.

### 참고 사항

- 기존 `AUTH_CORS_ALLOWED_ORIGIN` 환경 변수는 fallback으로 유지했습니다.
- JWT·CSRF 쿠키의 `SameSite=Lax` 정책은 변경하지 않았습니다.
- `spotlessCheck`, 단위·통합·인수 테스트, `bootJar`, Governance 테스트가 통과했습니다.
- 전체 소스 컨벤션 감사는 이번 변경과 무관한 기존 위반 14건에서 중단됐고, 변경 파일 감사는 통과했습니다.
- AI는 원인 분석과 코드·테스트 초안에 사용했으며 실제 diff와 보안 경계, 전체 검증 결과를 직접 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development environments now support requests from both the deployed frontend and `http://localhost:3000`.
  * CORS supports multiple explicitly configured origins.

* **Bug Fixes**
  * Improved CORS configuration validation rejects missing, blank, null, or wildcard origins.
  * Added coverage confirming local frontend requests receive the correct CORS and credential headers.

* **Tests**
  * Expanded security tests for development origins and workspace update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->