### PR TITLE
[FE] 채팅 메시지 SSE 스트리밍 수신 구현

### DIFF
--- a/frontend/src/shared/api/dto/chatMessage.ts
+++ b/frontend/src/shared/api/dto/chatMessage.ts
@@ -1,7 +1,8 @@
 /**
  * 대화 메시지 DTO
  *
- * - GET /api/v1/conversations/{sessionId}
+ * - GET  /api/v1/conversations/{sessionId}
+ * - POST /api/v1/conversations/{sessionId}/messages (SSE)
  */
 
 /** 메시지 작성 주체. USER는 사용자, ASSISTANT는 AI */
@@ -48,3 +49,99 @@ export class GetChatMessagesResponseDto {
     this.messages = raw.map((message) => new ChatMessageDto(message));
   }
 }
+
+// POST /api/v1/conversations/{sessionId}/messages (SSE)
+
+/** 메시지 전송 시 앱이 넘기는 값 */
+export interface PostChatMessageRequestInput {
+  content: string;
+}
+
+/** 메시지 전송 요청 본문. 응답은 JSON이 아니라 SSE 스트림 */
+export class PostChatMessageRequestDto {
+  /** 메시지 내용. 앞뒤 공백 제거, 공백만이면 서버가 거절, 최대 10,000자 */
+  content: string;
+
+  constructor({ content }: PostChatMessageRequestInput) {
+    this.content = content.trim();
+  }
+}
+
+/** SSE 연결 전 HTTP 오류의 서버 응답 모양 */
+export interface PostChatMessageErrorResponseRaw {
+  code: string;
+  message: string;
+}
+
+/** SSE 연결이 시작되기 전에 실패한 HTTP 오류 응답. 400·401·403·404·409·500이 같은 모양 */
+export class PostChatMessageErrorResponseDto {
+  /** 오류 코드. 예: VALIDATION_ERROR, CHAT_ACCESS_DENIED, CHAT_STREAM_ALREADY_ACTIVE */
+  code: string;
+  /** 사용자에게 보여 줄 수 있는 오류 메시지 */
+  message: string;
+
+  constructor(raw: PostChatMessageErrorResponseRaw) {
+    this.code = raw.code;
+    this.message = raw.message;
+  }
+}
+
+/** `event: chunk`의 data 모양 */
+export interface ChatStreamChunkRaw {
+  delta: string;
+}
+
+/** 답변 조각. 스트림 하나에서 여러 번 도착함 */
+export class ChatStreamChunkDto {
+  /** LLM 응답의 일부 텍스트. 도착 순서대로 이어 붙이면 전체 답변이 됨 */
+  delta: string;
+
+  constructor(raw: ChatStreamChunkRaw) {
+    this.delta = raw.delta;
+  }
+}
+
+/** `event: complete`의 data 모양 */
+export interface ChatStreamCompleteRaw {
+  messageId: number;
+}
+
+/** 답변이 끝나고 저장까지 마쳤음을 알리는 이벤트. 스트림당 한 번만 옴 */
+export class ChatStreamCompleteDto {
+  /** 저장된 assistant 메시지 ID */
+  messageId: number;
+
+  constructor(raw: ChatStreamCompleteRaw) {
+    this.messageId = raw.messageId;
+  }
+}
+
+/** `event: error`의 data 모양 */
+export interface ChatStreamErrorRaw {
+  code: string;
+  message: string;
+}
+
+/** 연결이 열린 뒤에 생긴 LLM 오류. HTTP 상태가 아니라 이벤트로 전달됨 */
+export class ChatStreamErrorDto {
+  /** 오류 코드. LLM_STREAM_FAILED 또는 LLM_STREAM_TIMEOUT */
+  code: string;
+  /** 사용자에게 보여 줄 수 있는 오류 메시지 */
+  message: string;
+
+  constructor(raw: ChatStreamErrorRaw) {
+    this.code = raw.code;
+    this.message = raw.message;
+  }
+}
+
+/**
+ * 스트림이 흘려보내는 이벤트 한 건.
+ *
+ * `event`로 갈라 `data`의 모양이 좁혀지도록 유니언으로 둡니다.
+ * 스펙에 없는 이벤트 이름은 요청 함수에서 버리므로 여기에 두지 않습니다.
+ */
+export type ChatStreamEvent =
+  | { event: "chunk"; data: ChatStreamChunkDto }
+  | { event: "complete"; data: ChatStreamCompleteDto }
+  | { event: "error"; data: ChatStreamErrorDto };

--- a/frontend/src/shared/api/fetch/api/v1/conversations/[sessionId]/messages/index.ts
+++ b/frontend/src/shared/api/fetch/api/v1/conversations/[sessionId]/messages/index.ts
@@ -1,5 +1,164 @@
+import {
+  ChatStreamChunkDto,
+  ChatStreamCompleteDto,
+  ChatStreamErrorDto,
+  PostChatMessageErrorResponseDto,
+  type ChatStreamEvent,
+  type PostChatMessageErrorResponseRaw,
+  type PostChatMessageRequestDto,
+} from "@api/dto/chatMessage";
+import { getCsrfToken } from "@api/httpClient";
+import { parseSseEvents, type SseEvent } from "@api/sse/parseSseEvents";
+
 export const SEND_CHAT_MESSAGE_API_PATH = (sessionId: number) =>
   `/api/v1/conversations/${sessionId}/messages`;
 
-// 요청 본문은 `content`(최대 10,000자) 하나예요
-// 응답이 SSE(text/event-stream)라 요청 타입·요청 함수·mock 핸들러는 이벤트 형식이 정해지는 채팅 스트리밍 Issue에서 추가해요
+/** 본문을 읽지 못했을 때 쓰는 값. 상태 코드만으로는 무엇이 잘못됐는지 알 수 없어요 */
+const UNKNOWN_REQUEST_ERROR = {
+  code: "UNKNOWN",
+  message: "답변 생성을 시작하지 못했어요",
+};
+
+interface ChatStreamRequestErrorParams {
+  status: number;
+  code: string;
+  message: string;
+}
+
+/**
+ * SSE 연결이 열리기 전에 실패한 HTTP 오류.
+ *
+ * 연결 뒤에 오는 `error` 이벤트와 달리 화면에 보여 줄 답변이 아직 없으므로 throw로 알립니다.
+ */
+export class ChatStreamRequestError extends Error {
+  /** HTTP 상태 코드. 400·401·403·404·409·500 */
+  status: number;
+  /** 서버 오류 코드. 본문을 읽지 못하면 "UNKNOWN" */
+  code: string;
+
+  constructor({ status, code, message }: ChatStreamRequestErrorParams) {
+    super(message);
+
+    this.name = "ChatStreamRequestError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/**
+ * fetch는 axios와 달리 baseURL을 모르고 상대 경로도 못 받으므로 직접 절대 주소로 만듭니다.
+ * 배포 환경에서는 API 도메인이 따로 있고, 없으면 지금 보고 있는 오리진을 씁니다.
+ */
+const toAbsoluteUrl = (path: string) =>
+  new URL(path, process.env.API_BASE_URL ?? window.location.origin).toString();
+
+/** 연결 전 실패 응답의 본문을 읽어 throw할 오류로 바꿉니다 */
+const toRequestError = async (response: Response) => {
+  // 본문이 비었거나 JSON이 아닐 수 있어 읽기 실패는 값 없음으로 다룹니다
+  const raw: PostChatMessageErrorResponseRaw | null = await response
+    .json()
+    .catch(() => null);
+
+  const { code, message } = raw
+    ? new PostChatMessageErrorResponseDto(raw)
+    : UNKNOWN_REQUEST_ERROR;
+
+  return new ChatStreamRequestError({ status: response.status, code, message });
+};
+
+/** 스펙에 있는 이벤트만 DTO로 감쌉니다. 모르는 이벤트 이름은 버립니다 */
+const toChatStreamEvent = ({
+  event,
+  data,
+}: SseEvent): ChatStreamEvent | null => {
+  switch (event) {
+    case "chunk":
+      return { event, data: new ChatStreamChunkDto(JSON.parse(data)) };
+    case "complete":
+      return { event, data: new ChatStreamCompleteDto(JSON.parse(data)) };
+    case "error":
+      return { event, data: new ChatStreamErrorDto(JSON.parse(data)) };
+    default:
+      return null;
+  }
+};
+
+interface StreamChatMessageApiParams {
+  sessionId: number;
+  body: PostChatMessageRequestDto;
+  signal?: AbortSignal;
+}
+
+/**
+ * @description 대화 세션에 메시지를 보내고 SSE로 도착하는 답변을 순서대로 흘려보냅니다
+ * @param params - 대화 세션 ID, 메시지 전송 요청 본문, 취소용 AbortSignal
+ * @returns chunk·complete·error 이벤트를 순서대로 내는 async generator
+ * @throws {ChatStreamRequestError} SSE 연결이 열리기 전에 HTTP 오류가 난 경우
+ * @example
+ * for await (const { event, data } of streamChatMessageApi({ sessionId: 100, body })) {
+ *   if (event === "chunk") answer += data.delta;
+ * }
+ */
+export async function* streamChatMessageApi({
+  sessionId,
+  body,
+  signal,
+}: StreamChatMessageApiParams) {
+  const response = await fetch(
+    toAbsoluteUrl(SEND_CHAT_MESSAGE_API_PATH(sessionId)),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        "X-XSRF-TOKEN": await getCsrfToken(),
+      },
+      // 로그인 상태는 쿠키로만 유지되므로 fetch에도 쿠키를 실어 보냅니다
+      credentials: "include",
+      body: JSON.stringify(body),
+      signal,
+    },
+  );
+
+  if (!response.ok || !response.body) throw await toRequestError(response);
+
+  const reader = response.body.getReader();
+  // stream: true여야 한글처럼 여러 바이트인 글자가 청크 경계에서 깨지지 않습니다
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  /** 버퍼에 이어 붙여 완성된 이벤트만 내보냅니다 */
+  function* drain(chunk: string) {
+    const { events, buffer: rest } = parseSseEvents({ buffer, chunk });
+    buffer = rest;
+
+    for (const event of events) {
+      if (signal?.aborted) return; // 취소한 뒤에는 남은 이벤트도 내지 않습니다
+
+      const streamEvent = toChatStreamEvent(event);
+      if (streamEvent) yield streamEvent;
+    }
+  }
+
+  try {
+    // 소비자가 이벤트를 받다가 취소할 수 있으므로 매번 다시 확인합니다
+    while (!signal?.aborted) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        // 마지막 프레임이 빈 줄 없이 끝났을 수 있어 남은 버퍼를 한 번 더 비웁니다
+        yield* drain("\n\n");
+        break;
+      }
+
+      yield* drain(decoder.decode(value, { stream: true }));
+    }
+  } catch (error) {
+    // 취소는 사용자가 그만둔 것이라 실패로 보고하지 않고 조용히 끝냅니다
+    if (!signal?.aborted) throw error;
+  } finally {
+    // 소비자가 중간에 멈춰도 연결을 놓아주도록 리더를 닫습니다.
+    // 취소된 스트림은 cancel()이 끝나지 않을 수 있어 기다리지 않고 실패도 무시합니다
+    void reader.cancel().catch(() => undefined);
+  }
+}

--- a/frontend/src/shared/api/fetch/api/v1/conversations/[sessionId]/messages/test.ts
+++ b/frontend/src/shared/api/fetch/api/v1/conversations/[sessionId]/messages/test.ts
@@ -1,0 +1,170 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { chatMessageStreamResponse } from "@api/mock/responses/chatMessage";
+import { mockServer } from "@api/mock/server";
+
+import { ChatStreamRequestError, streamChatMessageApi } from ".";
+
+const SESSION_ID = 100;
+const SEND_CHAT_MESSAGE_PATH = "*/api/v1/conversations/:sessionId/messages";
+
+const QUESTION = { content: "프로젝트 문서를 요약해줘" };
+
+/** 스트림이 끝날 때까지 받아 이벤트를 순서대로 모읍니다 */
+const collectStream = async (signal?: AbortSignal) => {
+  const events = [];
+
+  for await (const event of streamChatMessageApi({
+    sessionId: SESSION_ID,
+    body: QUESTION,
+    signal,
+  })) {
+    events.push(event);
+  }
+
+  return events;
+};
+
+/** 서버가 보내는 SSE 프레임 한 개 */
+const toFrame = (event: string, data: object) =>
+  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+/** 준비된 바이트를 그대로 흘려보내는 SSE 응답 */
+const sseResponse = (chunks: Uint8Array[]) =>
+  new HttpResponse(
+    new ReadableStream({
+      start(controller) {
+        chunks.forEach((chunk) => controller.enqueue(chunk));
+        controller.close();
+      },
+    }),
+    { headers: { "Content-Type": "text/event-stream" } },
+  );
+
+describe("streamChatMessageApi", () => {
+  it("mock 스트림의 delta를 순서대로 내고 complete로 메시지 ID를 알려준다", async () => {
+    const { deltas, messageId } = chatMessageStreamResponse;
+
+    const events = await collectStream();
+
+    expect(events).toEqual([
+      ...deltas.map((delta) => ({ event: "chunk", data: { delta } })),
+      { event: "complete", data: { messageId } },
+    ]);
+  });
+
+  it("연결 전 409는 상태 코드와 오류 코드를 담아 throw한다", async () => {
+    mockServer.use(
+      http.post(SEND_CHAT_MESSAGE_PATH, () =>
+        HttpResponse.json(
+          {
+            code: "CHAT_STREAM_ALREADY_ACTIVE",
+            message: "이미 응답을 만들고 있어요",
+          },
+          { status: 409 },
+        ),
+      ),
+    );
+
+    await expect(collectStream()).rejects.toThrow(ChatStreamRequestError);
+    await expect(collectStream()).rejects.toMatchObject({
+      status: 409,
+      code: "CHAT_STREAM_ALREADY_ACTIVE",
+    });
+  });
+
+  it("연결 전 403은 throw한다", async () => {
+    mockServer.use(
+      http.post(SEND_CHAT_MESSAGE_PATH, () =>
+        HttpResponse.json(
+          { code: "CHAT_ACCESS_DENIED", message: "접근 권한이 없어요" },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    await expect(collectStream()).rejects.toMatchObject({
+      status: 403,
+      code: "CHAT_ACCESS_DENIED",
+    });
+  });
+
+  it("연결 후 error 이벤트는 throw하지 않고 앞선 조각과 함께 흘려보낸다", async () => {
+    const encoder = new TextEncoder();
+    mockServer.use(
+      http.post(SEND_CHAT_MESSAGE_PATH, () =>
+        sseResponse([
+          encoder.encode(toFrame("chunk", { delta: "테스트 " })),
+          encoder.encode(
+            toFrame("error", {
+              code: "LLM_STREAM_FAILED",
+              message: "답변 생성에 실패했습니다",
+            }),
+          ),
+        ]),
+      ),
+    );
+
+    await expect(collectStream()).resolves.toEqual([
+      { event: "chunk", data: { delta: "테스트 " } },
+      {
+        event: "error",
+        data: {
+          code: "LLM_STREAM_FAILED",
+          message: "답변 생성에 실패했습니다",
+        },
+      },
+    ]);
+  });
+
+  it("모르는 이벤트 이름은 버린다", async () => {
+    const encoder = new TextEncoder();
+    mockServer.use(
+      http.post(SEND_CHAT_MESSAGE_PATH, () =>
+        sseResponse([
+          encoder.encode(toFrame("heartbeat", {})),
+          encoder.encode(toFrame("complete", { messageId: 102 })),
+        ]),
+      ),
+    );
+
+    await expect(collectStream()).resolves.toEqual([
+      { event: "complete", data: { messageId: 102 } },
+    ]);
+  });
+
+  it("한글이 청크 경계에서 잘려도 깨지지 않는다", async () => {
+    const encoder = new TextEncoder();
+    const frame = encoder.encode(toFrame("chunk", { delta: "테스트 " }));
+    // "테"의 3바이트 한가운데를 지나도록 잘라요
+    const splitIndex =
+      encoder.encode('event: chunk\ndata: {"delta":"').length + 1;
+
+    mockServer.use(
+      http.post(SEND_CHAT_MESSAGE_PATH, () =>
+        sseResponse([frame.slice(0, splitIndex), frame.slice(splitIndex)]),
+      ),
+    );
+
+    await expect(collectStream()).resolves.toEqual([
+      { event: "chunk", data: { delta: "테스트 " } },
+    ]);
+  });
+
+  it("취소하면 그 뒤로는 아무 이벤트도 내지 않고 정상 종료한다", async () => {
+    const controller = new AbortController();
+    const events = [];
+
+    for await (const event of streamChatMessageApi({
+      sessionId: SESSION_ID,
+      body: QUESTION,
+      signal: controller.signal,
+    })) {
+      events.push(event);
+      controller.abort();
+    }
+
+    expect(events).toHaveLength(1);
+  });
+});

--- a/frontend/src/shared/api/httpClient/index.ts
+++ b/frontend/src/shared/api/httpClient/index.ts
@@ -48,6 +48,15 @@ const loadCsrfToken = async () => {
   return csrfToken;
 };
 
+/**
+ * 지금 들고 있는 CSRF 토큰을 돌려주고, 없으면 받아옵니다.
+ *
+ * SSE 응답은 axios(XHR 어댑터)로 읽을 수 없어 fetch로 직접 보내야 하는데,
+ * 그 요청도 상태를 바꾸는 POST라 같은 토큰이 필요합니다. 요청마다 새로 받지 않도록
+ * 아래 인터셉터와 이 캐시를 함께 씁니다.
+ */
+export const getCsrfToken = async () => csrfToken ?? (await loadCsrfToken());
+
 const isMutatingRequest = (method?: string) =>
   MUTATING_METHODS.includes((method ?? "get").toLowerCase());
 

--- a/frontend/src/shared/api/mock/handlers/api/v1/conversations/[sessionId]/messages/index.ts
+++ b/frontend/src/shared/api/mock/handlers/api/v1/conversations/[sessionId]/messages/index.ts
@@ -1,0 +1,34 @@
+import { delay, http, HttpResponse } from "msw";
+
+import { chatMessageStreamResponse } from "@api/mock/responses/chatMessage";
+
+/** 조각 사이의 간격. 한 번에 몰아 보내면 스트리밍이 아니라 한 덩어리 응답이 돼요 */
+const CHUNK_INTERVAL = 10;
+
+/** SSE 프레임 한 개. 빈 줄이 이벤트의 끝을 알립니다 */
+const toFrame = (event: string, data: object) =>
+  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+export const sendChatMessageHandlers = [
+  http.post("*/api/v1/conversations/:sessionId/messages", () => {
+    const encoder = new TextEncoder();
+    const { deltas, messageId } = chatMessageStreamResponse;
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        for (const delta of deltas) {
+          await delay(CHUNK_INTERVAL);
+          controller.enqueue(encoder.encode(toFrame("chunk", { delta })));
+        }
+
+        await delay(CHUNK_INTERVAL);
+        controller.enqueue(encoder.encode(toFrame("complete", { messageId })));
+        controller.close();
+      },
+    });
+
+    return new HttpResponse(stream, {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }),
+];

--- a/frontend/src/shared/api/mock/handlers/index.ts
+++ b/frontend/src/shared/api/mock/handlers/index.ts
@@ -2,6 +2,7 @@ import { authCsrfHandlers } from "./api/v1/auth/csrf";
 import { authMeHandlers } from "./api/v1/auth/me";
 import { authNicknameHandlers } from "./api/v1/auth/nickname";
 import { chatMessagesHandlers } from "./api/v1/conversations/[sessionId]";
+import { sendChatMessageHandlers } from "./api/v1/conversations/[sessionId]/messages";
 import { invitationPreviewHandlers } from "./api/v1/invitations/[tokenOrCode]";
 import { invitationAcceptHandlers } from "./api/v1/invitations/accept";
 import { lastViewedWorkspaceHandlers } from "./api/v1/members/me/lastViewedWorkspace";
@@ -13,7 +14,7 @@ import { workspaceInvitationsHandlers } from "./api/v1/workspaces/[workspaceId]/
 import { workspaceInvitationReissueHandlers } from "./api/v1/workspaces/[workspaceId]/invitations/reissue";
 import { workspaceNotionOAuthAuthorizationsHandlers } from "./api/v1/workspaces/[workspaceId]/notionOauthAuthorizations";
 
-// 리다이렉트 엔드포인트(OAuth 시작·로그아웃)와 SSE 메시지 전송은 XHR 응답이 아니라 두지 않아요
+// 리다이렉트 엔드포인트(OAuth 시작·로그아웃)는 XHR 응답이 아니라 두지 않아요
 export const handlers = [
   ...authMeHandlers,
   ...authCsrfHandlers,
@@ -29,4 +30,5 @@ export const handlers = [
   ...invitationAcceptHandlers,
   ...invitationPreviewHandlers,
   ...chatMessagesHandlers,
+  ...sendChatMessageHandlers,
 ];

--- a/frontend/src/shared/api/mock/responses/chatMessage.ts
+++ b/frontend/src/shared/api/mock/responses/chatMessage.ts
@@ -1,4 +1,7 @@
-import type { ChatMessage } from "@api/mock/types/chatMessage";
+import type {
+  ChatMessage,
+  ChatMessageStream,
+} from "@api/mock/types/chatMessage";
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
@@ -36,3 +39,9 @@ export const chatMessagesResponse = [
     createdAt: fromNow(2 * HOUR - 2 * MINUTE - 3 * SECOND),
   },
 ] satisfies ChatMessage[];
+
+// 현재 Fake LLM이 돌려주는 두 조각이에요
+export const chatMessageStreamResponse = {
+  deltas: ["테스트 ", "LLM 응답입니다."],
+  messageId: 102,
+} satisfies ChatMessageStream;

--- a/frontend/src/shared/api/mock/types/chatMessage.ts
+++ b/frontend/src/shared/api/mock/types/chatMessage.ts
@@ -7,3 +7,11 @@ export interface ChatMessage {
   /** ISO 8601 */
   createdAt: string;
 }
+
+/** 메시지 전송 SSE 스트림이 흘려보내는 내용 */
+export interface ChatMessageStream {
+  /** chunk 이벤트로 나눠 보낼 답변 조각 */
+  deltas: string[];
+  /** complete 이벤트가 알려 주는 저장된 assistant 메시지 ID */
+  messageId: number;
+}

--- a/frontend/src/shared/api/sse/parseSseEvents/index.ts
+++ b/frontend/src/shared/api/sse/parseSseEvents/index.ts
@@ -1,0 +1,74 @@
+/**
+ * SSE 프레임 하나를 파싱한 결과.
+ *
+ * 어느 API의 이벤트인지는 모르므로 `data`는 파싱하지 않은 문자열 그대로 둡니다.
+ * 무엇이 유효한 이벤트 이름인지는 SSE가 아니라 엔드포인트 스펙이 정하므로 `fetch/`가 판단합니다.
+ */
+export interface SseEvent {
+  /** 이벤트 이름. `event:` 줄이 없으면 SSE 명세 기본값인 "message" */
+  event: string;
+  /** `data:` 줄의 값. 여러 줄이면 줄바꿈으로 이어 붙임 */
+  data: string;
+}
+
+/** 프레임(이벤트 하나)의 경계. SSE는 빈 줄로 이벤트를 끊어요 */
+const FRAME_SEPARATOR = "\n\n";
+
+/** `event:` 줄이 없을 때 쓰는 SSE 명세의 기본 이벤트 이름 */
+const DEFAULT_EVENT_NAME = "message";
+
+interface ParseSseEventsParams {
+  /** 앞 청크에서 프레임을 완성하지 못하고 남은 문자열 */
+  buffer: string;
+  /** 이번에 읽은 청크 */
+  chunk: string;
+}
+
+/**
+ * 프레임 하나를 `event` / `data`로 읽습니다.
+ *
+ * `data:` 줄이 하나도 없는 프레임(주석·하트비트)은 전달할 내용이 없으므로 이벤트로 세지 않습니다.
+ */
+const toSseEvent = (frame: string) => {
+  const dataLines: string[] = [];
+  let event = DEFAULT_EVENT_NAME;
+
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // 주석 줄
+
+    const colonIndex = line.indexOf(":");
+    const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+    // 필드 구분자 뒤의 공백 한 칸은 값이 아니라 서식이에요
+    const value =
+      colonIndex === -1 ? "" : line.slice(colonIndex + 1).replace(/^ /, "");
+
+    if (field === "event") event = value;
+    if (field === "data") dataLines.push(value);
+  }
+
+  if (dataLines.length === 0) return null;
+
+  return { event, data: dataLines.join("\n") } satisfies SseEvent;
+};
+
+/**
+ * @description 남은 버퍼와 새 청크를 이어 붙여 완성된 SSE 이벤트 목록과 다음 버퍼를 만듭니다
+ * @param params - 앞 청크에서 남은 버퍼와 이번에 읽은 청크
+ * @returns 완성된 이벤트 목록과, 아직 프레임을 이루지 못해 다음 청크로 넘길 버퍼
+ * @example
+ * const { events, buffer } = parseSseEvents({ buffer: "", chunk: 'event: chunk\ndata: {"delta":"안녕"}\n\n' });
+ * // events: [{ event: "chunk", data: '{"delta":"안녕"}' }], buffer: ""
+ */
+export const parseSseEvents = ({ buffer, chunk }: ParseSseEventsParams) => {
+  // 청크 경계에 \r과 \n이 나뉘어 걸릴 수 있으므로 이어 붙인 뒤에 한 번에 정규화해요
+  const text = `${buffer}${chunk}`.replace(/\r\n/g, "\n");
+
+  const frames = text.split(FRAME_SEPARATOR);
+  // 마지막 조각은 빈 줄을 아직 못 만난 부분이라 다음 청크를 기다려요
+  const rest = frames.pop() ?? "";
+
+  return {
+    events: frames.map(toSseEvent).filter((event) => event !== null),
+    buffer: rest,
+  };
+};

--- a/frontend/src/shared/api/sse/parseSseEvents/test.ts
+++ b/frontend/src/shared/api/sse/parseSseEvents/test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSseEvents } from ".";
+
+describe("parseSseEvents", () => {
+  it("빈 줄로 끝난 온전한 프레임 하나를 이벤트로 돌려준다", () => {
+    const { events, buffer } = parseSseEvents({
+      buffer: "",
+      chunk: 'event: chunk\ndata: {"delta":"테스트 "}\n\n',
+    });
+
+    expect(events).toEqual([{ event: "chunk", data: '{"delta":"테스트 "}' }]);
+    expect(buffer).toBe("");
+  });
+
+  it("한 청크에 프레임이 여러 개면 순서대로 모두 돌려준다", () => {
+    const { events, buffer } = parseSseEvents({
+      buffer: "",
+      chunk:
+        'event: chunk\ndata: {"delta":"테스트 "}\n\n' +
+        'event: complete\ndata: {"messageId":102}\n\n',
+    });
+
+    expect(events).toEqual([
+      { event: "chunk", data: '{"delta":"테스트 "}' },
+      { event: "complete", data: '{"messageId":102}' },
+    ]);
+    expect(buffer).toBe("");
+  });
+
+  it("data 중간에서 잘린 청크는 이벤트를 내지 않고 버퍼에 남긴다", () => {
+    const { events, buffer } = parseSseEvents({
+      buffer: "",
+      chunk: 'event: chunk\ndata: {"delta":"테',
+    });
+
+    expect(events).toEqual([]);
+    expect(buffer).toBe('event: chunk\ndata: {"delta":"테');
+  });
+
+  it("남은 버퍼에 다음 청크를 이어 붙여 잘렸던 프레임을 완성한다", () => {
+    const { events, buffer } = parseSseEvents({
+      buffer: 'event: chunk\ndata: {"delta":"테',
+      chunk: '스트 "}\n\n',
+    });
+
+    expect(events).toEqual([{ event: "chunk", data: '{"delta":"테스트 "}' }]);
+    expect(buffer).toBe("");
+  });
+
+  it("모르는 이벤트 이름도 버리지 않고 그대로 돌려준다", () => {
+    const { events } = parseSseEvents({
+      buffer: "",
+      chunk: "event: heartbeat\ndata: {}\n\n",
+    });
+
+    expect(events).toEqual([{ event: "heartbeat", data: "{}" }]);
+  });
+
+  it("event 줄이 없으면 SSE 기본 이벤트 이름인 message로 채운다", () => {
+    const { events } = parseSseEvents({ buffer: "", chunk: "data: hello\n\n" });
+
+    expect(events).toEqual([{ event: "message", data: "hello" }]);
+  });
+
+  it("data 줄이 여러 개면 줄바꿈으로 이어 붙인다", () => {
+    const { events } = parseSseEvents({
+      buffer: "",
+      chunk: "event: chunk\ndata: 첫 줄\ndata: 둘째 줄\n\n",
+    });
+
+    expect(events).toEqual([{ event: "chunk", data: "첫 줄\n둘째 줄" }]);
+  });
+
+  it("줄 끝이 CRLF여도 같은 이벤트로 읽는다", () => {
+    const { events, buffer } = parseSseEvents({
+      buffer: "",
+      chunk: 'event: chunk\r\ndata: {"delta":"테스트 "}\r\n\r\n',
+    });
+
+    expect(events).toEqual([{ event: "chunk", data: '{"delta":"테스트 "}' }]);
+    expect(buffer).toBe("");
+  });
+
+  it("주석 줄만 있는 프레임은 이벤트로 세지 않는다", () => {
+    const { events, buffer } = parseSseEvents({
+      buffer: "",
+      chunk: ": keep-alive\n\n",
+    });
+
+    expect(events).toEqual([]);
+    expect(buffer).toBe("");
+  });
+});


### PR DESCRIPTION
## 관련 이슈

closes #304

## 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능) -->

> 변경 배경·핵심 아이디어·코드 워크스루·퀴즈를 정리한 [변경 설명 페이지](https://claude.ai/code/artifact/70ecaa9e-17f9-4ffc-b167-5813b0cf574b?via=auto_preview)를 함께 참고해 주세요.

  채팅 답변은 `text/event-stream`으로 오는데, `EventSource`는 GET 전용이라 POST 본문·CSRF 헤더를 실을 수 없고 axios(XHR)는 응답이 끝나야 값을 돌려줍니다. 
그래서 `fetch` + `ReadableStream` 위에 SSE 수신 계층을 만들었습니다.

  - **SSE 프레임 파서** — `parseSseEvents({ buffer, chunk })` → `{ events, buffer }`. 빈 줄로 닫힌 프레임만 이벤트로 내고 나머지는 버퍼에 남깁니다. 네트워크를 모르는 순수 함수라 단위 테스트로 검증합니다.
  - **요청 함수** — `streamChatMessageApi`를 async generator로 만들어 `chunk`·`complete`·`error`를 순서대로 흘려보냅니다. 소비자는 `for await`로 받습니다.
  - **오류를 두 갈래로** — 연결 전 HTTP 오류(409·403·404 등)는 `ChatStreamRequestError`로 throw하고, 연결 후 `error` 이벤트는 throw하지 않고 이벤트로 넘깁니다. 이미 화면에 부분 답변이 떠 있는 상태라 요청 실패와 다르게 다뤄야 합니다.
  - **취소** — `AbortSignal`로 끊고, 취소는 실패가 아니라 정상 종료로 처리합니다.
  - **mock** — msw 핸들러가 `ReadableStream`으로 조각 2개와 `complete`를 지연을 두고 흘려보냅니다.

  화면 연결은 이번 범위가 아니며 #305 에서 이어집니다.


### 참고 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->