### PR TITLE
[BE] develop CI 테스트 컴파일 오류 수정

### DIFF
--- a/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
@@ -663,6 +663,7 @@ class ChatMessageServiceTest {
                 persistenceService,
                 chatMessageRepository,
                 llmClient,
+                documentSearchService,
                 new ActiveChatStreamRegistry(),
                 directExecutor
         );


### PR DESCRIPTION
## 관련 이슈

- Closes #321

## 작업 내용

- #316에서 추가된 PublishedDocumentSearchService 의존성을 ChatMessageServiceTest의 스트림 회귀 테스트 fixture에 전달했습니다.
- 운영 코드와 테스트 시나리오의 검증 의미는 변경하지 않았습니다.
- 현재 생성자 계약과 테스트 fixture가 어긋나 compileTestJava가 실패하던 문제를 복구했습니다.

### 참고 사항

- 원인: ChatMessageService 생성자는 7개 의존성을 요구하지만 ChatMessageServiceTest.java:661에서 6개만 전달하고 있었습니다.
- 원래 실패: Backend CI 33589450295와 Backend Dev CD 33589450420이 같은 compileTestJava 오류로 실패했습니다.
- 로컬 검증: ./gradlew test --no-daemon, ./gradlew integrationTest --no-daemon, ./gradlew bootJar --no-daemon, ./gradlew spotlessCheck --no-daemon PASS.
- GitHub Actions Backend CI 33590307209: formatting, unit tests, integration tests, acceptance tests, bootJar 전부 PASS.
- 로컬 전체 acceptance에서 발생한 java.io.EOFException은 대표 acceptance 단독 실행 PASS와 함께 별도 테스트 프로세스 안정성 이슈로 기록했습니다.
- 원자 커밋: 840a68c fix: 채팅 서비스 테스트 생성자 계약 동기화