### PR TITLE
[FE] 노션 연결 실패 화면 추가와 알 수 없는 result 쿼리 정리

### DIFF
--- a/frontend/src/modules/widgets/notion/NotionConnectCard/constants/notionConnect.ts
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/constants/notionConnect.ts
@@ -12,16 +12,15 @@ export const NOTION_CONNECTION_RESULT = {
 } as const;
 
 /**
- * 연결이 실패했을 때 연결 버튼 아래에 띄울 문구.
+ * 연결 시작이 실패했을 때 연결·다시 시도 버튼 아래에 띄울 문구.
  *
  * - `forbidden`: 연결 시작이 403. CSRF 실패는 httpClient가 한 번 재시도하므로 남는 403은 OWNER가 아닌 경우예요.
- * - `callbackFailed`: Notion에서 거절·취소했거나 서버가 콜백을 처리하지 못해 `?result=failed`로 돌아온 경우예요.
  * - `unknown`: 그 외(네트워크·5xx·timeout).
  *
- * 인증이 풀린 401은 로그인으로, 없는 워크스페이스 404는 선택 화면으로 보내므로 여기 없습니다.
+ * 인증이 풀린 401은 로그인으로, 없는 워크스페이스 404는 선택 화면으로 보냅니다.
+ * Notion에서 거절·취소해 `?result=failed`로 돌아온 경우는 문구가 아니라 실패 화면 전체로 안내해요.
  */
 export const NOTION_CONNECT_ERROR_MESSAGE = {
   forbidden: "워크스페이스 소유자만 노션을 연결할 수 있어요.",
-  callbackFailed: "노션 연결에 실패했어요. 다시 시도해 주세요.",
   unknown: "노션 연결을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.",
 } as const;

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/index.tsx
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/index.tsx
@@ -12,7 +12,7 @@ import { useNotionConnect } from "./model/useNotionConnect";
  * 워크스페이스 생성 플로우의 마지막 단계로, 노션에 쌓아둔 기록을 knot로 옮길지 물어요.
  * `노션 연결하기`는 연결 시작 API로 받은 Notion 인증 페이지로 이동하고, 돌아오면
  * `?result=connected`는 홈으로 보내고 `?result=failed`는 실패 화면(워크스페이스로 이동)을
- * 보여줍니다. `워크스페이스로 이동`은 연결 없이 홈으로 가요.
+ * 보여줍니다. 알 수 없는 `result`는 쿼리를 지우고 연결 카드로 되돌려요. `워크스페이스로 이동`은 연결 없이 홈으로 가요.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
  *

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/index.tsx
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/index.tsx
@@ -11,7 +11,8 @@ import { useNotionConnect } from "./model/useNotionConnect";
  *
  * 워크스페이스 생성 플로우의 마지막 단계로, 노션에 쌓아둔 기록을 knot로 옮길지 물어요.
  * `노션 연결하기`는 연결 시작 API로 받은 Notion 인증 페이지로 이동하고, 돌아오면
- * 결과에 따라 홈으로 가거나 실패 문구를 보여줍니다. `워크스페이스로 이동`은 연결 없이 홈으로 가요.
+ * `?result=connected`는 홈으로 보내고 `?result=failed`는 실패 화면(다시 시도·워크스페이스로 이동)을
+ * 보여줍니다. `워크스페이스로 이동`은 연결 없이 홈으로 가요.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
  *
@@ -19,8 +20,50 @@ import { useNotionConnect } from "./model/useNotionConnect";
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=432-1949 Card/Onboarding & Workspace}
  */
 export default function NotionConnectCard() {
-  const { isConnecting, errorMessage, handleConnect, handleGoHome } =
+  const { isFailed, isConnecting, errorMessage, handleConnect, handleGoHome } =
     useNotionConnect();
+
+  if (isFailed) {
+    return (
+      <Container>
+        <Icon />
+
+        <Header>
+          <Title>노션 연결에 실패했어요</Title>
+          <Description>
+            연결이 취소됐거나 문제가 생겼어요.
+            <br />
+            다시 시도할 수 있어요.
+          </Description>
+        </Header>
+
+        <Actions>
+          <Button
+            size="lg"
+            isFullWidth
+            isLoading={isConnecting}
+            onClick={handleConnect}
+          >
+            다시 시도
+          </Button>
+          {errorMessage && (
+            <ErrorMessage role="alert">{errorMessage}</ErrorMessage>
+          )}
+
+          <Divider label="또는" />
+
+          <Button
+            size="lg"
+            variant="outline"
+            isFullWidth
+            onClick={handleGoHome}
+          >
+            워크스페이스로 이동
+          </Button>
+        </Actions>
+      </Container>
+    );
+  }
 
   return (
     <Container>

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/index.tsx
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/index.tsx
@@ -11,7 +11,7 @@ import { useNotionConnect } from "./model/useNotionConnect";
  *
  * 워크스페이스 생성 플로우의 마지막 단계로, 노션에 쌓아둔 기록을 knot로 옮길지 물어요.
  * `노션 연결하기`는 연결 시작 API로 받은 Notion 인증 페이지로 이동하고, 돌아오면
- * `?result=connected`는 홈으로 보내고 `?result=failed`는 실패 화면(다시 시도·워크스페이스로 이동)을
+ * `?result=connected`는 홈으로 보내고 `?result=failed`는 실패 화면(워크스페이스로 이동)을
  * 보여줍니다. `워크스페이스로 이동`은 연결 없이 홈으로 가요.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 맡으므로 이 카드는 자기 모양만 그려요.
@@ -33,31 +33,12 @@ export default function NotionConnectCard() {
           <Description>
             연결이 취소됐거나 문제가 생겼어요.
             <br />
-            다시 시도할 수 있어요.
+            워크스페이스로 이동해 이용을 계속할 수 있어요.
           </Description>
         </Header>
 
         <Actions>
-          <Button
-            size="lg"
-            isFullWidth
-            isLoading={isConnecting}
-            onClick={handleConnect}
-          >
-            다시 시도
-          </Button>
-          {errorMessage && (
-            <ErrorMessage role="alert">{errorMessage}</ErrorMessage>
-          )}
-
-          <Divider label="또는" />
-
-          <Button
-            size="lg"
-            variant="outline"
-            isFullWidth
-            onClick={handleGoHome}
-          >
+          <Button size="lg" isFullWidth onClick={handleGoHome}>
             워크스페이스로 이동
           </Button>
         </Actions>

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/model/useNotionConnect.ts
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/model/useNotionConnect.ts
@@ -26,7 +26,7 @@ const isNotFoundError = (error: unknown) =>
  *
  * Notion에서 돌아오면 서버가 `?result=connected|failed`를 붙여 이 화면으로 보내요.
  * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 `isFailed`를 켜
- * 카드가 실패 화면(다시 시도·워크스페이스로 이동)을 그리게 둡니다.
+ * 카드가 실패 화면(워크스페이스로 이동)을 그리게 둡니다.
  *
  * 연결 시작 실패는 401 → 로그인, 404 → 워크스페이스 선택 화면으로 `replace` 이동하고,
  * 403(OWNER 아님)과 그 외는 버튼 아래 문구로 알립니다.

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/model/useNotionConnect.ts
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/model/useNotionConnect.ts
@@ -26,17 +26,19 @@ const isNotFoundError = (error: unknown) =>
  *
  * Notion에서 돌아오면 서버가 `?result=connected|failed`를 붙여 이 화면으로 보내요.
  * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 `isFailed`를 켜
- * 카드가 실패 화면(워크스페이스로 이동)을 그리게 둡니다.
+ * 카드가 실패 화면(워크스페이스로 이동)을 그리게 둡니다. 그 밖의 알 수 없는 값은
+ * 잘못된 접근으로 보고 쿼리를 지워(`replace`) 연결 카드로 되돌립니다.
  *
  * 연결 시작 실패는 401 → 로그인, 404 → 워크스페이스 선택 화면으로 `replace` 이동하고,
  * 403(OWNER 아님)과 그 외는 버튼 아래 문구로 알립니다.
  */
 export const useNotionConnect = () => {
   const { workspaceId } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const result = searchParams.get(NOTION_CONNECTION_RESULT_PARAM);
   const isConnected = result === NOTION_CONNECTION_RESULT.connected;
   const isFailed = result === NOTION_CONNECTION_RESULT.failed;
+  const isUnknownResult = result !== null && !isConnected && !isFailed;
 
   const [errorMessage, setErrorMessage] = useState<string>();
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -53,6 +55,12 @@ export const useNotionConnect = () => {
 
     navigateToWorkspaceHome({ workspaceId, replace: true });
   }, [isConnected, workspaceId, navigateToWorkspaceHome]);
+
+  useEffect(() => {
+    if (!isUnknownResult) return;
+
+    setSearchParams({}, { replace: true });
+  }, [isUnknownResult, setSearchParams]);
 
   const handleConnect = () => {
     if (workspaceId === undefined || isConnecting) return;

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/model/useNotionConnect.ts
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/model/useNotionConnect.ts
@@ -8,7 +8,6 @@ import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 
 import {
-  NOTION_CONNECT_ERROR_MESSAGE,
   NOTION_CONNECTION_RESULT,
   NOTION_CONNECTION_RESULT_PARAM,
 } from "../constants/notionConnect";
@@ -26,7 +25,8 @@ const isNotFoundError = (error: unknown) =>
  * 버튼을 로딩으로 붙잡아 두 번 눌리지 않게 합니다.
  *
  * Notion에서 돌아오면 서버가 `?result=connected|failed`를 붙여 이 화면으로 보내요.
- * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 실패 문구를 띄운 채 다시 시도할 수 있게 둡니다.
+ * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 `isFailed`를 켜
+ * 카드가 실패 화면(다시 시도·워크스페이스로 이동)을 그리게 둡니다.
  *
  * 연결 시작 실패는 401 → 로그인, 404 → 워크스페이스 선택 화면으로 `replace` 이동하고,
  * 403(OWNER 아님)과 그 외는 버튼 아래 문구로 알립니다.
@@ -36,12 +36,9 @@ export const useNotionConnect = () => {
   const [searchParams] = useSearchParams();
   const result = searchParams.get(NOTION_CONNECTION_RESULT_PARAM);
   const isConnected = result === NOTION_CONNECTION_RESULT.connected;
+  const isFailed = result === NOTION_CONNECTION_RESULT.failed;
 
-  const [errorMessage, setErrorMessage] = useState<string | undefined>(
-    result === NOTION_CONNECTION_RESULT.failed
-      ? NOTION_CONNECT_ERROR_MESSAGE.callbackFailed
-      : undefined,
-  );
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const { mutate, isPending } = useStartNotionOAuthMutation();
@@ -88,5 +85,5 @@ export const useNotionConnect = () => {
     navigateToWorkspaceHome({ workspaceId });
   };
 
-  return { isConnecting, errorMessage, handleConnect, handleGoHome };
+  return { isFailed, isConnecting, errorMessage, handleConnect, handleGoHome };
 };

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/test.tsx
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/test.tsx
@@ -73,7 +73,6 @@ const getConnectButton = () =>
   screen.getByRole("button", { name: "노션 연결하기" });
 const getGoHomeButton = () =>
   screen.getByRole("button", { name: "워크스페이스로 이동" });
-const getRetryButton = () => screen.getByRole("button", { name: "다시 시도" });
 
 const overrideStartStatus = (status: number) => {
   mockServer.use(
@@ -188,7 +187,7 @@ describe("NotionConnectCard", () => {
     expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
   });
 
-  it("403이면 소유자만 연결할 수 있다는 문구를 보여주고 이동하지 않는다", async () => {
+  it("403이면 소유자 문구를 보여주고 이동하지 않으며, 다시 연결하기를 누르면 문구를 지운다", async () => {
     overrideStartStatus(403);
     const { router } = renderCard();
 
@@ -199,6 +198,13 @@ describe("NotionConnectCard", () => {
     );
     expect(getConnectButton()).toBeEnabled();
     expect(router.state.location.pathname).toBe(NOTION_CONNECTION_PATH);
+
+    holdStartResponse();
+    fireEvent.click(getConnectButton());
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 
   it("그 외 실패면 잠시 후 다시 시도 문구를 보여준다", async () => {
@@ -230,37 +236,15 @@ describe("NotionConnectCard", () => {
     expect(
       screen.getByRole("heading", { name: "노션 연결에 실패했어요" }),
     ).toBeInTheDocument();
-    expect(getRetryButton()).toBeEnabled();
     expect(getGoHomeButton()).toBeEnabled();
     expect(
       screen.queryByRole("button", { name: "노션 연결하기" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "다시 시도" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(router.state.location.pathname).toBe(NOTION_CONNECTION_PATH);
-  });
-
-  it("실패 화면에서 다시 시도를 누르면 연결 시작 응답의 authorizationUrl로 페이지를 이동시킨다", async () => {
-    const assign = vi.fn();
-    vi.stubGlobal("location", { ...window.location, assign });
-    renderCard("?result=failed");
-
-    fireEvent.click(getRetryButton());
-
-    await waitFor(() => {
-      expect(assign).toHaveBeenCalledWith(expected.authorizationUrl);
-    });
-    expect(assign).toHaveBeenCalledTimes(1);
-  });
-
-  it("실패 화면에서 다시 시도가 403이면 소유자 안내 문구를 보여준다", async () => {
-    overrideStartStatus(403);
-    renderCard("?result=failed");
-
-    fireEvent.click(getRetryButton());
-
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      FORBIDDEN_ERROR_MESSAGE,
-    );
   });
 
   it("실패 화면에서 워크스페이스로 이동을 누르면 워크스페이스 홈으로 이동한다", () => {

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/test.tsx
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/test.tsx
@@ -254,4 +254,18 @@ describe("NotionConnectCard", () => {
 
     expect(router.state.location.pathname).toBe(HOME_PATH);
   });
+
+  it("?result가 알 수 없는 값이면 쿼리를 지우고 연결 카드를 보여준다", async () => {
+    const { router } = renderCard("?result=unknown");
+
+    await waitFor(() => {
+      expect(router.state.location.search).toBe("");
+    });
+    expect(router.state.location.pathname).toBe(NOTION_CONNECTION_PATH);
+    expect(getConnectButton()).toBeEnabled();
+
+    await goBack(router);
+
+    expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
+  });
 });

--- a/frontend/src/modules/widgets/notion/NotionConnectCard/test.tsx
+++ b/frontend/src/modules/widgets/notion/NotionConnectCard/test.tsx
@@ -34,7 +34,6 @@ const HOME_PATH = getRouterPath({
 const ELSEWHERE_PATH = "/elsewhere";
 const FORBIDDEN_ERROR_MESSAGE =
   "워크스페이스 소유자만 노션을 연결할 수 있어요.";
-const CALLBACK_FAILED_MESSAGE = "노션 연결에 실패했어요. 다시 시도해 주세요.";
 const UNKNOWN_ERROR_MESSAGE =
   "노션 연결을 시작하지 못했어요. 잠시 후 다시 시도해 주세요.";
 
@@ -74,6 +73,7 @@ const getConnectButton = () =>
   screen.getByRole("button", { name: "노션 연결하기" });
 const getGoHomeButton = () =>
   screen.getByRole("button", { name: "워크스페이스로 이동" });
+const getRetryButton = () => screen.getByRole("button", { name: "다시 시도" });
 
 const overrideStartStatus = (status: number) => {
   mockServer.use(
@@ -224,19 +224,50 @@ describe("NotionConnectCard", () => {
     expect(router.state.location.pathname).toBe(ELSEWHERE_PATH);
   });
 
-  it("?result=failed로 돌아오면 연결 실패 문구를 보여주고, 다시 연결하기를 누르면 지운다", async () => {
-    holdStartResponse();
+  it("?result=failed로 돌아오면 실패 화면을 보여주고 하단에 워크스페이스로 이동 버튼을 둔다", () => {
     const { router } = renderCard("?result=failed");
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      CALLBACK_FAILED_MESSAGE,
-    );
+    expect(
+      screen.getByRole("heading", { name: "노션 연결에 실패했어요" }),
+    ).toBeInTheDocument();
+    expect(getRetryButton()).toBeEnabled();
+    expect(getGoHomeButton()).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: "노션 연결하기" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(router.state.location.pathname).toBe(NOTION_CONNECTION_PATH);
+  });
 
-    fireEvent.click(getConnectButton());
+  it("실패 화면에서 다시 시도를 누르면 연결 시작 응답의 authorizationUrl로 페이지를 이동시킨다", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { ...window.location, assign });
+    renderCard("?result=failed");
+
+    fireEvent.click(getRetryButton());
 
     await waitFor(() => {
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(assign).toHaveBeenCalledWith(expected.authorizationUrl);
     });
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
+
+  it("실패 화면에서 다시 시도가 403이면 소유자 안내 문구를 보여준다", async () => {
+    overrideStartStatus(403);
+    renderCard("?result=failed");
+
+    fireEvent.click(getRetryButton());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      FORBIDDEN_ERROR_MESSAGE,
+    );
+  });
+
+  it("실패 화면에서 워크스페이스로 이동을 누르면 워크스페이스 홈으로 이동한다", () => {
+    const { router } = renderCard("?result=failed");
+
+    fireEvent.click(getGoHomeButton());
+
+    expect(router.state.location.pathname).toBe(HOME_PATH);
   });
 });

--- a/frontend/src/pages/workspace/[workspaceId]/notion-connection/index.tsx
+++ b/frontend/src/pages/workspace/[workspaceId]/notion-connection/index.tsx
@@ -6,8 +6,8 @@ import NotionConnectCard from "@widgets/notion/NotionConnectCard";
  * 워크스페이스 생성 플로우의 마지막 단계로, 기존 노션 기록을 knot으로 가져올지 묻는 화면이다.
  * 연동하거나 건너뛰면 워크스페이스 홈(`/workspace/:workspaceId`)으로 이동한다.
  * Notion OAuth를 마친 서버는 `?result=connected|failed`를 붙여 이 화면으로 되돌려보낸다.
- * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 실패 화면
- * (다시 시도·워크스페이스로 이동)을 보여준다.
+ * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 실패 화면(워크스페이스로 이동)을
+ * 보여준다.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *

--- a/frontend/src/pages/workspace/[workspaceId]/notion-connection/index.tsx
+++ b/frontend/src/pages/workspace/[workspaceId]/notion-connection/index.tsx
@@ -7,7 +7,7 @@ import NotionConnectCard from "@widgets/notion/NotionConnectCard";
  * 연동하거나 건너뛰면 워크스페이스 홈(`/workspace/:workspaceId`)으로 이동한다.
  * Notion OAuth를 마친 서버는 `?result=connected|failed`를 붙여 이 화면으로 되돌려보낸다.
  * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 실패 화면(워크스페이스로 이동)을
- * 보여준다.
+ * 보여주며, 알 수 없는 값이면 쿼리를 지우고 연결 카드로 되돌린다.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *

--- a/frontend/src/pages/workspace/[workspaceId]/notion-connection/index.tsx
+++ b/frontend/src/pages/workspace/[workspaceId]/notion-connection/index.tsx
@@ -6,6 +6,8 @@ import NotionConnectCard from "@widgets/notion/NotionConnectCard";
  * 워크스페이스 생성 플로우의 마지막 단계로, 기존 노션 기록을 knot으로 가져올지 묻는 화면이다.
  * 연동하거나 건너뛰면 워크스페이스 홈(`/workspace/:workspaceId`)으로 이동한다.
  * Notion OAuth를 마친 서버는 `?result=connected|failed`를 붙여 이 화면으로 되돌려보낸다.
+ * `connected`면 워크스페이스 홈으로 `replace` 이동하고, `failed`면 실패 화면
+ * (다시 시도·워크스페이스로 이동)을 보여준다.
  *
  * 로고와 중앙 배치는 `CenteredLayout`이 담당하고, 이 페이지는 카드를 놓기만 한다.
  *


### PR DESCRIPTION
## 관련 이슈

- #323

## 작업 내용

노션 인증 페이지에서 취소해 `?result=failed`로 돌아왔을 때 비어 있던 화면에 전용 실패 화면을 추가하고, 알 수 없는 `result` 값은 쿼리를 정리해 연결 카드로 되돌리도록 하였습니다.

> 변경 배경·핵심 아이디어·코드 워크스루·퀴즈를 정리한 [변경 설명 페이지](https://claude.ai/code/artifact/d2be1f81-301f-41b1-83a6-ae108a63f659)를 함께 참고해 주세요.

### result=failed 전용 실패 화면

기존에는 `?result=failed`로 돌아와도 연결 카드가 그대로 남고, 버튼 아래에 `callbackFailed` 문구 한 줄만 표시되었습니다. 노션까지 다녀온 연결 시도의 "결과"인데 화면이 결과를 말해 주지 않아, 전용 실패 화면을 그리도록 하였습니다.

```mermaid
sequenceDiagram
    participant U as 사용자
    participant F as FE 연결 화면
    participant S as 서버
    participant N as Notion

    U->>F: 노션 연결하기 클릭
    F->>S: 연결 시작 API
    S-->>F: authorizationUrl
    F->>N: 인증 페이지로 전체 이동
    U->>N: 취소
    N->>S: OAuth 콜백
    S-->>F: "303 리다이렉트 ?result=failed"
    F-->>U: 실패 화면 표시
```

`NotionConnectCard`가 `isFailed`일 때 이른 반환으로 실패 화면(제목·설명·`워크스페이스로 이동` 버튼)을 렌더링합니다. 별도 컴포넌트를 만드는 대신 기존 카드 셸(`Container`·`Header`·`Actions`)을 재사용하였습니다.

이에 따라 `NOTION_CONNECT_ERROR_MESSAGE`에서 `callbackFailed` 문구를 삭제하였습니다. 남은 문구(`forbidden`·`unknown`)는 연결 "시작" API 실패 전용이고, 콜백 실패는 화면이 담당한다는 역할 구분을 주석에도 반영하였습니다.

### 알 수 없는 result 쿼리 정리

`?result=oops`처럼 정의되지 않은 값이 붙어 들어오면 기존에는 아무 처리 없이 쿼리가 URL에 남았습니다. 잘못된 접근으로 보고, 쿼리만 지워 연결 카드로 되돌리도록 하였습니다.

```ts
useEffect(() => {
  if (!isUnknownResult) return;

  setSearchParams({}, { replace: true });
}, [isUnknownResult, setSearchParams]);
```

`replace`로 지우므로 히스토리에 잘못된 쿼리 URL이 남지 않아, 뒤로가기가 해당 주소로 되돌아가지 않습니다.

### 테스트

실패 화면 노출(연결하기·다시 시도 버튼과 alert 문구의 부재 포함), 실패 화면에서의 워크스페이스 홈 이동, 알 수 없는 쿼리 정리와 정리 후 뒤로가기 동작, 403 문구가 재시도 시 지워지는 동작을 검증하도록 테스트를 보강하였습니다. `NotionConnectCard` 테스트 12건이 모두 통과합니다.

### 참고 사항

- 이슈 TODO와 달라진 결정이 두 가지 있습니다. 의도에 맞는지 봐주시면 감사하겠습니다.
  - 실패 화면에 `다시 시도` 버튼을 두지 않고 `워크스페이스로 이동`만 제공하였습니다.
  - 알 수 없는 `result`는 워크스페이스 홈으로 이동시키는 대신, 화면을 떠나지 않고 쿼리만 정리해 연결 카드로 되돌립니다.
- `result=connected` 성공 화면은 이슈 메모대로 별도 이슈에서 진행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136RZkANqE7y8aPvmEVgDdP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated failure screen for unsuccessful Notion connections.
  * Added a button to navigate from the failure screen to the workspace.
  * Unknown connection results now return to the standard Notion connection card.
* **Bug Fixes**
  * Retrying after a 403 error now clears the owner-only error message.
  * Connection result handling now directs users to the appropriate screen for success, failure, and invalid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->