### PR TITLE
[BE] 문서 준비 전 채팅 메시지 저장 방지

### DIFF
--- a/backend/src/main/java/com/knot/backend/chat/application/ChatMessageService.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/ChatMessageService.java
@@ -82,6 +82,7 @@ public class ChatMessageService {
             }
         };
         try {
+            requirePublishedSnapshot(session.getWorkspaceId());
             chatMessagePersistenceService.saveMessage(
                     sessionId,
                     ChatMessageRole.USER,
@@ -140,6 +141,17 @@ public class ChatMessageService {
         } catch (RuntimeException exception) {
             releaseStream.run();
             throw exception;
+        }
+    }
+
+    private void requirePublishedSnapshot(long workspaceId) {
+        try {
+            documentSearchService.requirePublishedSnapshot(workspaceId);
+        } catch (SearchException exception) {
+            throw new ChatException(
+                    mapSearchError(exception),
+                    exception
+            );
         }
     }
 

--- a/backend/src/main/java/com/knot/backend/search/application/PublishedDocumentSearchService.java
+++ b/backend/src/main/java/com/knot/backend/search/application/PublishedDocumentSearchService.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -49,26 +48,22 @@ public class PublishedDocumentSearchService {
                 query
         );
         validateQuery(searchQuery);
-        Optional<Long> publishedImportRunId = searchChunkRepository.findPublishedImportRunId(workspaceId);
-        if (publishedImportRunId.isEmpty()) {
-            throw new SearchException(SearchErrorCode.SEARCH_IMPORT_NOT_READY);
-        }
+        Long publishedImportRunId = requirePublishedImportRunId(workspaceId);
         if (questionClassifier.isBroad(query)) {
             return SearchContext.needsClarification();
         }
 
-        Long importRunId = publishedImportRunId.orElseThrow();
         List<String> terms = queryTerms.extract(searchQuery);
         List<SearchChunk> vectorCandidates = embedAndSearch(
                 workspaceId,
-                importRunId,
+                publishedImportRunId,
                 searchQuery
         );
         List<SearchChunk> keywordCandidates = terms.isEmpty()
                 ? List.of()
                 : searchChunkRepository.findByKeywords(
                         workspaceId,
-                        importRunId,
+                        publishedImportRunId,
                         terms,
                         properties.candidateLimit()
                 );
@@ -83,6 +78,11 @@ public class PublishedDocumentSearchService {
                 selected,
                 properties.maxContextCharacters()
         );
+    }
+
+    public void requirePublishedSnapshot(Long workspaceId) {
+        validateWorkspaceId(workspaceId);
+        requirePublishedImportRunId(workspaceId);
     }
 
     private List<SearchChunk> embedAndSearch(
@@ -206,10 +206,19 @@ public class PublishedDocumentSearchService {
         if (embeddingProperties.dimensions() != 1024) {
             throw new SearchException(SearchErrorCode.SEARCH_CONFIGURATION_INVALID);
         }
+        validateWorkspaceId(workspaceId);
+        validateQuery(query);
+    }
+
+    private Long requirePublishedImportRunId(Long workspaceId) {
+        return searchChunkRepository.findPublishedImportRunId(workspaceId)
+                .orElseThrow(() -> new SearchException(SearchErrorCode.SEARCH_IMPORT_NOT_READY));
+    }
+
+    private void validateWorkspaceId(Long workspaceId) {
         if (workspaceId == null || workspaceId <= 0) {
             throw new SearchException(SearchErrorCode.INVALID_SEARCH_WORKSPACE_ID);
         }
-        validateQuery(query);
     }
 
     private void validateQuery(String query) {

--- a/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/application/ChatMessageServiceTest.java
@@ -1,13 +1,17 @@
 package com.knot.backend.chat.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.knot.backend.chat.domain.ChatErrorCode;
@@ -35,6 +39,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 class ChatMessageServiceTest {
     private final PublishedDocumentSearchService documentSearchService = mock(PublishedDocumentSearchService.class);
@@ -141,12 +146,19 @@ class ChatMessageServiceTest {
                 listener,
                 never()
         ).onError(any(ChatErrorCode.class));
-        verify(persistenceService).saveMessage(
-                anyLong(),
-                org.mockito.ArgumentMatchers.eq(ChatMessageRole.USER),
-                any(),
-                any()
+        InOrder acceptanceOrder = inOrder(
+                documentSearchService,
+                persistenceService
         );
+        acceptanceOrder.verify(documentSearchService)
+                .requirePublishedSnapshot(1L);
+        acceptanceOrder.verify(persistenceService)
+                .saveMessage(
+                        anyLong(),
+                        org.mockito.ArgumentMatchers.eq(ChatMessageRole.USER),
+                        any(),
+                        any()
+                );
         verify(persistenceService).saveAssistantWithReferences(
                 anyLong(),
                 org.mockito.ArgumentMatchers.eq("첫 응답"),
@@ -274,7 +286,7 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("최초 동기화 전에는 LLM을 호출하지 않고 문서 준비 오류를 전달한다")
+    @DisplayName("최초 동기화 전에는 메시지와 SSE를 시작하지 않고 문서 준비 오류를 반환한다")
     void sendMessage_failure_documentsNotReady() {
         // given
         ChatSessionRepository chatSessionRepository = mock(ChatSessionRepository.class);
@@ -290,25 +302,12 @@ class ChatMessageServiceTest {
                 )
         ).thenReturn(true);
         ChatMessagePersistenceService persistenceService = mock(ChatMessagePersistenceService.class);
-        when(
-                persistenceService.saveMessage(
-                        anyLong(),
-                        any(),
-                        any(),
-                        any()
-                )
-        ).thenReturn(mock(ChatMessage.class));
         ChatMessageRepository chatMessageRepository = mock(ChatMessageRepository.class);
-        when(chatMessageRepository.findAllBySessionId(10L)).thenReturn(List.of());
-        when(
-                documentSearchService.search(
-                        1L,
-                        "질문",
-                        "질문"
-                )
-        ).thenThrow(new SearchException(SearchErrorCode.SEARCH_IMPORT_NOT_READY));
+        doThrow(new SearchException(SearchErrorCode.SEARCH_IMPORT_NOT_READY)).when(documentSearchService)
+                .requirePublishedSnapshot(1L);
         LlmClient llmClient = mock(LlmClient.class);
         ChatStreamListener listener = mock(ChatStreamListener.class);
+        ActiveChatStreamRegistry registry = new ActiveChatStreamRegistry();
         ChatMessageService service = new ChatMessageService(
                 new ChatSessionAccessPolicy(
                         chatSessionRepository,
@@ -318,12 +317,12 @@ class ChatMessageServiceTest {
                 chatMessageRepository,
                 llmClient,
                 documentSearchService,
-                new ActiveChatStreamRegistry(),
+                registry,
                 Runnable::run
         );
 
         // when
-        service.sendMessage(
+        org.assertj.core.api.ThrowableAssert.ThrowingCallable action = () -> service.sendMessage(
                 10L,
                 2L,
                 "질문",
@@ -331,20 +330,17 @@ class ChatMessageServiceTest {
         );
 
         // then
-        verify(listener).onError(ChatErrorCode.CHAT_DOCUMENTS_NOT_READY);
-        verify(
-                llmClient,
-                never()
-        ).start(any());
-        verify(
-                persistenceService,
-                never()
-        ).saveAssistantWithReferences(
-                anyLong(),
-                anyString(),
-                any(),
-                any()
+        assertThatThrownBy(action).isInstanceOfSatisfying(
+                ChatException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ChatErrorCode.CHAT_DOCUMENTS_NOT_READY)
         );
+        verifyNoInteractions(
+                persistenceService,
+                chatMessageRepository,
+                llmClient,
+                listener
+        );
+        assertThat(registry.tryAcquire(10L)).isTrue();
     }
 
     @Test

--- a/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageAcceptanceTest.java
@@ -1,0 +1,237 @@
+package com.knot.backend.chat.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.knot.backend.auth.domain.AuthTokenProvider;
+import com.knot.backend.auth.domain.AuthenticatedMember;
+import com.knot.backend.testsupport.TestApplicationProperties;
+import com.knot.backend.testsupport.TestcontainersConfiguration;
+import jakarta.servlet.http.Cookie;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@Tag("acceptance")
+@Import(TestcontainersConfiguration.class)
+@TestApplicationProperties
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = AutowireMode.ALL)
+class ChatMessageAcceptanceTest {
+    private static final String JWT_COOKIE_NAME = "KNOT_ACCESS_TOKEN";
+    private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
+
+    private final MockMvc mockMvc;
+    private final AuthTokenProvider authTokenProvider;
+    private final ObjectMapper objectMapper;
+    private final JdbcClient jdbcClient;
+
+    ChatMessageAcceptanceTest(
+            MockMvc mockMvc,
+            AuthTokenProvider authTokenProvider,
+            ObjectMapper objectMapper,
+            JdbcClient jdbcClient
+    ) {
+        this.mockMvc = mockMvc;
+        this.authTokenProvider = authTokenProvider;
+        this.objectMapper = objectMapper;
+        this.jdbcClient = jdbcClient;
+    }
+
+    @BeforeEach
+    void clearTables() {
+        jdbcClient
+                .sql(
+                        "TRUNCATE TABLE chat_messages, chat_sessions, workspace_members, workspaces, members "
+                                + "RESTART IDENTITY CASCADE"
+                )
+                .update();
+    }
+
+    @Test
+    @DisplayName("공개된 문서가 없으면 채팅 요청을 409로 거절하고 USER 메시지를 저장하지 않는다")
+    void sendMessage_failure_documentsNotReady() throws Exception {
+        // given
+        long memberId = saveMember();
+        long workspaceId = saveWorkspace();
+        saveWorkspaceMember(
+                workspaceId,
+                memberId
+        );
+        long sessionId = saveChatSession(
+                workspaceId,
+                memberId
+        );
+        OffsetDateTime lastMessageAt = singleLastMessageAt(sessionId);
+        Cookie accessTokenCookie = accessTokenCookie(memberId);
+        CsrfCredentials csrfCredentials = csrfCredentials();
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post(
+                        "/api/v1/conversations/{sessionId}/messages",
+                        sessionId
+                ).cookie(
+                        accessTokenCookie,
+                        csrfCredentials.cookie()
+                )
+                        .header(
+                                "X-XSRF-TOKEN",
+                                csrfCredentials.token()
+                        )
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"content":"질문"}
+                                """)
+        );
+
+        // then
+        result.andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CHAT_DOCUMENTS_NOT_READY"))
+                .andExpect(jsonPath("$.message").value("문서 동기화가 완료된 후 검색할 수 있습니다"));
+        assertThat(countChatMessages(sessionId)).isZero();
+        assertThat(singleLastMessageAt(sessionId)).isEqualTo(lastMessageAt);
+    }
+
+    private Cookie accessTokenCookie(long memberId) {
+        String token = authTokenProvider.issue(
+                AuthenticatedMember.of(
+                        memberId,
+                        "octocat",
+                        null
+                )
+        );
+        return new Cookie(
+                JWT_COOKIE_NAME,
+                token
+        );
+    }
+
+    private CsrfCredentials csrfCredentials() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/v1/auth/csrf"))
+                .andExpect(status().isOk())
+                .andReturn();
+        Cookie cookie = result.getResponse()
+                .getCookie(CSRF_COOKIE_NAME);
+        assertThat(cookie).isNotNull();
+        JsonNode responseBody = objectMapper.readTree(
+                result.getResponse()
+                        .getContentAsString()
+        );
+        return new CsrfCredentials(
+                cookie,
+                responseBody.get("token")
+                        .asText()
+        );
+    }
+
+    private long saveMember() {
+        return jdbcClient.sql("""
+                INSERT INTO members (nickname, profile_image_url)
+                VALUES ('octocat', NULL)
+                RETURNING id
+                """)
+                .query(Long.class)
+                .single();
+    }
+
+    private long saveWorkspace() {
+        return jdbcClient.sql("""
+                INSERT INTO workspaces (name, created_at)
+                VALUES ('Knot 팀', TIMESTAMPTZ '2026-09-02 00:00:00Z')
+                RETURNING id
+                """)
+                .query(Long.class)
+                .single();
+    }
+
+    private void saveWorkspaceMember(
+            long workspaceId,
+            long memberId
+    ) {
+        jdbcClient.sql("""
+                INSERT INTO workspace_members (workspace_id, member_id, role, joined_at, last_viewed)
+                VALUES (:workspaceId, :memberId, 'OWNER', TIMESTAMPTZ '2026-09-02 00:00:00Z', FALSE)
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "memberId",
+                        memberId
+                )
+                .update();
+    }
+
+    private long saveChatSession(
+            long workspaceId,
+            long memberId
+    ) {
+        return jdbcClient.sql("""
+                INSERT INTO chat_sessions (workspace_id, member_id, title, created_at, last_message_at)
+                VALUES (
+                    :workspaceId,
+                    :memberId,
+                    '새 대화',
+                    TIMESTAMPTZ '2026-09-02 00:00:00Z',
+                    TIMESTAMPTZ '2026-09-02 00:00:00Z'
+                )
+                RETURNING id
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "memberId",
+                        memberId
+                )
+                .query(Long.class)
+                .single();
+    }
+
+    private long countChatMessages(long sessionId) {
+        return jdbcClient.sql("SELECT COUNT(*) FROM chat_messages WHERE session_id = :sessionId")
+                .param(
+                        "sessionId",
+                        sessionId
+                )
+                .query(Long.class)
+                .single();
+    }
+
+    private OffsetDateTime singleLastMessageAt(long sessionId) {
+        return jdbcClient.sql("SELECT last_message_at FROM chat_sessions WHERE id = :sessionId")
+                .param(
+                        "sessionId",
+                        sessionId
+                )
+                .query(OffsetDateTime.class)
+                .single();
+    }
+
+    private record CsrfCredentials(
+            Cookie cookie,
+            String token
+    ) {
+    }
+}

--- a/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageControllerTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageControllerTest.java
@@ -1,6 +1,7 @@
 package com.knot.backend.chat.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -9,7 +10,10 @@ import static org.mockito.Mockito.when;
 import com.knot.backend.auth.domain.AuthenticatedMember;
 import com.knot.backend.chat.application.ChatMessageService;
 import com.knot.backend.chat.application.ChatStreamHandle;
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
 import com.knot.backend.chat.presentation.dto.request.SendChatMessageRequest;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -45,5 +49,38 @@ class ChatMessageControllerTest {
 
         // then
         assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("문서가 준비되지 않은 요청은 SSE emitter를 반환하기 전에 거절한다")
+    void sendMessage_failure_documentsNotReady() {
+        // given
+        ChatMessageService service = mock(ChatMessageService.class);
+        ChatMessageController controller = new ChatMessageController(service);
+        when(
+                service.sendMessage(
+                        anyLong(),
+                        anyLong(),
+                        any(),
+                        any()
+                )
+        ).thenThrow(new ChatException(ChatErrorCode.CHAT_DOCUMENTS_NOT_READY));
+
+        // when
+        ThrowingCallable action = () -> controller.sendMessage(
+                10L,
+                new SendChatMessageRequest("질문"),
+                AuthenticatedMember.of(
+                        2L,
+                        "흑곰",
+                        null
+                )
+        );
+
+        // then
+        assertThatThrownBy(action).isInstanceOfSatisfying(
+                ChatException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ChatErrorCode.CHAT_DOCUMENTS_NOT_READY)
+        );
     }
 }

--- a/backend/src/test/java/com/knot/backend/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/knot/backend/global/exception/GlobalExceptionHandlerTest.java
@@ -2,6 +2,8 @@ package com.knot.backend.global.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
 import com.knot.backend.global.response.ErrorResponse;
 import com.knot.backend.workspace.domain.WorkspaceErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +13,29 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 class GlobalExceptionHandlerTest {
+
+    @DisplayName("문서가 준비되지 않은 채팅 요청은 409 JSON 오류로 변환한다")
+    @Test
+    void handleProjectException_success_chatDocumentsNotReady() {
+        // given
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        ChatException exception = new ChatException(ChatErrorCode.CHAT_DOCUMENTS_NOT_READY);
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleProjectException(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(
+                response.getBody()
+                        .code()
+        ).isEqualTo("CHAT_DOCUMENTS_NOT_READY");
+        assertThat(
+                response.getBody()
+                        .message()
+        ).isEqualTo("문서 동기화가 완료된 후 검색할 수 있습니다");
+    }
 
     @DisplayName("호출 제한 예외는 429와 Retry-After 오류 응답으로 변환한다")
     @Test

--- a/backend/src/test/java/com/knot/backend/search/application/PublishedDocumentSearchServiceTest.java
+++ b/backend/src/test/java/com/knot/backend/search/application/PublishedDocumentSearchServiceTest.java
@@ -169,6 +169,34 @@ class PublishedDocumentSearchServiceTest {
     }
 
     @Test
+    @DisplayName("공개된 snapshot이 없으면 채팅 수락 전 준비 검사가 실패한다")
+    void requirePublishedSnapshot_failure_noPublishedSnapshot() {
+        // given
+        SearchChunkRepository repository = mock(SearchChunkRepository.class);
+        when(repository.findPublishedImportRunId(7L)).thenReturn(Optional.empty());
+        PublishedDocumentSearchService service = new PublishedDocumentSearchService(
+                repository,
+                mock(DocumentEmbeddingClient.class),
+                new SearchQueryTerms(),
+                new SearchQuestionClassifier(),
+                PROPERTIES,
+                new EmbeddingProperties(
+                        "qwen-embedding",
+                        1024
+                )
+        );
+
+        // when
+        ThrowingCallable action = () -> service.requirePublishedSnapshot(7L);
+
+        // then
+        assertThatThrownBy(action).isInstanceOfSatisfying(
+                SearchException.class,
+                exception -> assertThat(exception.searchErrorCode()).isEqualTo(SearchErrorCode.SEARCH_IMPORT_NOT_READY)
+        );
+    }
+
+    @Test
     @DisplayName("범위가 넓은 질문은 snapshot이 있어도 모델 검색 대신 구체화를 요청한다")
     void search_success_broadQuestionNeedsClarification() {
         // given


### PR DESCRIPTION
## 관련 이슈

- #334

## 작업 내용

- 마지막 성공 publication 존재 여부를 USER 메시지 저장 전에 검사하도록 채팅 요청의 수락 순서를 변경했습니다.
- publication이 없으면 SSE 시작 전 `409 CHAT_DOCUMENTS_NOT_READY`로 거절하고 메시지와 세션 `lastMessageAt`을 변경하지 않습니다.
- Service 호출 순서·무호출 단위 테스트와 JWT·CSRF·PostgreSQL HTTP 인수 테스트를 추가했습니다.

### 참고 사항

- HTTP 200 이후 검색·LLM·스트림 실패의 USER 메시지 보존 계약은 유지합니다.
- `./gradlew spotlessCheck test integrationTest acceptanceTest bootJar`, 변경 범위 컨벤션 감사, Governance 테스트 8건과 `git diff --check`가 통과했습니다.
- 전체 컨벤션 감사는 이번 diff 밖 기존 파일 21건의 위반으로 중단됐으며, 변경 파일 7개에는 위반이 없습니다.
- AI를 구현과 테스트 초안 작성에 사용했고, Issue #334·채팅 UX 계약과 실제 diff를 대조한 뒤 전체 테스트로 별도 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat messages are now prevented from sending until document synchronization is complete.
  - Users receive a clear “documents are not ready” error when no published document snapshot is available.
  - Unavailable document states no longer create partially saved chat messages or start an incomplete response stream.
- **Reliability**
  - Improved handling of document-readiness checks before processing chat requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->