### PR TITLE
[FE] 개발 서버 mock 로그인 쿠키와 GitHub·Notion OAuth 플로우 재현

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,6 +14,23 @@ export default defineConfig({
   use: {
     baseURL: BASE_URL,
     trace: "on-first-retry", // 재시도할 때만 트레이스를 남겨요
+    // dev 서버 mock이 이 쿠키로 로그인 상태를 판정해요(src/shared/api/mock/handlers/dev).
+    // E2E는 로그인 플로우가 아니라 화면 플로우를 확인하므로 로그인된 상태에서 시작해요
+    storageState: {
+      cookies: [
+        {
+          name: "KNOT_MOCK_AUTH",
+          value: "member",
+          domain: "localhost",
+          path: "/",
+          expires: -1,
+          httpOnly: false,
+          secure: false,
+          sameSite: "Lax" as const,
+        },
+      ],
+      origins: [],
+    },
   },
   projects: [
     {

--- a/frontend/src/shared/api/mock/browser.ts
+++ b/frontend/src/shared/api/mock/browser.ts
@@ -1,6 +1,14 @@
 import { setupWorker } from "msw/browser";
 
 import { handlers } from "./handlers";
+import { devAuthHandlers, devNotionOAuthHandlers } from "./handlers/dev";
 
 // 개발 서버 전용. src/index.tsx가 API_MOCKING 플래그 안에서 동적 import해요
-export const mockWorker = setupWorker(...handlers);
+// 먼저 맞는 핸들러가 이기므로, 개발 전용 핸들러(쿠키 로그인 판정 me·nickname,
+// 같은 오리진으로 돌려보내는 Notion OAuth 시작)를 앞에 둬 기본 핸들러만 덮어요.
+// vitest(server.ts)에는 넣지 않아요
+export const mockWorker = setupWorker(
+  ...devAuthHandlers,
+  ...devNotionOAuthHandlers,
+  ...handlers,
+);

--- a/frontend/src/shared/api/mock/handlers/dev/index.ts
+++ b/frontend/src/shared/api/mock/handlers/dev/index.ts
@@ -1,0 +1,78 @@
+import { http, HttpResponse } from "msw";
+
+import { AUTH_ME_API_PATH } from "@api/fetch/api/v1/auth/me";
+import { AUTH_NICKNAME_API_PATH } from "@api/fetch/api/v1/auth/nickname";
+import { meResponse } from "@api/mock/responses/auth";
+import type { NotionOAuthAuthorizationResponse } from "@api/mock/types/notionConnection";
+
+/**
+ * 개발 서버의 mock 로그인 상태 쿠키.
+ *
+ * `webpack.config.js`의 mock OAuth 미들웨어가 심고 여기 핸들러가 읽어요.
+ * 이름이나 값을 바꾸면 그 미들웨어·`playwright.config.ts`의 storageState와 함께 바꿔야 해요.
+ */
+export const MOCK_AUTH_COOKIE_NAME = "KNOT_MOCK_AUTH";
+
+/** 실제 백엔드의 접근 토큰(member)·온보딩 토큰(onboarding) 구분을 쿠키 값으로 흉내내요 */
+export const MOCK_AUTH_STATUS = {
+  MEMBER: "member",
+  ONBOARDING: "onboarding",
+} as const;
+
+/**
+ * 개발 브라우저 전용 인증 핸들러.
+ *
+ * 실제 백엔드처럼 쿠키로 로그인 상태를 판정해 GitHub 로그인 → 온보딩 → 홈 진입
+ * 플로우를 개발 서버에서 재현해요. OAuth 진입 자체는 페이지 네비게이션이라 msw가
+ * 가로채지 못하므로 `webpack.config.js`의 devServer 미들웨어가 302로 대신해요.
+ *
+ * `browser.ts`에서만 기본 핸들러 앞에 둬(먼저 맞는 핸들러가 이겨요) me·nickname을
+ * 덮어요. vitest(server.ts)는 항상 로그인된 기본 핸들러를 그대로 쓰므로 넣지 않아요.
+ */
+export const devAuthHandlers = [
+  http.get(`*${AUTH_ME_API_PATH}`, ({ cookies }) => {
+    if (cookies[MOCK_AUTH_COOKIE_NAME] !== MOCK_AUTH_STATUS.MEMBER) {
+      return new HttpResponse(null, { status: 401 });
+    }
+
+    return HttpResponse.json(meResponse);
+  }),
+
+  http.post(`*${AUTH_NICKNAME_API_PATH}`, ({ cookies }) => {
+    if (cookies[MOCK_AUTH_COOKIE_NAME] === undefined) {
+      return new HttpResponse(null, { status: 401 });
+    }
+
+    // 온보딩 토큰 → 접근 토큰 전환을 재현해요. msw의 Set-Cookie 저장은 새로고침하면
+    // 사라지므로 document.cookie에 직접 써요 (resolver는 페이지 컨텍스트에서 돌아요)
+    document.cookie = `${MOCK_AUTH_COOKIE_NAME}=${MOCK_AUTH_STATUS.MEMBER}; path=/; SameSite=Lax`;
+
+    return new HttpResponse(null, { status: 200 });
+  }),
+];
+
+/**
+ * 개발 브라우저 전용 Notion OAuth 핸들러.
+ *
+ * 기본 핸들러는 실제 Notion 인증 URL을 돌려주는데, client_id가 가짜라 개발 서버에서
+ * 실제로 이동하면 Notion이 거절해 플로우가 거기서 끊겨요. 그래서 실제 흐름(Notion 동의
+ * → `GET /api/v1/notion/oauth/callback` → 303)이 끝났을 때 도착하는 같은 오리진의 결과
+ * 화면 URL을 인증 URL 자리에 바로 돌려줘, 연결 시작 → 결과 처리 → 홈 이동까지 개발
+ * 서버에서 재현해요. 실패 화면은 주소창에서 `result=failed`로 바꿔 확인하세요.
+ *
+ * `devAuthHandlers`처럼 `browser.ts`에서만 기본 핸들러 앞에 둬요. vitest는 노션 연동
+ * 카드 테스트가 실제 Notion URL로의 이동을 확인하므로 기본 핸들러를 그대로 써요.
+ */
+export const devNotionOAuthHandlers = [
+  http.post(
+    "*/api/v1/workspaces/:workspaceId/notion-oauth-authorizations",
+    ({ params }) =>
+      HttpResponse.json(
+        {
+          // 결과 파라미터는 NotionConnectCard constants/notionConnect.ts(connected|failed)와 같은 약속이에요
+          authorizationUrl: `/workspace/${String(params.workspaceId)}/notion-connection?result=connected`,
+        } satisfies NotionOAuthAuthorizationResponse,
+        { status: 201 },
+      ),
+  ),
+];

--- a/frontend/src/shared/api/mock/handlers/dev/test.ts
+++ b/frontend/src/shared/api/mock/handlers/dev/test.ts
@@ -1,0 +1,93 @@
+import { meResponse } from "@api/mock/responses/auth";
+import { mockServer } from "@api/mock/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  devAuthHandlers,
+  devNotionOAuthHandlers,
+  MOCK_AUTH_COOKIE_NAME,
+  MOCK_AUTH_STATUS,
+} from ".";
+
+// 절대 URL이어야 Node fetch가 보낼 수 있어요. 핸들러는 오리진 와일드카드라 아무 오리진이나 맞아요
+const ME_URL = "http://localhost:3000/api/v1/auth/me";
+const NICKNAME_URL = "http://localhost:3000/api/v1/auth/nickname";
+const NOTION_OAUTH_URL =
+  "http://localhost:3000/api/v1/workspaces/7/notion-oauth-authorizations";
+
+// axios(jsdom XHR)는 jar의 쿠키를 요청에 싣지 않아, fetch로 쿠키 헤더를 직접 실어 보내요
+const requestMe = (cookie?: string) =>
+  fetch(ME_URL, { headers: cookie === undefined ? {} : { cookie } });
+
+const requestNickname = (cookie?: string) =>
+  fetch(NICKNAME_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(cookie === undefined ? {} : { cookie }),
+    },
+    body: JSON.stringify({ nickname: "노티드" }),
+  });
+
+const memberCookie = `${MOCK_AUTH_COOKIE_NAME}=${MOCK_AUTH_STATUS.MEMBER}`;
+const onboardingCookie = `${MOCK_AUTH_COOKIE_NAME}=${MOCK_AUTH_STATUS.ONBOARDING}`;
+
+// 개발 브라우저(browser.ts)에서만 기본 핸들러를 덮는 핸들러라 여기서도 use로 등록해 검증해요
+beforeEach(() => mockServer.use(...devAuthHandlers, ...devNotionOAuthHandlers));
+
+// 닉네임 등록 핸들러가 승격하며 쓴 쿠키가 다음 테스트로 새지 않게 지워요
+afterEach(() => {
+  document.cookie = `${MOCK_AUTH_COOKIE_NAME}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+});
+
+describe("개발 브라우저 전용 인증 핸들러", () => {
+  describe("GET /api/v1/auth/me", () => {
+    it("로그인 쿠키가 없으면 401을 돌려준다", async () => {
+      const response = await requestMe();
+
+      expect(response.status).toBe(401);
+    });
+
+    it("member 쿠키가 있으면 meResponse를 돌려준다", async () => {
+      const response = await requestMe(memberCookie);
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(meResponse);
+    });
+
+    it("온보딩 쿠키만 있으면 아직 회원이 아니므로 401을 돌려준다", async () => {
+      const response = await requestMe(onboardingCookie);
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/v1/auth/nickname", () => {
+    it("로그인 쿠키가 없으면 401을 돌려주고 쿠키를 만들지 않는다", async () => {
+      const response = await requestNickname();
+
+      expect(response.status).toBe(401);
+      expect(document.cookie).not.toContain(MOCK_AUTH_COOKIE_NAME);
+    });
+
+    it("온보딩 쿠키가 있으면 성공하고 member 쿠키로 승격한다", async () => {
+      const response = await requestNickname(onboardingCookie);
+
+      expect(response.status).toBe(200);
+      expect(document.cookie).toContain(memberCookie);
+    });
+  });
+});
+
+describe("개발 브라우저 전용 Notion OAuth 핸들러", () => {
+  describe("POST /api/v1/workspaces/:workspaceId/notion-oauth-authorizations", () => {
+    it("실제 Notion 대신 같은 오리진의 연동 결과 화면 URL을 돌려준다", async () => {
+      const response = await fetch(NOTION_OAUTH_URL, { method: "POST" });
+
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({
+        authorizationUrl: "/workspace/7/notion-connection?result=connected",
+      });
+    });
+  });
+});

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -41,6 +41,33 @@ export default (env, argv) => {
       open: true,
       port: 3000,
       historyApiFallback: true, // SPA 라우팅을 위해 추가
+      // mock 모드에서 GitHub 로그인 진입을 대신해요. GithubLoginButton은 페이지를 통째로
+      // 이동시키는데 msw는 네비게이션을 가로채지 못하므로, dev 서버가 실제 백엔드처럼
+      // 로그인 상태 쿠키(src/shared/api/mock/handlers/dev와 같은 약속)를 심고 302로 돌려보내요.
+      // 기본은 기존 회원(→ /), 주소창에 ?scenario=onboarding을 붙이면 신규 가입(→ /onboarding)이에요.
+      setupMiddlewares: (middlewares) => {
+        if (isApiMockingEnabled) {
+          middlewares.unshift({
+            name: "mock-github-oauth",
+            path: "/oauth2/authorization/github",
+            middleware: (req, res) => {
+              const { searchParams } = new URL(req.url, "http://localhost");
+              const isOnboarding =
+                searchParams.get("scenario") === "onboarding";
+
+              res.statusCode = 302;
+              res.setHeader(
+                "Set-Cookie",
+                `KNOT_MOCK_AUTH=${isOnboarding ? "onboarding" : "member"}; Path=/; SameSite=Lax`,
+              );
+              res.setHeader("Location", isOnboarding ? "/onboarding" : "/");
+              res.end();
+            },
+          });
+        }
+
+        return middlewares;
+      },
       client: {
         overlay: { errors: true, warnings: false }, // 빌드 오류만 브라우저에 오버레이 표시 (경고는 숨김)
       },
@@ -179,7 +206,10 @@ ${exports}
         inject: true, // <script> 태그 자동 삽입
       }),
       new webpack.DefinePlugin({
-        "process.env.API_BASE_URL": JSON.stringify(process.env.API_BASE_URL),
+        // mock 모드에서는 오리진 없이(같은 오리진) 요청해야 msw와 mock OAuth 미들웨어가 받아요
+        "process.env.API_BASE_URL": JSON.stringify(
+          isApiMockingEnabled ? "" : process.env.API_BASE_URL,
+        ),
         // 문자열 리터럴로 넣어 src/index.tsx의 분기가 빌드 시점에 접혀요
         "process.env.API_MOCKING": JSON.stringify(String(isApiMockingEnabled)),
       }),


### PR DESCRIPTION
## 관련 이슈

- #281

## 작업 내용

mock 모드의 개발 서버에서 GitHub 로그인 → 온보딩 → 홈, Notion 연결 시작 → 결과 화면 → 홈까지 실제 백엔드 없이 끝까지 재현할 수 있도록, 개발 브라우저 전용 mock 핸들러와 dev 서버 미들웨어를 추가하였습니다. #281의 서버 모킹 인프라 위에 얹는 후속 작업입니다.

> 변경 배경·핵심 아이디어·코드 워크스루·퀴즈를 정리한 [변경 설명 페이지](https://claude.ai/code/artifact/78c3298d-f0e4-445a-bb21-5e74834bddfa)를 함께 참고해 주세요.

### 쿠키로 로그인 상태를 판정하는 개발 브라우저 전용 인증 핸들러

기존 기본 핸들러는 `GET /api/v1/auth/me`가 조건 없이 200을 돌려줘 개발 서버가 항상 "로그인된 회원" 상태였습니다. 그래서 로그인 화면은 `GuestGuard`가 곧바로 홈으로 밀어내고, me가 401이어야 열리는 온보딩은 볼 방법이 없었습니다.

실제 백엔드의 `httpOnly` 토큰 쿠키를 자바스크립트가 읽고 쓸 수 있는 `KNOT_MOCK_AUTH` 쿠키 하나로 흉내 내도록 하였습니다. 값 `member`는 접근 토큰을, `onboarding`은 온보딩 토큰을 대신합니다.

| 쿠키 값 | `GET /api/v1/auth/me` | `POST /api/v1/auth/nickname` |
| --- | --- | --- |
| 없음 | 401 | 401 |
| `onboarding` | 401 | 200, 쿠키를 `member`로 승격 |
| `member` | 200 (`meResponse`) | 200 |

닉네임 등록 요청은 페이지가 보내므로 msw가 받는데, msw 응답의 `Set-Cookie`는 브라우저의 진짜 쿠키로 남지 않습니다. 그래서 핸들러가 `document.cookie`에 직접 `member`를 써서 온보딩 토큰 → 접근 토큰 전환을 재현하였습니다. 브라우저용 msw resolver는 페이지 컨텍스트에서 실행되므로 가능합니다.

```ts
http.post(`*${AUTH_NICKNAME_API_PATH}`, ({ cookies }) => {
  if (cookies[MOCK_AUTH_COOKIE_NAME] === undefined) {
    return new HttpResponse(null, { status: 401 });
  }

  // msw의 Set-Cookie 저장은 새로고침하면 사라지므로 document.cookie에 직접 써요
  document.cookie = `${MOCK_AUTH_COOKIE_NAME}=${MOCK_AUTH_STATUS.MEMBER}; path=/; SameSite=Lax`;

  return new HttpResponse(null, { status: 200 });
}),
```

### mock 모드 GitHub OAuth 미들웨어와 같은 오리진 요청 설정

`GithubLoginButton`은 `window.location.href`로 페이지를 통째로 이동시키는데, msw는 네비게이션 요청을 가로채지 못합니다. 그래서 진짜 HTTP 응답으로 쿠키를 심고 302를 돌려줄 수 있는 webpack dev 서버에 `/oauth2/authorization/github` 미들웨어를 두었습니다. 기본은 기존 회원(`member` → `/`)이고, 주소창에 `?scenario=onboarding`을 붙이면 신규 가입(`onboarding` → `/onboarding`)입니다.

```mermaid
sequenceDiagram
    participant B as 브라우저
    participant D as dev 서버 미들웨어
    participant M as msw 워커

    B->>D: GET /oauth2/authorization/github "페이지 이동"
    D-->>B: 302 Location: / + Set-Cookie: KNOT_MOCK_AUTH=member
    B->>M: GET /api/v1/auth/me "Cookie: KNOT_MOCK_AUTH=member"
    M-->>B: 200 meResponse
    B->>B: EntryRedirect가 워크스페이스 홈으로 이동
```

이 흐름이 성립하려면 API 요청과 로그인 이동이 모두 dev 서버와 같은 오리진으로 가야 합니다. 그래야 미들웨어가 요청을 받고, 거기서 심은 쿠키가 이후 요청에 실리며, 그 요청을 msw가 가로챌 수 있습니다. 그래서 mock 모드에서는 `DefinePlugin`의 `API_BASE_URL`을 빈 문자열로 접었습니다. mock이 꺼진 빌드에서는 기존 값을 그대로 쓰므로 프로덕션에는 영향이 없습니다.

### Notion OAuth 시작 핸들러가 같은 오리진의 결과 화면 URL을 반환

기본 핸들러는 실제 Notion 인증 URL을 돌려주는데 `client_id`가 가짜라 개발 서버에서 이동하면 Notion이 거절해 플로우가 끊겼습니다. 실제 흐름(Notion 동의 → `GET /api/v1/notion/oauth/callback` → 303)이 끝났을 때 도착하는 `/workspace/:workspaceId/notion-connection?result=connected`를 인증 URL 자리에 바로 돌려주도록 하였습니다. `NotionConnectCard`는 받은 URL로 `location.assign`할 뿐이라 코드 변경 없이 연결 시작 → 결과 처리 → 홈 이동까지 재현됩니다. 실패 화면은 주소창에서 `result=failed`로 바꿔 확인할 수 있습니다.

### 개발 브라우저 워커에만 기본 핸들러 앞에 등록

msw는 먼저 매칭되는 핸들러가 이기므로, `browser.ts`에서 dev 핸들러 두 묶음을 기본 핸들러 앞에 펼쳐 me·nickname·Notion OAuth 시작 세 경로만 덮었습니다. vitest용 `server.ts`에는 넣지 않았습니다. 단위 테스트는 "항상 로그인된 회원"과 "실제 Notion URL로 이동" 가정 위에 이미 쓰여 있고, 쿠키 판정은 브라우저에서만 의미가 있기 때문입니다. dev 핸들러 자체는 `handlers/dev/test.ts`에서 `mockServer.use`로 잠시 얹어 6건으로 검증하였습니다.

### E2E는 mock 로그인 쿠키로 로그인된 상태에서 시작

E2E(`workspaceHomePage.test.ts`)는 로그인 플로우가 아니라 홈 화면 플로우를 확인하므로, `playwright.config.ts`의 `storageState`로 `KNOT_MOCK_AUTH=member` 쿠키를 미리 주입하였습니다. 이 설정이 없으면 dev 핸들러의 me가 401을 돌려줘 테스트가 로그인 화면에 멈춥니다.

### 참고 사항

- 쿠키 이름·값 문자열이 `handlers/dev/index.ts`, `webpack.config.js`, `playwright.config.ts` 세 곳에 중복됩니다. 설정 파일이 TS 모듈을 import하기 어려워 상수를 공유하지 못했고, 대신 JSDoc으로 함께 바꿔야 한다고 남겨 두었습니다. 더 나은 공유 방법이 있으면 의견 부탁드립니다.
- 닉네임 등록 핸들러가 `document.cookie`에 직접 쓰는 부분은 msw 응답의 `Set-Cookie`가 진짜 쿠키가 되지 않는 한계 때문입니다. 핸들러가 브라우저 상태를 건드리는 방식이 괜찮을지 봐주시면 감사하겠습니다.
- `storageState`는 모든 E2E에 공통으로 적용되므로, 이후 로그인 화면 자체를 E2E로 다루려면 해당 테스트에서 `storageState`를 비워야 합니다.
- 확인 방법: `pnpm dev`에서 로그인 버튼으로 기존 회원 흐름을, `http://localhost:3000/oauth2/authorization/github?scenario=onboarding`으로 신규 가입 흐름을, 노션 연동 화면에서 연결 시작으로 결과 화면 → 홈 이동을 볼 수 있습니다. 쿠키를 지우면 로그인 화면으로 돌아옵니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HWPxsMvCfrrBEKmdTYsiW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added development-mode authentication simulation, including member and onboarding states.
  * Added mocked GitHub and Notion OAuth flows for local testing.
  * Added automatic redirects to the appropriate onboarding or home page after mocked GitHub sign-in.

* **Tests**
  * Added end-to-end coverage for authentication states, nickname onboarding, and mocked Notion authorization.
  * Playwright tests now start in a logged-in state by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->