### PR TITLE
[FE] 홈 화면 Notion 동기화 API 연동과 완료·실패 2초 복귀 처리

### DIFF
--- a/frontend/src/__test__/workspaceHomePage.test.ts
+++ b/frontend/src/__test__/workspaceHomePage.test.ts
@@ -3,8 +3,10 @@ import {
   GetWorkspaceResponseDto,
   GetWorkspacesResponseDto,
 } from "@api/dto/workspace";
+import { GetNotionImportStatusResponseDto } from "@api/dto/notionImport";
 import { PostWorkspaceInvitationResponseDto } from "@api/dto/workspaceInvitation";
 import { meResponse } from "@api/mock/responses/auth";
+import { notionImportStatusResponse } from "@api/mock/responses/notionImport";
 import {
   workspaceDetailResponse,
   workspacesResponse,
@@ -17,8 +19,8 @@ import { expect, test, type Page } from "@playwright/test";
  *
  * 홈 진입, 사이드바 열고 닫기, 폴더 트리 펼침·접힘, 초대 링크·코드 복사, Notion 동기화,
  * 하단 Dock으로 탐색 이동까지 홈 화면 위에서 사용자가 밟는 플로우를 페이지 단위로 확인해요.
- * 회원·워크스페이스·초대는 dev 서버의 msw mock 응답(`API_MOCKING`)에서 오므로 기대값도 같은 응답을
- * DTO로 변환해 가져와요. 동기화와 사이드바 트리는 API가 아직 없어 위젯의 임시 상수예요.
+ * 회원·워크스페이스·초대·동기화는 dev 서버의 msw mock 응답(`API_MOCKING`)에서 오므로 기대값도 같은
+ * 응답을 DTO로 변환해 가져와요. 사이드바 트리와 마지막 동기화 시각은 API가 아직 없어 위젯의 임시 상수예요.
  */
 
 const expectedMe = new GetMeResponseDto(meResponse);
@@ -37,9 +39,11 @@ const GREETING = `반가워요, ${expectedMe.nickname} 님`;
 const INVITE_CODE = expectedInvitation.code;
 const DISPLAY_INVITE_LINK = `/invite/${expectedInvitation.linkToken}`;
 
-// TODO(동기화 API Issue 미정): Notion 동기화 API 연결 후 응답으로 교체
+// TODO(마지막 동기화 시각 API 미정): 시각 API 연결 후 응답으로 교체
 const LAST_SYNCED_AT_LABEL = "어제 오후 3:12에 동기화";
-const SYNCED_DOCUMENT_COUNT = 8;
+const SYNCED_DOCUMENT_COUNT = new GetNotionImportStatusResponseDto(
+  notionImportStatusResponse,
+).processedPageCount;
 
 const getSidebarToggle = (page: Page) =>
   page.getByRole("button", { name: "사이드바" });
@@ -276,7 +280,7 @@ test.describe("팀원 초대 카드", () => {
 });
 
 test.describe("Notion 동기화 카드", () => {
-  test("지금 동기화를 누르면 로딩을 거쳐 새로 들어온 문서 수와 비활성 완료 버튼으로 바뀐다", async ({
+  test("지금 동기화를 누르면 새로 들어온 문서 수와 비활성 완료 버튼이 보였다가 2초 뒤 기본 상태로 돌아온다", async ({
     page,
   }) => {
     const notionCard = getCard({ page, title: "Notion 동기화" });
@@ -284,9 +288,7 @@ test.describe("Notion 동기화 카드", () => {
 
     await syncButton.click();
 
-    await expect(syncButton).toHaveAttribute("aria-busy", "true");
-    await expect(syncButton).toBeDisabled();
-
+    // mock 응답이 즉시 완료라 로딩은 순간이에요. 로딩 잠금은 위젯 통합 테스트가 확인해요
     await expect(
       notionCard.getByText(`문서 ${SYNCED_DOCUMENT_COUNT}개가 새로 들어왔어요`),
     ).toBeVisible();
@@ -295,6 +297,11 @@ test.describe("Notion 동기화 카드", () => {
     ).toBeDisabled();
     await expect(syncButton).toBeHidden();
     await expect(notionCard.getByText(LAST_SYNCED_AT_LABEL)).toBeHidden();
+
+    // 2초 뒤 원래 `지금 동기화`와 마지막 동기화 시각으로 돌아와요
+    await expect(syncButton).toBeVisible();
+    await expect(syncButton).toBeEnabled();
+    await expect(notionCard.getByText(LAST_SYNCED_AT_LABEL)).toBeVisible();
   });
 });
 

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/constants/notionSync.ts
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/constants/notionSync.ts
@@ -1,10 +1,11 @@
-// TODO(동기화 API Issue 미정): Notion 동기화 API 연결 후 지연·안내 문구·문서 수를 응답으로 교체
-
-/** 임시 동기화 지연(ms). 로딩 상태를 눈으로 확인할 만큼만 기다려요. */
-export const SYNC_DELAY_MS = 1000;
+// TODO(마지막 동기화 시각 API 미정): 시각을 주는 API 연결 후 응답으로 교체
 
 /** 마지막 동기화 시각 안내. Figma 예시 문구를 그대로 둔 임시 값이에요. */
 export const LAST_SYNCED_AT_LABEL = "어제 오후 3:12에 동기화";
 
-/** 동기화가 끝났을 때 새로 들어온 문서 수. */
-export const SYNCED_DOCUMENT_COUNT = 8;
+/** 완료·실패 안내를 보여준 뒤 기본 상태로 돌아가기까지의 시간(ms). */
+export const SYNC_RESULT_RESET_DELAY_MS = 2000;
+
+/** 서버가 실패 사유를 주지 못했을 때(시작 요청 자체가 실패) 보여줄 안내 문구. */
+export const SYNC_FAILED_MESSAGE =
+  "동기화에 실패했어요. 잠시 후 다시 시도해 주세요";

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/index.tsx
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/index.tsx
@@ -11,16 +11,29 @@ import { useNotionSync } from "./model/useNotionSync";
 /**
  * 홈의 Notion 동기화 카드.
  *
- * 마지막 동기화 시각을 보여주고, `지금 동기화`를 누르면 임시 지연 동안 스피너를 돌린 뒤
- * 새로 들어온 문서 수 안내와 비활성 `완료` 버튼으로 바뀌어요.
- * 동기화 API가 아직 없어 지연·문서 수는 `constants/notionSync`의 임시 값이에요.
+ * 마지막 동기화 시각을 보여주고, `지금 동기화`를 누르면 동기화 API로 Import를 시작해
+ * 끝날 때까지 스피너를 돌려요. 완료되면 새로 들어온 문서 수 안내와 비활성 `완료` 버튼으로,
+ * 실패하면 실패 안내 문구로 바뀌고, 두 경우 모두 2초 뒤 기본 상태로 돌아와요.
+ * 마지막 동기화 시각은 아직 API가 없어 `constants/notionSync`의 임시 값이에요.
  *
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10086 Card/NotionImport status=기본}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10101 홈 화면/노션 연동 완료}
  */
 export default function NotionSyncCard() {
-  const { isSyncing, isSynced, syncedDocumentCount, startSync } =
-    useNotionSync();
+  const {
+    isSyncing,
+    isSynced,
+    isSyncFailed,
+    syncedDocumentCount,
+    failureMessage,
+    startSync,
+  } = useNotionSync();
+
+  const getDescription = () => {
+    if (isSynced) return `문서 ${syncedDocumentCount}개가 새로 들어왔어요`;
+    if (isSyncFailed) return failureMessage;
+    return LAST_SYNCED_AT_LABEL;
+  };
 
   return (
     <Container>
@@ -31,11 +44,7 @@ export default function NotionSyncCard() {
           </IconChip>
           <Title>Notion 동기화</Title>
         </Head>
-        <Description>
-          {isSynced
-            ? `문서 ${syncedDocumentCount}개가 새로 들어왔어요`
-            : LAST_SYNCED_AT_LABEL}
-        </Description>
+        <Description>{getDescription()}</Description>
       </Content>
 
       {isSynced ? (

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/model/useNotionSync.ts
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/model/useNotionSync.ts
@@ -1,31 +1,70 @@
-import useTimeout from "@hooks/common/useTimeout";
-import { useState } from "react";
+import useStartNotionImportMutation from "@api/mutations/useStartNotionImportMutation";
+import useNotionImportStatusQuery from "@api/queries/useNotionImportStatusQuery";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router";
 
-import { SYNC_DELAY_MS, SYNCED_DOCUMENT_COUNT } from "../constants/notionSync";
+import {
+  SYNC_FAILED_MESSAGE,
+  SYNC_RESULT_RESET_DELAY_MS,
+} from "../constants/notionSync";
 
 /**
  * Notion 동기화 카드의 진행 상태.
  *
- * `startSync`를 부르면 임시 지연 동안 `isSyncing`이 되고, 지연이 끝나면 `isSynced`로 바뀌어요.
- * 지연 중에 카드가 언마운트되면 `useTimeout`이 타이머를 정리해 완료로 넘어가지 않아요.
+ * `startSync`가 현재 `:workspaceId`의 동기화(Import)를 시작하고, 응답의 실행 ID로
+ * 상태를 폴링해요. 완료(COMPLETED)·실패(FAILED 또는 시작 요청 실패) 결과를 보여준 뒤
+ * 2초 뒤에 기본 상태로 돌아가요. 결과가 바뀌거나 언마운트되면 복귀 타이머는 정리돼요.
  */
 export const useNotionSync = () => {
-  const [isSynced, setIsSynced] = useState(false);
-  const { isTimedOut: isSyncing, start } = useTimeout({
-    timeout: SYNC_DELAY_MS,
-    callback: () => setIsSynced(true),
-  });
+  const { workspaceId } = useParams();
+  const [importRunId, setImportRunId] = useState<number | null>(null);
+  const [isStartFailed, setIsStartFailed] = useState(false);
+
+  const { mutate: startImport, isPending: isStarting } =
+    useStartNotionImportMutation();
+  const { data: importStatus, isError: isStatusError } =
+    useNotionImportStatusQuery({ importRunId });
+
+  const status = importStatus?.status;
+  const isSynced = status === "COMPLETED";
+  const isSyncFailed = isStartFailed || isStatusError || status === "FAILED";
+  const isSyncing =
+    isStarting || (importRunId !== null && !isSynced && !isSyncFailed);
+
+  // 완료·실패 결과를 보여준 뒤 기본 상태로 돌아가요. 새 동기화가 시작되거나 언마운트되면 정리돼요
+  useEffect(() => {
+    const hasResult =
+      isStartFailed ||
+      isStatusError ||
+      status === "COMPLETED" ||
+      status === "FAILED";
+    if (!hasResult) return;
+
+    // TODO(페이지 트리·마지막 동기화 시각 API 미정): 완료 시 그 쿼리들을 무효화
+    const timer = setTimeout(() => {
+      setImportRunId(null);
+      setIsStartFailed(false);
+    }, SYNC_RESULT_RESET_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [isStartFailed, isStatusError, status]);
 
   const startSync = () => {
     if (isSyncing || isSynced) return;
 
-    start();
+    setIsStartFailed(false);
+    startImport(Number(workspaceId), {
+      onSuccess: ({ id }) => setImportRunId(id),
+      onError: () => setIsStartFailed(true),
+    });
   };
 
   return {
     isSyncing,
     isSynced,
-    syncedDocumentCount: SYNCED_DOCUMENT_COUNT,
+    isSyncFailed,
+    syncedDocumentCount: importStatus?.processedPageCount ?? 0,
+    failureMessage: importStatus?.failureReason ?? SYNC_FAILED_MESSAGE,
     startSync,
   };
 };

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/test.tsx
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/test.tsx
@@ -1,19 +1,66 @@
+import { GetNotionImportStatusResponseDto } from "@api/dto/notionImport";
+import { NOTION_IMPORT_STATUS_API_PATH } from "@api/fetch/api/v1/imports/[importRunId]";
+import { NOTION_IMPORTS_API_PATH } from "@api/fetch/api/v1/workspaces/[workspaceId]/imports";
+import {
+  notionImportStartResponse,
+  notionImportStatusResponse,
+} from "@api/mock/responses/notionImport";
+import { mockServer } from "@api/mock/server";
 import { ThemeProvider } from "@emotion/react";
 import { theme } from "@provider/themeProvider";
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getRouterPath, PATH_ROUTE } from "@routes/PATH_ROUTE";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { delay, http, HttpResponse } from "msw";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import NotionSyncCard from ".";
 
-// TODO(동기화 API Issue 미정): API 연결 후 msw 응답으로 교체
-const SYNC_DELAY_MS = 1000;
+const expectedStatus = new GetNotionImportStatusResponseDto(
+  notionImportStatusResponse,
+);
+
+const WORKSPACE_ID = 1;
+const HOME_PATH = getRouterPath({
+  routeKey: "WORKSPACE_HOME",
+  params: { workspaceId: String(WORKSPACE_ID) },
+});
 const LAST_SYNCED_TEXT = "어제 오후 3:12에 동기화";
-const SYNCED_TEXT = "문서 8개가 새로 들어왔어요";
+const SYNCED_TEXT = `문서 ${expectedStatus.processedPageCount}개가 새로 들어왔어요`;
+const START_FAILED_TEXT = "동기화에 실패했어요. 잠시 후 다시 시도해 주세요";
+const RESULT_RESET_DELAY_MS = 2000;
+
+// FAILED 상태로 덮을 때 쓰는 mock 변형. 기대 문구도 같은 값을 DTO로 변환해 가져와요
+const failedStatusResponse = {
+  ...notionImportStatusResponse,
+  status: "FAILED" as const,
+  failureReason: "Notion 문서를 가져오지 못했습니다",
+};
+const FAILED_REASON_TEXT =
+  new GetNotionImportStatusResponseDto(failedStatusResponse).failureReason ??
+  "";
 
 const renderCard = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const router = createMemoryRouter(
+    [{ path: PATH_ROUTE.WORKSPACE_HOME, element: <NotionSyncCard /> }],
+    { initialEntries: [HOME_PATH] },
+  );
+
   const view = render(
     <ThemeProvider theme={theme}>
-      <NotionSyncCard />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </ThemeProvider>,
   );
 
@@ -22,17 +69,47 @@ const renderCard = () => {
   return { ...view, syncButton };
 };
 
-const advanceTimers = async (ms: number) => {
+const click = async (element: HTMLElement) => {
   await act(async () => {
-    vi.advanceTimersByTime(ms);
+    fireEvent.click(element);
   });
 };
 
-describe("NotionSyncCard", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
+/** 가짜 타이머를 ms만큼 진행시키며 사이사이의 응답 마이크로태스크도 흘려보내요 */
+const advanceTimers = async (ms: number) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
   });
+};
 
+/** 시작 응답을 붙잡아 요청 중 상태를 관찰할 수 있게 해요 */
+const holdStartResponse = () => {
+  mockServer.use(
+    http.post(`*${NOTION_IMPORTS_API_PATH(WORKSPACE_ID)}`, async () => {
+      await delay("infinite");
+      return HttpResponse.json(notionImportStartResponse, { status: 202 });
+    }),
+  );
+};
+
+const failStartResponse = () => {
+  mockServer.use(
+    http.post(`*${NOTION_IMPORTS_API_PATH(WORKSPACE_ID)}`, () =>
+      HttpResponse.json(null, { status: 500 }),
+    ),
+  );
+};
+
+const failImportStatus = () => {
+  mockServer.use(
+    http.get(
+      `*${NOTION_IMPORT_STATUS_API_PATH(notionImportStatusResponse.id)}`,
+      () => HttpResponse.json(failedStatusResponse),
+    ),
+  );
+};
+
+describe("NotionSyncCard", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -46,56 +123,100 @@ describe("NotionSyncCard", () => {
     expect(syncButton).toHaveAttribute("aria-busy", "false");
   });
 
-  it("지금 동기화를 누르면 버튼이 로딩 상태로 잠긴다", () => {
+  it("지금 동기화를 누르면 서버 응답이 올 때까지 버튼이 로딩 상태로 잠긴다", async () => {
+    holdStartResponse();
     const { syncButton } = renderCard();
 
-    fireEvent.click(syncButton);
+    await click(syncButton);
 
-    expect(syncButton).toBeDisabled();
+    await waitFor(() => expect(syncButton).toBeDisabled());
     expect(syncButton).toHaveAttribute("aria-busy", "true");
     expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
   });
 
-  it("지연이 끝나기 전에는 완료로 바뀌지 않는다", async () => {
+  it("동기화가 완료되면 새로 들어온 문서 안내와 비활성 완료 버튼으로 바뀐다", async () => {
     const { syncButton } = renderCard();
 
-    fireEvent.click(syncButton);
-    await advanceTimers(SYNC_DELAY_MS - 1);
+    await click(syncButton);
 
-    expect(syncButton).toHaveAttribute("aria-busy", "true");
-    expect(screen.queryByText(SYNCED_TEXT)).not.toBeInTheDocument();
-  });
-
-  it("지연 뒤 새로 들어온 문서 안내와 비활성 완료 버튼으로 바뀐다", async () => {
-    const { syncButton } = renderCard();
-
-    fireEvent.click(syncButton);
-    await advanceTimers(SYNC_DELAY_MS);
-
-    expect(screen.getByText(SYNCED_TEXT)).toBeInTheDocument();
+    // 문서 수는 mock 상태 응답에서만 올 수 있어, 보이면 시작·상태 요청이 실제로 나간 거예요
+    expect(await screen.findByText(SYNCED_TEXT)).toBeInTheDocument();
     expect(screen.queryByText(LAST_SYNCED_TEXT)).not.toBeInTheDocument();
 
     const doneButton = screen.getByRole("button", { name: "완료" });
     expect(doneButton).toBeDisabled();
-    expect(doneButton).toHaveAttribute("aria-busy", "false");
     expect(
       screen.queryByRole("button", { name: "지금 동기화" }),
     ).not.toBeInTheDocument();
   });
 
-  it("지연 중 언마운트되면 타이머를 정리해 오류 없이 끝난다", async () => {
+  it("완료 안내는 2초 뒤 기본 상태로 돌아온다", async () => {
+    vi.useFakeTimers();
+    const { syncButton } = renderCard();
+
+    await click(syncButton);
+    await advanceTimers(0); // 시작·상태 응답을 흘려보내요
+
+    expect(screen.getByText(SYNCED_TEXT)).toBeInTheDocument();
+
+    await advanceTimers(RESULT_RESET_DELAY_MS - 1);
+
+    expect(screen.getByText(SYNCED_TEXT)).toBeInTheDocument();
+
+    await advanceTimers(1);
+
+    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(SYNCED_TEXT)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "지금 동기화" })).toBeEnabled();
+  });
+
+  it("동기화가 실패로 끝나면 실패 사유를 보여주고 2초 뒤 기본 상태로 돌아온다", async () => {
+    failImportStatus();
+    vi.useFakeTimers();
+    const { syncButton } = renderCard();
+
+    await click(syncButton);
+    await advanceTimers(0); // 시작·상태 응답을 흘려보내요
+
+    expect(screen.getByText(FAILED_REASON_TEXT)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "지금 동기화" })).toBeEnabled();
+
+    await advanceTimers(RESULT_RESET_DELAY_MS);
+
+    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(FAILED_REASON_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("시작 요청이 실패하면 실패 안내를 보여주고 2초 뒤 기본 상태로 돌아온다", async () => {
+    failStartResponse();
+    vi.useFakeTimers();
+    const { syncButton } = renderCard();
+
+    await click(syncButton);
+    await advanceTimers(0); // 실패 응답을 흘려보내요
+
+    expect(screen.getByText(START_FAILED_TEXT)).toBeInTheDocument();
+
+    await advanceTimers(RESULT_RESET_DELAY_MS);
+
+    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(START_FAILED_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("완료 안내 중 언마운트되면 복귀 타이머를 정리해 오류 없이 끝난다", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
+    vi.useFakeTimers();
     const { syncButton, unmount } = renderCard();
 
-    fireEvent.click(syncButton);
+    await click(syncButton);
+    await advanceTimers(0); // 시작·상태 응답을 흘려보내요
+    expect(screen.getByText(SYNCED_TEXT)).toBeInTheDocument();
+
     unmount();
-    await act(async () => {
-      vi.runAllTimers();
-    });
+    await advanceTimers(RESULT_RESET_DELAY_MS);
 
     expect(consoleError).not.toHaveBeenCalled();
-    expect(screen.queryByText(SYNCED_TEXT)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/shared/api/dto/notionImport.ts
+++ b/frontend/src/shared/api/dto/notionImport.ts
@@ -1,0 +1,72 @@
+/**
+ * Notion Import(동기화) DTO
+ *
+ * - POST /api/v1/workspaces/{workspaceId}/imports
+ * - GET  /api/v1/imports/{importRunId}
+ */
+
+// POST /api/v1/workspaces/{workspaceId}/imports
+
+/** Notion Import 시작의 서버 응답 모양 */
+export interface PostNotionImportResponseRaw {
+  id: number;
+}
+
+/**
+ * Notion Import 시작 응답. 요청 본문은 없고 워크스페이스 ID만 경로로 받아요.
+ * 새로 시작하면 202, 이미 실행 중인 Import가 있으면 409로 오지만 본문 모양은 같아서
+ * 요청 함수가 409도 성공으로 받아 실행 중인 Import를 그대로 추적해요.
+ */
+export class PostNotionImportResponseDto {
+  /** 추적할 Import 실행 ID. `GET /api/v1/imports/{id}`로 상태를 조회해요 */
+  id: number;
+
+  constructor(raw: PostNotionImportResponseRaw) {
+    this.id = raw.id;
+  }
+}
+
+// GET /api/v1/imports/{importRunId}
+
+/** Notion Import 실행 상태 조회의 서버 응답 모양 */
+export interface GetNotionImportStatusResponseRaw {
+  id: number;
+  status: "PENDING" | "RUNNING" | "COMPLETED" | "FAILED";
+  totalPageCount: number | null;
+  processedPageCount: number;
+  failureReason: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+/** Notion Import 실행 상태 조회 응답. 진행 중이면 폴링으로 다시 조회해요 */
+export class GetNotionImportStatusResponseDto {
+  /** Import 실행 ID */
+  id: number;
+  /** Import 진행 상태. PENDING·RUNNING은 진행 중, COMPLETED·FAILED는 끝난 상태예요 */
+  status: "PENDING" | "RUNNING" | "COMPLETED" | "FAILED";
+  /** 가져올 전체 Page 수. 아직 알 수 없으면 null */
+  totalPageCount: number | null;
+  /** 처리한 Page 수. 완료되면 새로 들어온 문서 수 안내에 써요 */
+  processedPageCount: number;
+  /** 사용자에게 보여줄 실패 사유. FAILED가 아니면 null */
+  failureReason: string | null;
+  /** Import 요청 시각(ISO 8601) */
+  createdAt: string;
+  /** Import 시작 시각(ISO 8601). 시작 전이면 null */
+  startedAt: string | null;
+  /** Import 종료 시각(ISO 8601). 진행 중이면 null */
+  completedAt: string | null;
+
+  constructor(raw: GetNotionImportStatusResponseRaw) {
+    this.id = raw.id;
+    this.status = raw.status;
+    this.totalPageCount = raw.totalPageCount;
+    this.processedPageCount = raw.processedPageCount;
+    this.failureReason = raw.failureReason;
+    this.createdAt = raw.createdAt;
+    this.startedAt = raw.startedAt;
+    this.completedAt = raw.completedAt;
+  }
+}

--- a/frontend/src/shared/api/fetch/api/v1/imports/[importRunId]/index.ts
+++ b/frontend/src/shared/api/fetch/api/v1/imports/[importRunId]/index.ts
@@ -1,0 +1,24 @@
+import {
+  GetNotionImportStatusResponseDto,
+  type GetNotionImportStatusResponseRaw,
+} from "@api/dto/notionImport";
+import { httpClient } from "@api/httpClient";
+
+export const NOTION_IMPORT_STATUS_API_PATH = (importRunId: number) =>
+  `/api/v1/imports/${importRunId}`;
+
+/**
+ * @description Notion Import 실행 하나의 진행 상태를 조회합니다
+ * @param importRunId - 시작 응답으로 받은 Import 실행 ID
+ * @returns Import 진행 상태와 처리한 Page 수
+ * @example
+ * const { status, processedPageCount } = await getNotionImportStatusApi(1);
+ */
+export const getNotionImportStatusApi = async (importRunId: number) => {
+  const response = await httpClient<GetNotionImportStatusResponseRaw>({
+    method: "get",
+    url: NOTION_IMPORT_STATUS_API_PATH(importRunId),
+  });
+
+  return new GetNotionImportStatusResponseDto(response.data);
+};

--- a/frontend/src/shared/api/fetch/api/v1/workspaces/[workspaceId]/imports/index.ts
+++ b/frontend/src/shared/api/fetch/api/v1/workspaces/[workspaceId]/imports/index.ts
@@ -1,0 +1,27 @@
+import {
+  PostNotionImportResponseDto,
+  type PostNotionImportResponseRaw,
+} from "@api/dto/notionImport";
+import { httpClient } from "@api/httpClient";
+
+export const NOTION_IMPORTS_API_PATH = (workspaceId: number) =>
+  `/api/v1/workspaces/${workspaceId}/imports`;
+
+/**
+ * @description 워크스페이스의 Notion 동기화(Import)를 시작합니다. 이미 실행 중이면(409) 그 실행의 ID를 그대로 받아요
+ * @param workspaceId - 워크스페이스 ID
+ * @returns 상태 조회에 쓸 Import 실행 ID
+ * @example
+ * const { id } = await startNotionImportApi(1);
+ */
+export const startNotionImportApi = async (workspaceId: number) => {
+  const response = await httpClient<PostNotionImportResponseRaw>({
+    method: "post",
+    url: NOTION_IMPORTS_API_PATH(workspaceId),
+    // 202(새 실행)와 409(이미 실행 중)는 본문 모양이 같아 둘 다 성공으로 받아요
+    validateStatus: (status) =>
+      (status >= 200 && status < 300) || status === 409,
+  });
+
+  return new PostNotionImportResponseDto(response.data);
+};

--- a/frontend/src/shared/api/mock/handlers/api/v1/imports/[importRunId]/index.ts
+++ b/frontend/src/shared/api/mock/handlers/api/v1/imports/[importRunId]/index.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from "msw";
+
+import { notionImportStatusResponse } from "@api/mock/responses/notionImport";
+
+// 경로 파라미터가 있어 fetch 상수 대신 패턴을 직접 적어요. RUNNING·FAILED 상태는 테스트에서 덮어요
+export const notionImportStatusHandlers = [
+  http.get("*/api/v1/imports/:importRunId", () =>
+    HttpResponse.json(notionImportStatusResponse),
+  ),
+];

--- a/frontend/src/shared/api/mock/handlers/api/v1/workspaces/[workspaceId]/imports/index.ts
+++ b/frontend/src/shared/api/mock/handlers/api/v1/workspaces/[workspaceId]/imports/index.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from "msw";
+
+import { notionImportStartResponse } from "@api/mock/responses/notionImport";
+
+// 경로 파라미터가 있어 fetch 상수 대신 패턴을 직접 적어요. 409(이미 실행 중)·에러는 테스트에서 덮어요
+export const workspaceNotionImportsHandlers = [
+  http.post("*/api/v1/workspaces/:workspaceId/imports", () =>
+    HttpResponse.json(notionImportStartResponse, { status: 202 }),
+  ),
+];

--- a/frontend/src/shared/api/mock/handlers/index.ts
+++ b/frontend/src/shared/api/mock/handlers/index.ts
@@ -3,12 +3,14 @@ import { authMeHandlers } from "./api/v1/auth/me";
 import { authNicknameHandlers } from "./api/v1/auth/nickname";
 import { chatMessagesHandlers } from "./api/v1/conversations/[sessionId]";
 import { sendChatMessageHandlers } from "./api/v1/conversations/[sessionId]/messages";
+import { notionImportStatusHandlers } from "./api/v1/imports/[importRunId]";
 import { invitationPreviewHandlers } from "./api/v1/invitations/[tokenOrCode]";
 import { invitationAcceptHandlers } from "./api/v1/invitations/accept";
 import { lastViewedWorkspaceHandlers } from "./api/v1/members/me/lastViewedWorkspace";
 import { workspacesHandlers } from "./api/v1/workspaces";
 import { workspaceHandlers } from "./api/v1/workspaces/[workspaceId]";
 import { workspaceConversationsHandlers } from "./api/v1/workspaces/[workspaceId]/conversations";
+import { workspaceNotionImportsHandlers } from "./api/v1/workspaces/[workspaceId]/imports";
 import { workspaceInvitationHandlers } from "./api/v1/workspaces/[workspaceId]/invitation";
 import { workspaceInvitationsHandlers } from "./api/v1/workspaces/[workspaceId]/invitations";
 import { workspaceInvitationReissueHandlers } from "./api/v1/workspaces/[workspaceId]/invitations/reissue";
@@ -26,6 +28,8 @@ export const handlers = [
   ...workspaceInvitationsHandlers,
   ...workspaceInvitationReissueHandlers,
   ...workspaceConversationsHandlers,
+  ...workspaceNotionImportsHandlers,
+  ...notionImportStatusHandlers,
   ...workspaceNotionOAuthAuthorizationsHandlers,
   ...invitationAcceptHandlers,
   ...invitationPreviewHandlers,

--- a/frontend/src/shared/api/mock/responses/notionImport.ts
+++ b/frontend/src/shared/api/mock/responses/notionImport.ts
@@ -1,0 +1,20 @@
+import type {
+  NotionImportStartResponse,
+  NotionImportStatusResponse,
+} from "@api/mock/types/notionImport";
+
+export const notionImportStartResponse = {
+  id: 1,
+} satisfies NotionImportStartResponse;
+
+// 기본값은 바로 완료된 실행 하나만 둬요. RUNNING·FAILED 같은 변형은 테스트에서 mockServer.use로 덮어요
+export const notionImportStatusResponse = {
+  id: 1,
+  status: "COMPLETED",
+  totalPageCount: 8,
+  processedPageCount: 8,
+  failureReason: null,
+  createdAt: "2026-09-02T00:00:00Z",
+  startedAt: "2026-09-02T00:00:01Z",
+  completedAt: "2026-09-02T00:00:30Z",
+} satisfies NotionImportStatusResponse;

--- a/frontend/src/shared/api/mock/types/notionImport.ts
+++ b/frontend/src/shared/api/mock/types/notionImport.ts
@@ -1,0 +1,25 @@
+/** Notion Import 시작 응답 */
+export interface NotionImportStartResponse {
+  /** Import 실행 ID */
+  id: number;
+}
+
+/** Notion Import 실행 상태 응답 */
+export interface NotionImportStatusResponse {
+  /** Import 실행 ID */
+  id: number;
+  /** Import 진행 상태 */
+  status: "PENDING" | "RUNNING" | "COMPLETED" | "FAILED";
+  /** 가져올 전체 Page 수. 아직 알 수 없으면 null */
+  totalPageCount: number | null;
+  /** 처리한 Page 수 */
+  processedPageCount: number;
+  /** 사용자 공개용 실패 사유. FAILED가 아니면 null */
+  failureReason: string | null;
+  /** Import 요청 시각(ISO 8601) */
+  createdAt: string;
+  /** Import 시작 시각. 시작 전이면 null */
+  startedAt: string | null;
+  /** Import 종료 시각. 진행 중이면 null */
+  completedAt: string | null;
+}

--- a/frontend/src/shared/api/mutations/useStartNotionImportMutation/index.ts
+++ b/frontend/src/shared/api/mutations/useStartNotionImportMutation/index.ts
@@ -1,0 +1,18 @@
+import { startNotionImportApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/imports";
+import { useMutation } from "@tanstack/react-query";
+
+/**
+ * 워크스페이스의 Notion 동기화(Import)를 시작하는 뮤테이션 훅.
+ *
+ * 요청 본문이 없어 `mutate(workspaceId)`로 워크스페이스 ID만 넘겨요.
+ * 시작 응답은 접수(202)일 뿐이라 성공·실패 판정은 응답의 실행 ID로
+ * `useNotionImportStatusQuery`를 폴링하는 쪽이 맡아요. 동기화 결과를 읽는
+ * 쿼리(페이지 트리·마지막 동기화 시각)가 아직 없어 여기서 무효화할 쿼리는 없어요.
+ */
+const useStartNotionImportMutation = () => {
+  return useMutation({
+    mutationFn: (workspaceId: number) => startNotionImportApi(workspaceId),
+  });
+};
+
+export default useStartNotionImportMutation;

--- a/frontend/src/shared/api/queries/useNotionImportStatusQuery/index.ts
+++ b/frontend/src/shared/api/queries/useNotionImportStatusQuery/index.ts
@@ -1,0 +1,39 @@
+import { getNotionImportStatusApi } from "@api/fetch/api/v1/imports/[importRunId]";
+import { notionImportKeys } from "@api/queryKey/notionImport";
+import { skipToken, useQuery } from "@tanstack/react-query";
+
+/** 진행 중인 Import의 상태를 다시 물어보는 간격(ms) */
+const POLL_INTERVAL_MS = 1000;
+
+interface UseNotionImportStatusQueryParams {
+  importRunId: number | null;
+}
+
+/**
+ * Notion Import 실행 상태를 조회하는 쿼리 훅.
+ *
+ * 시작 응답의 실행 ID로 상태를 조회하고, 끝나기 전(PENDING·RUNNING)에는 1초 간격으로
+ * 다시 물어봐요. COMPLETED·FAILED가 오거나 조회가 실패하면 폴링을 멈춰요.
+ * 추적할 실행이 없으면(`importRunId === null`) 요청하지 않아요.
+ */
+const useNotionImportStatusQuery = ({
+  importRunId,
+}: UseNotionImportStatusQueryParams) => {
+  return useQuery({
+    queryKey: notionImportKeys.detail(importRunId),
+    queryFn:
+      importRunId === null
+        ? skipToken
+        : () => getNotionImportStatusApi(importRunId),
+    refetchInterval: (query) => {
+      if (query.state.status === "error") return false;
+
+      const status = query.state.data?.status;
+      if (status === "COMPLETED" || status === "FAILED") return false;
+
+      return POLL_INTERVAL_MS;
+    },
+  });
+};
+
+export default useNotionImportStatusQuery;

--- a/frontend/src/shared/api/queryKey/notionImport.ts
+++ b/frontend/src/shared/api/queryKey/notionImport.ts
@@ -1,0 +1,6 @@
+export const notionImportKeys = {
+  all: ["notionImports"] as const,
+  // 추적할 실행이 없는 동안(null)에도 키가 필요해 null을 허용해요. 그때는 쿼리가 비활성이라 요청은 없어요
+  detail: (importRunId: number | null) =>
+    [...notionImportKeys.all, "detail", importRunId] as const,
+};


### PR DESCRIPTION
## 관련 이슈

- #324
- #325

## 작업 내용

홈 화면 Notion 동기화 카드를 실제 Import API와 연결하여 요청 중·완료·실패 상태를 화면에 그대로 반영하고, 완료·실패 안내가 2초 뒤 기본 상태로 복귀하도록 수정하였습니다.

> 변경 배경·핵심 아이디어·코드 워크스루·퀴즈를 정리한 [변경 설명 페이지](https://claude.ai/code/artifact/d45b2c84-b85d-4382-a53e-3d3c3dd72d2e)를 함께 참고해 주세요.

### Notion Import DTO·요청 함수·msw mock 추가

동기화는 오래 걸리는 작업이라 서버가 접수(202)와 실행 ID만 즉시 돌려주고, 클라이언트가 그 ID로 상태를 조회하는 구조입니다. 이에 맞춰 시작(`POST /api/v1/workspaces/{workspaceId}/imports`)과 상태 조회(`GET /api/v1/imports/{importRunId}`)의 요청 함수와 DTO를 추가하였습니다.

```mermaid
sequenceDiagram
    participant C as 동기화 카드
    participant S as 서버

    C->>S: POST /api/v1/workspaces/1/imports
    S-->>C: 202 { id: 1 }
    loop 끝날 때까지 1초 간격 폴링
        C->>S: GET /api/v1/imports/1
        S-->>C: { status: RUNNING, processedPageCount: 3 }
    end
    S-->>C: { status: COMPLETED, processedPageCount: 8 }
    Note over C: 문서 8개가 새로 들어왔어요 표시
    Note over C: 2초 뒤 기본 상태로 복귀
```

이미 실행 중인 Import가 있으면 시작 요청이 409로 오는데, 본문 모양이 202와 같은 `{ id }`이므로 요청 함수가 409도 성공으로 받아 그 실행을 그대로 추적하도록 하였습니다.

```ts
export const startNotionImportApi = async (workspaceId: number) => {
  const response = await httpClient<PostNotionImportResponseRaw>({
    method: "post",
    url: NOTION_IMPORTS_API_PATH(workspaceId),
    // 202(새 실행)와 409(이미 실행 중)는 본문 모양이 같아 둘 다 성공으로 받아요
    validateStatus: (status) =>
      (status >= 200 && status < 300) || status === 409,
  });

  return new PostNotionImportResponseDto(response.data);
};
```

msw mock은 컨벤션대로 `types`·`responses`·`handlers`에 추가하였고, 기본값은 바로 완료된 실행 하나만 두어 RUNNING·FAILED 같은 변형은 테스트에서 `mockServer.use`로 덮도록 하였습니다.

### 시작 뮤테이션과 상태 폴링 쿼리 훅

시작 응답은 접수일 뿐이라 `useStartNotionImportMutation`은 얇게 두고, 성공·실패 판정은 `useNotionImportStatusQuery`의 폴링이 맡습니다. `refetchInterval`을 함수로 주어 진행 중(PENDING·RUNNING)에만 1초 간격으로 다시 조회하고, COMPLETED·FAILED가 오거나 조회가 실패하면 폴링을 멈춥니다. 추적할 실행이 없는 동안은 `skipToken`으로 쿼리를 비활성화하였습니다.

```ts
refetchInterval: (query) => {
  if (query.state.status === "error") return false;

  const status = query.state.data?.status;
  if (status === "COMPLETED" || status === "FAILED") return false;

  return POLL_INTERVAL_MS; // 1초
},
```

### 동기화 카드 연결과 2초 복귀 처리

`useNotionSync`의 임시 `useTimeout` 모킹 로직을 제거하고, 위 두 훅의 결과에서 `isSyncing`·`isSynced`·`isSyncFailed`를 파생하도록 바꾸었습니다. `isSyncing`은 시작 요청 중(`isPending`)과 실행 ID를 받아 결과를 기다리는 폴링 구간을 모두 덮어, 진행 중에는 버튼이 계속 잠깁니다.

```mermaid
stateDiagram-v2
    기본 --> 동기화중: 지금 동기화 클릭
    동기화중 --> 완료: COMPLETED
    동기화중 --> 실패: 시작 실패 또는 FAILED
    완료 --> 기본: 2초 뒤 복귀
    실패 --> 기본: 2초 뒤 복귀
```

실패 문구는 두 갈래로 나뉩니다. 실행이 FAILED로 끝나면 상태 응답의 `failureReason`을 그대로 보여주고, 시작 요청 자체가 실패해 보여줄 사유가 없으면 대체 문구 상수를 보여줍니다.

완료·실패 결과가 생기면 `useEffect`에서 2초 타이머를 걸어 기본 상태로 되돌리고(#325), 클린업에서 `clearTimeout`을 하여 결과가 바뀌거나 카드가 언마운트되면 타이머가 정리되도록 하였습니다. 복귀 시 `importRunId`를 `null`로 돌려 폴링 쿼리도 함께 비활성화됩니다.

### 테스트 정비

위젯 테스트는 가짜 타이머 시나리오에서 msw 시나리오로 재작성하였습니다. `delay("infinite")`로 시작 응답을 붙잡아 로딩 잠금을, 기본·FAILED·500 응답으로 완료·실행 실패·시작 실패의 세 결말을, 가짜 타이머로 2초 복귀와 언마운트 시 타이머 정리를 각각 검증합니다.

E2E는 문서 수 기대값을 상수 대신 mock 상태 응답의 `processedPageCount`로 바꾸고, 2초 뒤 기본 상태로 돌아오는 단언을 추가하였습니다. 로딩 잠금 단언은 mock 응답이 즉시 완료라 시점이 불안정하여 제거하고, 응답을 붙잡을 수 있는 위젯 통합 테스트로 역할을 옮겼습니다.

### 참고 사항

- 이슈 #325에는 복귀 지연이 3초로 적혀 있으나, 논의에 따라 2초(`SYNC_RESULT_RESET_DELAY_MS`)로 확정하였습니다.
- 이슈 #324의 TODO 중 "성공 시 워크스페이스 트리·마지막 동기화 시각 쿼리 무효화"는 무효화할 쿼리가 아직 API째로 없어 TODO 주석으로만 남겨 두었고, 해당 API가 생길 때 후속 PR에서 진행하겠습니다. 마지막 동기화 시각도 같은 이유로 임시 상수를 유지합니다.
- 시작 요청의 409를 성공으로 받는 처리(`validateStatus`)가 적절한 방향인지 의견 부탁드립니다.
