### PR TITLE
[BE] OpenAI 호환 LLM 스트리밍 어댑터 연결

### DIFF
--- a/backend/src/main/java/com/knot/backend/chat/application/ChatMessageService.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/ChatMessageService.java
@@ -1,6 +1,7 @@
 package com.knot.backend.chat.application;
 
 import com.knot.backend.chat.application.dto.command.LlmMessage;
+import com.knot.backend.chat.application.dto.command.LlmMessageRole;
 import com.knot.backend.chat.application.dto.command.LlmRequest;
 import com.knot.backend.chat.domain.ChatErrorCode;
 import com.knot.backend.chat.domain.ChatException;
@@ -185,7 +186,10 @@ public class ChatMessageService {
                 history.stream()
                         .map(
                                 message -> new LlmMessage(
-                                        message.getRole(),
+                                        LlmMessageRole.valueOf(
+                                                message.getRole()
+                                                        .name()
+                                        ),
                                         message.getContent()
                                 )
                         )

--- a/backend/src/main/java/com/knot/backend/chat/application/ChatMessageService.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/ChatMessageService.java
@@ -85,10 +85,10 @@ public class ChatMessageService {
                         true
                 );
                 try {
-                    closeStream(streamReference);
+                    cancel(futureReference);
                 } finally {
                     try {
-                        cancel(futureReference);
+                        closeStream(streamReference);
                     } finally {
                         releaseStream.run();
                     }

--- a/backend/src/main/java/com/knot/backend/chat/application/dto/command/LlmMessage.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/dto/command/LlmMessage.java
@@ -1,9 +1,7 @@
 package com.knot.backend.chat.application.dto.command;
 
-import com.knot.backend.chat.domain.ChatMessageRole;
-
 public record LlmMessage(
-        ChatMessageRole role,
+        LlmMessageRole role,
         String content
 ) {
 }

--- a/backend/src/main/java/com/knot/backend/chat/application/dto/command/LlmMessageRole.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/dto/command/LlmMessageRole.java
@@ -1,0 +1,7 @@
+package com.knot.backend.chat.application.dto.command;
+
+public enum LlmMessageRole {
+    SYSTEM,
+    USER,
+    ASSISTANT,
+}

--- a/backend/src/main/java/com/knot/backend/chat/domain/ChatErrorCode.java
+++ b/backend/src/main/java/com/knot/backend/chat/domain/ChatErrorCode.java
@@ -108,6 +108,12 @@ public enum ChatErrorCode implements ErrorCode {
             "채팅 응답이 이미 진행 중입니다"
     ),
 
+    LLM_CONFIGURATION_INVALID(
+            ErrorCategory.INTERNAL_SERVER_ERROR,
+            "LLM_CONFIGURATION_INVALID",
+            "LLM 설정이 올바르지 않습니다"
+    ),
+
     LLM_STREAM_FAILED(
             ErrorCategory.INTERNAL_SERVER_ERROR,
             "LLM_STREAM_FAILED",

--- a/backend/src/main/java/com/knot/backend/chat/infrastructure/FakeLlmClient.java
+++ b/backend/src/main/java/com/knot/backend/chat/infrastructure/FakeLlmClient.java
@@ -4,9 +4,11 @@ import com.knot.backend.chat.application.LlmClient;
 import com.knot.backend.chat.application.LlmStream;
 import com.knot.backend.chat.application.dto.command.LlmRequest;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(prefix = "llm", name = "provider", havingValue = "fake", matchIfMissing = true)
 public class FakeLlmClient implements LlmClient {
 
     @Override

--- a/backend/src/main/java/com/knot/backend/chat/infrastructure/LlmClientConfig.java
+++ b/backend/src/main/java/com/knot/backend/chat/infrastructure/LlmClientConfig.java
@@ -1,0 +1,37 @@
+package com.knot.backend.chat.infrastructure;
+
+import com.knot.backend.chat.application.LlmClient;
+import java.net.http.HttpClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "llm", name = "provider", havingValue = "openai-compatible")
+@EnableConfigurationProperties(LlmProperties.class)
+public class LlmClientConfig {
+
+    @Bean(name = "llmHttpClient")
+    public HttpClient llmHttpClient(LlmProperties properties) {
+        properties.validate();
+        return HttpClient.newBuilder()
+                .connectTimeout(properties.requestTimeout())
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    @Bean
+    public LlmClient openAiCompatibleLlmClient(
+            @Qualifier("llmHttpClient") HttpClient httpClient,
+            tools.jackson.databind.ObjectMapper objectMapper,
+            LlmProperties properties
+    ) {
+        return new OpenAiCompatibleLlmClient(
+                httpClient,
+                objectMapper,
+                properties
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/infrastructure/LlmProperties.java
+++ b/backend/src/main/java/com/knot/backend/chat/infrastructure/LlmProperties.java
@@ -1,0 +1,45 @@
+package com.knot.backend.chat.infrastructure;
+
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
+import java.net.URI;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "llm")
+public record LlmProperties(
+        URI baseUri,
+        String apiKey,
+        String model,
+        int maxTokens,
+        double temperature,
+        Duration requestTimeout
+) {
+
+    public void validate() {
+        if (!isAbsoluteHttpUri(baseUri) || isBlank(apiKey) || isBlank(model) || maxTokens <= 0 || temperature < 0
+                || temperature > 2 || !isPositive(requestTimeout)) {
+            throw new ChatException(ChatErrorCode.LLM_CONFIGURATION_INVALID);
+        }
+    }
+
+    public URI chatCompletionsUri() {
+        validate();
+        String value = baseUri.toString();
+        String separator = value.endsWith("/") ? "" : "/";
+        return URI.create(value + separator + "chat/completions");
+    }
+
+    private boolean isAbsoluteHttpUri(URI uri) {
+        return uri != null && uri.isAbsolute() && uri.getHost() != null
+                && ("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()));
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private boolean isPositive(Duration value) {
+        return value != null && !value.isZero() && !value.isNegative();
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmClient.java
+++ b/backend/src/main/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmClient.java
@@ -1,0 +1,139 @@
+package com.knot.backend.chat.infrastructure;
+
+import com.knot.backend.chat.application.LlmClient;
+import com.knot.backend.chat.application.LlmStream;
+import com.knot.backend.chat.application.dto.command.LlmMessage;
+import com.knot.backend.chat.application.dto.command.LlmRequest;
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+final class OpenAiCompatibleLlmClient implements LlmClient {
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final LlmProperties properties;
+
+    OpenAiCompatibleLlmClient(
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            LlmProperties properties
+    ) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+    }
+
+    @Override
+    public LlmStream start(LlmRequest request) {
+        HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(
+                    request(request),
+                    HttpResponse.BodyHandlers.ofInputStream()
+            );
+        } catch (InterruptedException exception) {
+            Thread.currentThread()
+                    .interrupt();
+            throw failed(exception);
+        } catch (IOException | JacksonException exception) {
+            throw failed(exception);
+        }
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            close(response.body());
+            throw failed();
+        }
+        return new OpenAiCompatibleLlmStream(
+                response.body(),
+                objectMapper
+        );
+    }
+
+    private HttpRequest request(LlmRequest request) throws JacksonException {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put(
+                "model",
+                properties.model()
+        );
+        payload.put(
+                "messages",
+                request.messages()
+                        .stream()
+                        .map(this::message)
+                        .toList()
+        );
+        payload.put(
+                "stream",
+                true
+        );
+        payload.put(
+                "max_tokens",
+                properties.maxTokens()
+        );
+        payload.put(
+                "temperature",
+                properties.temperature()
+        );
+        return HttpRequest.newBuilder(properties.chatCompletionsUri())
+                .timeout(properties.requestTimeout())
+                .header(
+                        "Authorization",
+                        "Bearer " + properties.apiKey()
+                )
+                .header(
+                        "Content-Type",
+                        "application/json"
+                )
+                .header(
+                        "Accept",
+                        "text/event-stream"
+                )
+                .POST(
+                        HttpRequest.BodyPublishers.ofString(
+                                objectMapper.writeValueAsString(payload),
+                                StandardCharsets.UTF_8
+                        )
+                )
+                .build();
+    }
+
+    private Map<String, String> message(LlmMessage message) {
+        return Map.of(
+                "role",
+                message.role()
+                        .name()
+                        .toLowerCase(Locale.ROOT),
+                "content",
+                message.content()
+        );
+    }
+
+    private ChatException failed() {
+        return new ChatException(ChatErrorCode.LLM_STREAM_FAILED);
+    }
+
+    private ChatException failed(Throwable cause) {
+        return new ChatException(
+                ChatErrorCode.LLM_STREAM_FAILED,
+                cause
+        );
+    }
+
+    private void close(InputStream inputStream) {
+        try {
+            inputStream.close();
+        } catch (IOException ignored) {
+            // 상태 코드 오류를 원인 없이 외부에 노출하지 않는다.
+        }
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmStream.java
+++ b/backend/src/main/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmStream.java
@@ -1,0 +1,118 @@
+package com.knot.backend.chat.infrastructure;
+
+import com.knot.backend.chat.application.LlmStream;
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.NoSuchElementException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+final class OpenAiCompatibleLlmStream implements LlmStream {
+    private final BufferedReader reader;
+    private final ObjectMapper objectMapper;
+    private String nextChunk;
+    private boolean completed;
+    private boolean closed;
+
+    OpenAiCompatibleLlmStream(
+            InputStream inputStream,
+            ObjectMapper objectMapper
+    ) {
+        this.reader = new BufferedReader(
+                new InputStreamReader(
+                        inputStream,
+                        StandardCharsets.UTF_8
+                )
+        );
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (nextChunk != null) {
+            return true;
+        }
+        if (completed) {
+            return false;
+        }
+        try {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.startsWith("data:")) {
+                    continue;
+                }
+                String data = line.substring("data:".length())
+                        .trim();
+                if ("[DONE]".equals(data)) {
+                    complete();
+                    return false;
+                }
+                String content = contentFrom(data);
+                if (content != null && !content.isEmpty()) {
+                    nextChunk = content;
+                    return true;
+                }
+            }
+            complete();
+            return false;
+        } catch (JacksonException | IOException exception) {
+            complete();
+            throw new ChatException(
+                    ChatErrorCode.LLM_STREAM_FAILED,
+                    exception
+            );
+        }
+    }
+
+    @Override
+    public String next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException("LLM stream is complete");
+        }
+        String chunk = nextChunk;
+        nextChunk = null;
+        return chunk;
+    }
+
+    @Override
+    public void close() {
+        complete();
+    }
+
+    private String contentFrom(String data) throws JacksonException {
+        JsonNode response = objectMapper.readTree(data);
+        JsonNode choices = response.get("choices");
+        if (choices == null || !choices.isArray() || choices.isEmpty()) {
+            return null;
+        }
+        JsonNode delta = choices.get(0)
+                .get("delta");
+        if (delta == null) {
+            return null;
+        }
+        JsonNode content = delta.get("content");
+        return content != null && content.isString() ? content.asString() : null;
+    }
+
+    private void complete() {
+        if (completed && closed) {
+            return;
+        }
+        completed = true;
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            reader.close();
+        } catch (IOException ignored) {
+            // 이미 종료된 외부 스트림은 추가로 전파하지 않는다.
+        }
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmStream.java
+++ b/backend/src/main/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmStream.java
@@ -9,21 +9,24 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 final class OpenAiCompatibleLlmStream implements LlmStream {
+    private final InputStream inputStream;
     private final BufferedReader reader;
     private final ObjectMapper objectMapper;
+    private final AtomicBoolean closed = new AtomicBoolean();
     private String nextChunk;
-    private boolean completed;
-    private boolean closed;
+    private boolean doneReceived;
 
     OpenAiCompatibleLlmStream(
             InputStream inputStream,
             ObjectMapper objectMapper
     ) {
+        this.inputStream = inputStream;
         this.reader = new BufferedReader(
                 new InputStreamReader(
                         inputStream,
@@ -38,7 +41,7 @@ final class OpenAiCompatibleLlmStream implements LlmStream {
         if (nextChunk != null) {
             return true;
         }
-        if (completed) {
+        if (closed.get() || doneReceived) {
             return false;
         }
         try {
@@ -50,7 +53,8 @@ final class OpenAiCompatibleLlmStream implements LlmStream {
                 String data = line.substring("data:".length())
                         .trim();
                 if ("[DONE]".equals(data)) {
-                    complete();
+                    doneReceived = true;
+                    closeInputStream();
                     return false;
                 }
                 String content = contentFrom(data);
@@ -59,10 +63,16 @@ final class OpenAiCompatibleLlmStream implements LlmStream {
                     return true;
                 }
             }
-            complete();
-            return false;
+            if (closed.get()) {
+                return false;
+            }
+            closeInputStream();
+            throw new ChatException(ChatErrorCode.LLM_STREAM_FAILED);
         } catch (JacksonException | IOException exception) {
-            complete();
+            if (closed.get()) {
+                return false;
+            }
+            closeInputStream();
             throw new ChatException(
                     ChatErrorCode.LLM_STREAM_FAILED,
                     exception
@@ -82,7 +92,7 @@ final class OpenAiCompatibleLlmStream implements LlmStream {
 
     @Override
     public void close() {
-        complete();
+        closeInputStream();
     }
 
     private String contentFrom(String data) throws JacksonException {
@@ -100,17 +110,15 @@ final class OpenAiCompatibleLlmStream implements LlmStream {
         return content != null && content.isString() ? content.asString() : null;
     }
 
-    private void complete() {
-        if (completed && closed) {
+    private void closeInputStream() {
+        if (!closed.compareAndSet(
+                false,
+                true
+        )) {
             return;
         }
-        completed = true;
-        if (closed) {
-            return;
-        }
-        closed = true;
         try {
-            reader.close();
+            inputStream.close();
         } catch (IOException ignored) {
             // 이미 종료된 외부 스트림은 추가로 전파하지 않는다.
         }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -33,6 +33,15 @@ spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
 spring.security.oauth2.client.registration.github.scope=read:user
 
+# LLM (fake is the safe local default; enable openai-compatible explicitly)
+llm.provider=${LLM_PROVIDER:fake}
+llm.base-uri=${LLM_BASE_URI:http://localhost:1234/v1}
+llm.api-key=${LLM_API_KEY:}
+llm.model=${LLM_MODEL:qwen/qwen3.6-27b}
+llm.max-tokens=${LLM_MAX_TOKENS:1024}
+llm.temperature=${LLM_TEMPERATURE:0.2}
+llm.request-timeout=${LLM_REQUEST_TIMEOUT:PT30S}
+
 # JWT
 auth.jwt.secret=${JWT_SECRET:}
 auth.jwt.expiration=PT1H

--- a/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
@@ -47,6 +47,8 @@ class ChatMessageServiceTest {
         ChatSession session = mock(ChatSession.class);
         when(session.getMemberId()).thenReturn(2L);
         when(session.getWorkspaceId()).thenReturn(1L);
+        when(userMessage.getRole()).thenReturn(ChatMessageRole.USER);
+        when(userMessage.getContent()).thenReturn("질문");
         when(chatSessionRepository.findById(10L)).thenReturn(java.util.Optional.of(session));
         when(
                 workspaceMemberRepository.existsByWorkspaceIdAndMemberId(

--- a/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
 import com.knot.backend.chat.domain.ChatMessage;
 import com.knot.backend.chat.domain.ChatMessageRepository;
 import com.knot.backend.chat.domain.ChatMessageRole;
@@ -182,6 +183,96 @@ class ChatMessageServiceTest {
                 any(),
                 any()
         );
+        verify(
+                persistenceService,
+                never()
+        ).saveMessage(
+                anyLong(),
+                org.mockito.ArgumentMatchers.eq(ChatMessageRole.ASSISTANT),
+                any(),
+                any()
+        );
+    }
+
+    @Test
+    @DisplayName("chunk을 받은 뒤 스트림이 끊기면 부분 assistant를 저장하지 않는다")
+    void sendMessage_failure_streamEndsBeforeDone_doesNotPersistPartialAssistant() {
+        // given
+        ChatSessionRepository chatSessionRepository = mock(ChatSessionRepository.class);
+        WorkspaceMemberRepository workspaceMemberRepository = mock(WorkspaceMemberRepository.class);
+        ChatSessionAccessPolicy accessPolicy = new ChatSessionAccessPolicy(
+                chatSessionRepository,
+                workspaceMemberRepository
+        );
+        ChatMessageRepository chatMessageRepository = mock(ChatMessageRepository.class);
+        ChatMessagePersistenceService persistenceService = mock(ChatMessagePersistenceService.class);
+        LlmClient llmClient = mock(LlmClient.class);
+        LlmStream llmStream = new LlmStream() {
+            private boolean chunkReturned;
+
+            @Override
+            public boolean hasNext() {
+                if (!chunkReturned) {
+                    return true;
+                }
+                throw new ChatException(ChatErrorCode.LLM_STREAM_FAILED);
+            }
+
+            @Override
+            public String next() {
+                chunkReturned = true;
+                return "부분 ";
+            }
+
+            @Override
+            public void close() {}
+        };
+        ChatStreamListener listener = mock(ChatStreamListener.class);
+        ChatMessage userMessage = mock(ChatMessage.class);
+        ChatSession session = mock(ChatSession.class);
+        when(session.getMemberId()).thenReturn(2L);
+        when(session.getWorkspaceId()).thenReturn(1L);
+        when(userMessage.getRole()).thenReturn(ChatMessageRole.USER);
+        when(userMessage.getContent()).thenReturn("질문");
+        when(chatSessionRepository.findById(10L)).thenReturn(java.util.Optional.of(session));
+        when(
+                workspaceMemberRepository.existsByWorkspaceIdAndMemberId(
+                        1L,
+                        2L
+                )
+        ).thenReturn(true);
+        when(
+                persistenceService.saveMessage(
+                        anyLong(),
+                        any(),
+                        any(),
+                        any()
+                )
+        ).thenReturn(userMessage);
+        when(chatMessageRepository.findAllBySessionId(10L)).thenReturn(List.of(userMessage));
+        when(llmClient.start(any())).thenReturn(llmStream);
+        when(listener.onChunk(any())).thenReturn(true);
+        Executor directExecutor = Runnable::run;
+        ChatMessageService service = new ChatMessageService(
+                accessPolicy,
+                persistenceService,
+                chatMessageRepository,
+                llmClient,
+                new ActiveChatStreamRegistry(),
+                directExecutor
+        );
+
+        // when
+        service.sendMessage(
+                10L,
+                2L,
+                "질문",
+                listener
+        );
+
+        // then
+        verify(listener).onChunk("부분 ");
+        verify(listener).onError(ChatErrorCode.LLM_STREAM_FAILED);
         verify(
                 persistenceService,
                 never()

--- a/backend/src/test/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmClientTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmClientTest.java
@@ -1,0 +1,205 @@
+package com.knot.backend.chat.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.knot.backend.chat.application.LlmStream;
+import com.knot.backend.chat.application.dto.command.LlmMessage;
+import com.knot.backend.chat.application.dto.command.LlmMessageRole;
+import com.knot.backend.chat.application.dto.command.LlmRequest;
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class OpenAiCompatibleLlmClientTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private HttpServer server;
+    private ExecutorService serverExecutor;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+        if (serverExecutor != null) {
+            serverExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("OpenAI 호환 SSE 응답을 chunk로 전달하고 인증값은 HTTP 헤더에만 보낸다")
+    void start_success_streamsChunksAndSendsRequest() throws Exception {
+        // given
+        AtomicReference<String> requestBody = new AtomicReference<>();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        URI baseUri = startServer(exchange -> {
+            requestBody.set(
+                    new String(
+                            exchange.getRequestBody()
+                                    .readAllBytes(),
+                            StandardCharsets.UTF_8
+                    )
+            );
+            authorization.set(
+                    exchange.getRequestHeaders()
+                            .getFirst("Authorization")
+            );
+            respond(
+                    exchange,
+                    200,
+                    """
+                            data: {"choices":[{"delta":{"content":"첫 "}}]}
+
+                            data: {"choices":[{"delta":{"content":"응답"}}]}
+
+                            data: [DONE]
+
+                            """
+            );
+        });
+        LlmProperties properties = new LlmProperties(
+                baseUri,
+                "server-token",
+                "qwen/qwen3.6-27b",
+                512,
+                0.2,
+                Duration.ofSeconds(5)
+        );
+        OpenAiCompatibleLlmClient client = new OpenAiCompatibleLlmClient(
+                HttpClient.newHttpClient(),
+                objectMapper,
+                properties
+        );
+
+        // when
+        LlmStream stream = client.start(
+                new LlmRequest(
+                        List.of(
+                                new LlmMessage(
+                                        LlmMessageRole.USER,
+                                        "질문"
+                                )
+                        )
+                )
+        );
+
+        // then
+        assertThat(stream.next()).isEqualTo("첫 ");
+        assertThat(stream.next()).isEqualTo("응답");
+        assertThat(stream.hasNext()).isFalse();
+        assertThat(authorization).hasValue("Bearer server-token");
+        JsonNode payload = objectMapper.readTree(requestBody.get());
+        assertThat(
+                payload.get("model")
+                        .asString()
+        ).isEqualTo("qwen/qwen3.6-27b");
+        assertThat(
+                payload.get("stream")
+                        .asBoolean()
+        ).isTrue();
+        assertThat(
+                payload.get("messages")
+                        .get(0)
+                        .get("role")
+                        .asString()
+        ).isEqualTo("user");
+        assertThat(payload.toString()).doesNotContain("server-token");
+    }
+
+    @Test
+    @DisplayName("LLM 서버가 성공이 아닌 상태를 반환하면 스트림 실패로 변환한다")
+    void start_failure_nonSuccessStatus() throws Exception {
+        // given
+        URI baseUri = startServer(
+                exchange -> respond(
+                        exchange,
+                        401,
+                        "unauthorized"
+                )
+        );
+        OpenAiCompatibleLlmClient client = new OpenAiCompatibleLlmClient(
+                HttpClient.newHttpClient(),
+                objectMapper,
+                new LlmProperties(
+                        baseUri,
+                        "server-token",
+                        "qwen/qwen3.6-27b",
+                        512,
+                        0.2,
+                        Duration.ofSeconds(5)
+                )
+        );
+
+        // when & then
+        assertThatThrownBy(() -> client.start(new LlmRequest(List.of()))).isInstanceOfSatisfying(
+                ChatException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ChatErrorCode.LLM_STREAM_FAILED)
+        );
+    }
+
+    private URI startServer(ExchangeHandler handler) throws IOException {
+        server = HttpServer.create(
+                new InetSocketAddress(
+                        "localhost",
+                        0
+                ),
+                0
+        );
+        serverExecutor = Executors.newCachedThreadPool();
+        server.setExecutor(serverExecutor);
+        server.createContext(
+                "/v1/chat/completions",
+                exchange -> {
+                    try (exchange) {
+                        handler.handle(exchange);
+                    }
+                }
+        );
+        server.start();
+        return URI.create(
+                "http://localhost:" + server.getAddress()
+                        .getPort() + "/v1"
+        );
+    }
+
+    private void respond(
+            HttpExchange exchange,
+            int status,
+            String body
+    ) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders()
+                .set(
+                        "Content-Type",
+                        "text/event-stream"
+                );
+        exchange.sendResponseHeaders(
+                status,
+                bytes.length
+        );
+        exchange.getResponseBody()
+                .write(bytes);
+    }
+
+    @FunctionalInterface
+    private interface ExchangeHandler {
+
+        void handle(HttpExchange exchange) throws IOException;
+    }
+}

--- a/backend/src/test/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmClientTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/infrastructure/OpenAiCompatibleLlmClientTest.java
@@ -20,6 +20,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -150,6 +153,158 @@ class OpenAiCompatibleLlmClientTest {
         assertThatThrownBy(() -> client.start(new LlmRequest(List.of()))).isInstanceOfSatisfying(
                 ChatException.class,
                 exception -> assertThat(exception.getErrorCode()).isEqualTo(ChatErrorCode.LLM_STREAM_FAILED)
+        );
+    }
+
+    @Test
+    @DisplayName("DONE 없이 SSE 응답이 끝나면 partial chunk를 정상 완료로 처리하지 않는다")
+    void stream_failure_eofBeforeDone() throws Exception {
+        // given
+        URI baseUri = startServer(
+                exchange -> respond(
+                        exchange,
+                        200,
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"부분 \"}}]}\n\n"
+                )
+        );
+        OpenAiCompatibleLlmClient client = new OpenAiCompatibleLlmClient(
+                HttpClient.newHttpClient(),
+                objectMapper,
+                new LlmProperties(
+                        baseUri,
+                        "server-token",
+                        "qwen/qwen3.6-27b",
+                        512,
+                        0.2,
+                        Duration.ofSeconds(5)
+                )
+        );
+        LlmStream stream = client.start(new LlmRequest(List.of()));
+
+        // when & then
+        assertThat(stream.next()).isEqualTo("부분 ");
+        assertThatThrownBy(stream::hasNext).isInstanceOfSatisfying(
+                ChatException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ChatErrorCode.LLM_STREAM_FAILED)
+        );
+    }
+
+    @Test
+    @DisplayName("응답 body가 멈춘 상태에서 스트림을 닫으면 대기 중인 읽기가 즉시 끝난다")
+    void stream_closeWhileReading_unblocksConsumer() throws Exception {
+        // given
+        AtomicReference<HttpExchange> responseExchange = new AtomicReference<>();
+        CountDownLatch responseStarted = new CountDownLatch(1);
+        CountDownLatch releaseResponse = new CountDownLatch(1);
+        URI baseUri = startHangingServer(
+                responseExchange,
+                responseStarted,
+                releaseResponse
+        );
+        OpenAiCompatibleLlmClient client = new OpenAiCompatibleLlmClient(
+                HttpClient.newHttpClient(),
+                objectMapper,
+                new LlmProperties(
+                        baseUri,
+                        "server-token",
+                        "qwen/qwen3.6-27b",
+                        512,
+                        0.2,
+                        Duration.ofSeconds(5)
+                )
+        );
+        LlmStream stream = client.start(new LlmRequest(List.of()));
+        ExecutorService consumer = Executors.newSingleThreadExecutor();
+        Future<Boolean> hasNext = consumer.submit(stream::hasNext);
+
+        try {
+            assertThat(
+                    responseStarted.await(
+                            5,
+                            java.util.concurrent.TimeUnit.SECONDS
+                    )
+            ).isTrue();
+            assertThatThrownBy(
+                    () -> hasNext.get(
+                            200,
+                            java.util.concurrent.TimeUnit.MILLISECONDS
+                    )
+            ).isInstanceOf(TimeoutException.class);
+
+            // when
+            stream.close();
+
+            // then
+            assertThat(
+                    hasNext.get(
+                            2,
+                            java.util.concurrent.TimeUnit.SECONDS
+                    )
+            ).isFalse();
+        } finally {
+            stream.close();
+            releaseResponse.countDown();
+            HttpExchange exchange = responseExchange.get();
+            if (exchange != null) {
+                exchange.close();
+            }
+            consumer.shutdownNow();
+            assertThat(
+                    consumer.awaitTermination(
+                            5,
+                            java.util.concurrent.TimeUnit.SECONDS
+                    )
+            ).isTrue();
+        }
+    }
+
+    private URI startHangingServer(
+            AtomicReference<HttpExchange> responseExchange,
+            CountDownLatch responseStarted,
+            CountDownLatch releaseResponse
+    ) throws IOException {
+        server = HttpServer.create(
+                new InetSocketAddress(
+                        "localhost",
+                        0
+                ),
+                0
+        );
+        serverExecutor = Executors.newCachedThreadPool();
+        server.setExecutor(serverExecutor);
+        server.createContext(
+                "/v1/chat/completions",
+                exchange -> {
+                    responseExchange.set(exchange);
+                    exchange.getResponseHeaders()
+                            .set(
+                                    "Content-Type",
+                                    "text/event-stream"
+                            );
+                    exchange.sendResponseHeaders(
+                            200,
+                            0
+                    );
+                    exchange.getResponseBody()
+                            .write(": connected\n\n".getBytes(StandardCharsets.UTF_8));
+                    exchange.getResponseBody()
+                            .flush();
+                    responseStarted.countDown();
+                    try {
+                        releaseResponse.await(
+                                5,
+                                java.util.concurrent.TimeUnit.SECONDS
+                        );
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread()
+                                .interrupt();
+                    }
+                }
+        );
+        server.start();
+        return URI.create(
+                "http://localhost:" + server.getAddress()
+                        .getPort() + "/v1"
         );
     }
 


### PR DESCRIPTION
## 관련 이슈

- Closes #239

## 작업 내용

- 기존 `LlmClient` 포트에 OpenAI-compatible `/v1/chat/completions` SSE adapter를 연결했습니다.
- `llm.provider=fake`를 안전한 기본값으로 유지하고 `openai-compatible`일 때만 실제 HTTP client를 활성화합니다.
- LM Studio와 NVIDIA NIM에 공통으로 사용할 수 있도록 base URI, API key, model, max tokens, temperature, timeout을 환경변수 기반으로 설정합니다.
- SSE `data` chunk와 `[DONE]`을 현재 pull형 `LlmStream`으로 변환하고 비정상 HTTP·I/O·JSON 오류를 기존 LLM 오류 계약으로 변환합니다.
- LLM application message role을 domain 저장 role과 분리해 이후 system grounding prompt를 수용할 수 있게 했습니다.
- API key는 Authorization 헤더에만 사용하며 request payload·로그·SSE 응답에는 넣지 않습니다.
- 로컬 HTTP stub 기반 정상 chunk·완료·비정상 상태·payload 보안 테스트를 추가했습니다.

### 참고 사항

- 이번 PR은 provider adapter 경계만 담당하며 Import Snapshot 기반 RAG와 source reference 연결은 #311에서 별도 리뷰합니다.
- Spring AI는 현재 MVC `SseEmitter`와 custom Import publication schema를 바꾸지 않기 위해 이번 범위에서 도입하지 않았습니다.
- 검증: `./gradlew test` PASS, `./gradlew spotlessCheck` PASS, `git diff --check` PASS.
- 실환경 실행 시 `LLM_PROVIDER=openai-compatible`, `LLM_BASE_URI=http://<lm-studio-host>:1234/v1`, `LLM_API_KEY=<secret>`를 주입합니다. secret 값은 저장소에 기록하지 않습니다.