### PR TITLE
[BE] 개발 환경 Notion OAuth 공개 연결 설정 복구

### DIFF
--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -97,11 +97,15 @@ jobs:
           NCP_DEV_KNOWN_HOSTS: ${{ secrets.NCP_DEV_KNOWN_HOSTS }}
           WORKSPACE_INVITATION_LOOKUP_HASH_KEY: ${{ secrets.WORKSPACE_INVITATION_LOOKUP_HASH_KEY }}
           WORKSPACE_INVITATION_ENCRYPTION_KEY: ${{ secrets.WORKSPACE_INVITATION_ENCRYPTION_KEY }}
+          NOTION_OAUTH_CLIENT_ID: ${{ secrets.NOTION_OAUTH_CLIENT_ID }}
+          NOTION_OAUTH_CLIENT_SECRET: ${{ secrets.NOTION_OAUTH_CLIENT_SECRET }}
         run: |
           set -Eeuo pipefail
 
           : "${WORKSPACE_INVITATION_LOOKUP_HASH_KEY:?WORKSPACE_INVITATION_LOOKUP_HASH_KEY secret is required}"
           : "${WORKSPACE_INVITATION_ENCRYPTION_KEY:?WORKSPACE_INVITATION_ENCRYPTION_KEY secret is required}"
+          : "${NOTION_OAUTH_CLIENT_ID:?NOTION_OAUTH_CLIENT_ID secret is required}"
+          : "${NOTION_OAUTH_CLIENT_SECRET:?NOTION_OAUTH_CLIENT_SECRET secret is required}"
 
           install -d -m 700 "$HOME/.ssh"
           umask 077
@@ -113,6 +117,11 @@ jobs:
           env_file="$RUNNER_TEMP/knot-backend-dev.env"
           printf 'WORKSPACE_INVITATION_LOOKUP_HASH_KEY=%s\n' "$WORKSPACE_INVITATION_LOOKUP_HASH_KEY" > "$env_file"
           printf 'WORKSPACE_INVITATION_ENCRYPTION_KEY=%s\n' "$WORKSPACE_INVITATION_ENCRYPTION_KEY" >> "$env_file"
+          printf 'NOTION_OAUTH_ENABLED=true\n' >> "$env_file"
+          printf 'NOTION_OAUTH_CLIENT_ID=%s\n' "$NOTION_OAUTH_CLIENT_ID" >> "$env_file"
+          printf 'NOTION_OAUTH_CLIENT_SECRET=%s\n' "$NOTION_OAUTH_CLIENT_SECRET" >> "$env_file"
+          printf 'NOTION_OAUTH_CALLBACK_URI=https://dev-api.knoted.kr/api/v1/notion/oauth/callback\n' >> "$env_file"
+          printf 'NOTION_OAUTH_REDIRECT_BASE_URI=https://dev.knoted.kr\n' >> "$env_file"
           chmod 600 "$env_file"
 
           python3 - "$env_file" <<'PY'


### PR DESCRIPTION
## 관련 이슈

- Closes #329

## 작업 내용

- 백엔드 개발 배포에 Notion OAuth client ID와 client secret을 GitHub Actions Secret으로 주입합니다.
- 개발 API callback과 개발 프론트엔드 redirect base를 배포 환경 파일에 명시합니다.
- 기존 서버의 OAuth state hash key와 token encryption key는 변경하지 않습니다.

### 참고 사항

- Notion에 모든 워크스페이스 설치가 가능한 `Knot QA` OAuth 연결과 개발 callback URI를 등록했습니다.
- `./gradlew clean check bootJar` 통과
- GitHub governance 테스트 8개 통과
- YAML 파싱과 `git diff --check` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development deployment configuration to support Notion OAuth settings and callback routing.
  - Added validation to ensure required OAuth configuration is available during deployment.
  - No direct changes to the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->