### PR TITLE
[FE] 홈화면 노션 동기화 기본 문구를 연결 여부로 수정

### DIFF
--- a/frontend/src/__test__/workspaceHomePage.test.ts
+++ b/frontend/src/__test__/workspaceHomePage.test.ts
@@ -19,8 +19,8 @@ import { expect, test, type Page } from "@playwright/test";
  *
  * 홈 진입, 사이드바 열고 닫기, 폴더 트리 펼침·접힘, 초대 링크·코드 복사, Notion 동기화,
  * 하단 Dock으로 탐색 이동까지 홈 화면 위에서 사용자가 밟는 플로우를 페이지 단위로 확인해요.
- * 회원·워크스페이스·초대·동기화는 dev 서버의 msw mock 응답(`API_MOCKING`)에서 오므로 기대값도 같은
- * 응답을 DTO로 변환해 가져와요. 사이드바 트리와 마지막 동기화 시각은 API가 아직 없어 위젯의 임시 상수예요.
+ * 회원·워크스페이스·초대·노션 연결 상태·동기화는 dev 서버의 msw mock 응답(`API_MOCKING`)에서 오므로
+ * 기대값도 같은 응답을 DTO로 변환해 가져와요. 사이드바 트리는 API가 아직 없어 위젯의 임시 상수예요.
  */
 
 const expectedMe = new GetMeResponseDto(meResponse);
@@ -39,8 +39,8 @@ const GREETING = `반가워요, ${expectedMe.nickname} 님`;
 const INVITE_CODE = expectedInvitation.code;
 const DISPLAY_INVITE_LINK = `/invite/${expectedInvitation.linkToken}`;
 
-// TODO(마지막 동기화 시각 API 미정): 시각 API 연결 후 응답으로 교체
-const LAST_SYNCED_AT_LABEL = "어제 오후 3:12에 동기화";
+// 연결 상태별 문구는 NotionSyncCard 위젯의 상수예요. mock 기본 응답이 CONNECTED라 연결됨 문구를 기대해요
+const NOTION_CONNECTED_LABEL = "노션이 연결되어 있어요";
 const SYNCED_DOCUMENT_COUNT = new GetNotionImportStatusResponseDto(
   notionImportStatusResponse,
 ).processedPageCount;
@@ -91,7 +91,7 @@ test.describe("홈 진입", () => {
     await expect(page.getByRole("heading", { name: GREETING })).toBeVisible();
 
     const notionCard = getCard({ page, title: "Notion 동기화" });
-    await expect(notionCard.getByText(LAST_SYNCED_AT_LABEL)).toBeVisible();
+    await expect(notionCard.getByText(NOTION_CONNECTED_LABEL)).toBeVisible();
     await expect(
       notionCard.getByRole("button", { name: "지금 동기화" }),
     ).toBeEnabled();
@@ -296,12 +296,12 @@ test.describe("Notion 동기화 카드", () => {
       notionCard.getByRole("button", { name: "완료" }),
     ).toBeDisabled();
     await expect(syncButton).toBeHidden();
-    await expect(notionCard.getByText(LAST_SYNCED_AT_LABEL)).toBeHidden();
+    await expect(notionCard.getByText(NOTION_CONNECTED_LABEL)).toBeHidden();
 
-    // 2초 뒤 원래 `지금 동기화`와 마지막 동기화 시각으로 돌아와요
+    // 2초 뒤 원래 `지금 동기화`와 연결 상태 안내로 돌아와요
     await expect(syncButton).toBeVisible();
     await expect(syncButton).toBeEnabled();
-    await expect(notionCard.getByText(LAST_SYNCED_AT_LABEL)).toBeVisible();
+    await expect(notionCard.getByText(NOTION_CONNECTED_LABEL)).toBeVisible();
   });
 });
 

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/constants/notionSync.ts
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/constants/notionSync.ts
@@ -1,7 +1,19 @@
-// TODO(마지막 동기화 시각 API 미정): 시각을 주는 API 연결 후 응답으로 교체
+/**
+ * Notion 연결 상태별 안내 문구. 연결 상태 조회 응답의 `status`를 그대로 키로 써요.
+ *
+ * - `NOT_CONNECTED`: 연결한 적이 없거나 끊긴 상태
+ * - `CONNECTED`: 연결됨
+ * - `REAUTH_REQUIRED`: 연결을 승인한 멤버가 더 이상 OWNER가 아니라 OWNER가 다시 연결해야 하는 상태
+ */
+export const NOTION_CONNECTION_STATUS_LABEL = {
+  NOT_CONNECTED: "노션이 연결되어 있지 않아요",
+  CONNECTED: "노션이 연결되어 있어요",
+  REAUTH_REQUIRED: "노션을 다시 연결해야 해요",
+} as const;
 
-/** 마지막 동기화 시각 안내. Figma 예시 문구를 그대로 둔 임시 값이에요. */
-export const LAST_SYNCED_AT_LABEL = "어제 오후 3:12에 동기화";
+/** 연결 상태 조회 자체가 실패했을 때 보여줄 안내 문구. */
+export const NOTION_CONNECTION_STATUS_UNKNOWN_MESSAGE =
+  "노션 연결 상태를 확인하지 못했어요";
 
 /** 완료·실패 안내를 보여준 뒤 기본 상태로 돌아가기까지의 시간(ms). */
 export const SYNC_RESULT_RESET_DELAY_MS = 2000;

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/index.tsx
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/index.tsx
@@ -5,22 +5,27 @@ import CheckIcon from "@/assets/icons/check.svg";
 import NotionIcon from "@/assets/icons/notion.svg";
 import SyncIcon from "@/assets/icons/sync.svg";
 
-import { LAST_SYNCED_AT_LABEL } from "./constants/notionSync";
+import {
+  NOTION_CONNECTION_STATUS_LABEL,
+  NOTION_CONNECTION_STATUS_UNKNOWN_MESSAGE,
+} from "./constants/notionSync";
 import { useNotionSync } from "./model/useNotionSync";
 
 /**
  * 홈의 Notion 동기화 카드.
  *
- * 마지막 동기화 시각을 보여주고, `지금 동기화`를 누르면 동기화 API로 Import를 시작해
- * 끝날 때까지 스피너를 돌려요. 완료되면 새로 들어온 문서 수 안내와 비활성 `완료` 버튼으로,
- * 실패하면 실패 안내 문구로 바뀌고, 두 경우 모두 2초 뒤 기본 상태로 돌아와요.
- * 마지막 동기화 시각은 아직 API가 없어 `constants/notionSync`의 임시 값이에요.
+ * Notion 연결 상태(연결 안 됨·연결됨·재인증 필요)를 보여주고, `지금 동기화`를 누르면 동기화 API로
+ * Import를 시작해 끝날 때까지 스피너를 돌려요. 완료되면 새로 들어온 문서 수 안내와 비활성 `완료` 버튼으로,
+ * 실패하면 실패 안내 문구로 바뀌고, 두 경우 모두 2초 뒤 연결 상태 안내로 돌아와요.
+ * 연결 상태를 아직 못 받았으면 안내를 비워 두고, 조회가 실패하면 확인 실패 문구를 보여줘요.
  *
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10086 Card/NotionImport status=기본}
  * @see {@link https://www.figma.com/design/jyDFCKX5AIztZessq4H7nQ/knot?node-id=600-10101 홈 화면/노션 연동 완료}
  */
 export default function NotionSyncCard() {
   const {
+    connectionStatus,
+    isConnectionStatusError,
     isSyncing,
     isSynced,
     isSyncFailed,
@@ -32,7 +37,10 @@ export default function NotionSyncCard() {
   const getDescription = () => {
     if (isSynced) return `문서 ${syncedDocumentCount}개가 새로 들어왔어요`;
     if (isSyncFailed) return failureMessage;
-    return LAST_SYNCED_AT_LABEL;
+    if (isConnectionStatusError)
+      return NOTION_CONNECTION_STATUS_UNKNOWN_MESSAGE;
+    if (connectionStatus === undefined) return null;
+    return NOTION_CONNECTION_STATUS_LABEL[connectionStatus];
   };
 
   return (

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/model/useNotionSync.ts
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/model/useNotionSync.ts
@@ -1,4 +1,5 @@
 import useStartNotionImportMutation from "@api/mutations/useStartNotionImportMutation";
+import useNotionConnectionQuery from "@api/queries/useNotionConnectionQuery";
 import useNotionImportStatusQuery from "@api/queries/useNotionImportStatusQuery";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
@@ -9,7 +10,10 @@ import {
 } from "../constants/notionSync";
 
 /**
- * Notion 동기화 카드의 진행 상태.
+ * Notion 동기화 카드의 연결 상태와 진행 상태.
+ *
+ * 현재 `:workspaceId`의 Notion 연결 상태(연결 안 됨·연결됨·재인증 필요)를 조회해 `connectionStatus`로
+ * 넘기고, 조회가 실패하면 `isConnectionStatusError`로 알려요. 문구 매핑은 카드가 맡아요.
  *
  * `startSync`가 현재 `:workspaceId`의 동기화(Import)를 시작하고, 응답의 실행 ID로
  * 상태를 폴링해요. 완료(COMPLETED)·실패(FAILED 또는 시작 요청 실패) 결과를 보여준 뒤
@@ -20,6 +24,8 @@ export const useNotionSync = () => {
   const [importRunId, setImportRunId] = useState<number | null>(null);
   const [isStartFailed, setIsStartFailed] = useState(false);
 
+  const { data: connection, isError: isConnectionStatusError } =
+    useNotionConnectionQuery({ workspaceId: Number(workspaceId) });
   const { mutate: startImport, isPending: isStarting } =
     useStartNotionImportMutation();
   const { data: importStatus, isError: isStatusError } =
@@ -60,6 +66,8 @@ export const useNotionSync = () => {
   };
 
   return {
+    connectionStatus: connection?.status,
+    isConnectionStatusError,
     isSyncing,
     isSynced,
     isSyncFailed,

--- a/frontend/src/modules/widgets/notion/NotionSyncCard/test.tsx
+++ b/frontend/src/modules/widgets/notion/NotionSyncCard/test.tsx
@@ -1,6 +1,8 @@
 import { GetNotionImportStatusResponseDto } from "@api/dto/notionImport";
 import { NOTION_IMPORT_STATUS_API_PATH } from "@api/fetch/api/v1/imports/[importRunId]";
 import { NOTION_IMPORTS_API_PATH } from "@api/fetch/api/v1/workspaces/[workspaceId]/imports";
+import { NOTION_CONNECTION_API_PATH } from "@api/fetch/api/v1/workspaces/[workspaceId]/notionConnection";
+import { notionConnectionResponse } from "@api/mock/responses/notionConnection";
 import {
   notionImportStartResponse,
   notionImportStatusResponse,
@@ -32,7 +34,11 @@ const HOME_PATH = getRouterPath({
   routeKey: "WORKSPACE_HOME",
   params: { workspaceId: String(WORKSPACE_ID) },
 });
-const LAST_SYNCED_TEXT = "어제 오후 3:12에 동기화";
+// 연결 상태별 안내 문구. mock 기본 응답이 CONNECTED라 기본 화면은 연결됨 문구를 기대해요
+const CONNECTED_TEXT = "노션이 연결되어 있어요";
+const NOT_CONNECTED_TEXT = "노션이 연결되어 있지 않아요";
+const REAUTH_REQUIRED_TEXT = "노션을 다시 연결해야 해요";
+const CONNECTION_UNKNOWN_TEXT = "노션 연결 상태를 확인하지 못했어요";
 const SYNCED_TEXT = `문서 ${expectedStatus.processedPageCount}개가 새로 들어왔어요`;
 const START_FAILED_TEXT = "동기화에 실패했어요. 잠시 후 다시 시도해 주세요";
 const RESULT_RESET_DELAY_MS = 2000;
@@ -100,6 +106,24 @@ const failStartResponse = () => {
   );
 };
 
+const respondConnectionStatus = (
+  status: "NOT_CONNECTED" | "REAUTH_REQUIRED",
+) => {
+  mockServer.use(
+    http.get(`*${NOTION_CONNECTION_API_PATH(WORKSPACE_ID)}`, () =>
+      HttpResponse.json({ ...notionConnectionResponse, status }),
+    ),
+  );
+};
+
+const failConnectionStatus = () => {
+  mockServer.use(
+    http.get(`*${NOTION_CONNECTION_API_PATH(WORKSPACE_ID)}`, () =>
+      HttpResponse.json(null, { status: 500 }),
+    ),
+  );
+};
+
 const failImportStatus = () => {
   mockServer.use(
     http.get(
@@ -115,12 +139,35 @@ describe("NotionSyncCard", () => {
     vi.restoreAllMocks();
   });
 
-  it("처음에는 마지막 동기화 시각과 지금 동기화 버튼을 보여준다", () => {
+  it("처음에는 노션 연결 상태와 지금 동기화 버튼을 보여준다", async () => {
     const { syncButton } = renderCard();
 
-    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(await screen.findByText(CONNECTED_TEXT)).toBeInTheDocument();
     expect(syncButton).toBeEnabled();
     expect(syncButton).toHaveAttribute("aria-busy", "false");
+  });
+
+  it("노션이 연결되어 있지 않으면 연결 안 됨 안내를 보여준다", async () => {
+    respondConnectionStatus("NOT_CONNECTED");
+    renderCard();
+
+    expect(await screen.findByText(NOT_CONNECTED_TEXT)).toBeInTheDocument();
+  });
+
+  it("노션 재연결이 필요하면 다시 연결 안내를 보여준다", async () => {
+    respondConnectionStatus("REAUTH_REQUIRED");
+    renderCard();
+
+    expect(await screen.findByText(REAUTH_REQUIRED_TEXT)).toBeInTheDocument();
+  });
+
+  it("연결 상태 조회가 실패하면 확인하지 못했다는 안내를 보여준다", async () => {
+    failConnectionStatus();
+    renderCard();
+
+    expect(
+      await screen.findByText(CONNECTION_UNKNOWN_TEXT),
+    ).toBeInTheDocument();
   });
 
   it("지금 동기화를 누르면 서버 응답이 올 때까지 버튼이 로딩 상태로 잠긴다", async () => {
@@ -131,7 +178,7 @@ describe("NotionSyncCard", () => {
 
     await waitFor(() => expect(syncButton).toBeDisabled());
     expect(syncButton).toHaveAttribute("aria-busy", "true");
-    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(await screen.findByText(CONNECTED_TEXT)).toBeInTheDocument();
   });
 
   it("동기화가 완료되면 새로 들어온 문서 안내와 비활성 완료 버튼으로 바뀐다", async () => {
@@ -141,7 +188,7 @@ describe("NotionSyncCard", () => {
 
     // 문서 수는 mock 상태 응답에서만 올 수 있어, 보이면 시작·상태 요청이 실제로 나간 거예요
     expect(await screen.findByText(SYNCED_TEXT)).toBeInTheDocument();
-    expect(screen.queryByText(LAST_SYNCED_TEXT)).not.toBeInTheDocument();
+    expect(screen.queryByText(CONNECTED_TEXT)).not.toBeInTheDocument();
 
     const doneButton = screen.getByRole("button", { name: "완료" });
     expect(doneButton).toBeDisabled();
@@ -165,7 +212,7 @@ describe("NotionSyncCard", () => {
 
     await advanceTimers(1);
 
-    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(CONNECTED_TEXT)).toBeInTheDocument();
     expect(screen.queryByText(SYNCED_TEXT)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "지금 동기화" })).toBeEnabled();
   });
@@ -183,7 +230,7 @@ describe("NotionSyncCard", () => {
 
     await advanceTimers(RESULT_RESET_DELAY_MS);
 
-    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(CONNECTED_TEXT)).toBeInTheDocument();
     expect(screen.queryByText(FAILED_REASON_TEXT)).not.toBeInTheDocument();
   });
 
@@ -199,7 +246,7 @@ describe("NotionSyncCard", () => {
 
     await advanceTimers(RESULT_RESET_DELAY_MS);
 
-    expect(screen.getByText(LAST_SYNCED_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(CONNECTED_TEXT)).toBeInTheDocument();
     expect(screen.queryByText(START_FAILED_TEXT)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/shared/api/dto/notionConnection.ts
+++ b/frontend/src/shared/api/dto/notionConnection.ts
@@ -2,6 +2,7 @@
  * Notion 연결 DTO
  *
  * - POST /api/v1/workspaces/{workspaceId}/notion-oauth-authorizations
+ * - GET  /api/v1/workspaces/{workspaceId}/notion-connection
  */
 
 // POST /api/v1/workspaces/{workspaceId}/notion-oauth-authorizations
@@ -21,5 +22,29 @@ export class PostNotionOAuthAuthorizationResponseDto {
 
   constructor(raw: PostNotionOAuthAuthorizationResponseRaw) {
     this.authorizationUrl = raw.authorizationUrl;
+  }
+}
+
+// GET /api/v1/workspaces/{workspaceId}/notion-connection
+
+/** Notion 연결 상태 조회의 서버 응답 모양 */
+export interface GetNotionConnectionResponseRaw {
+  status: "NOT_CONNECTED" | "CONNECTED" | "REAUTH_REQUIRED";
+}
+
+/**
+ * 워크스페이스의 Notion 연결 상태 조회 응답(200). 워크스페이스 멤버면 누구나 조회할 수 있고,
+ * 연결된 적이 없어도 404가 아니라 NOT_CONNECTED로 와요
+ */
+export class GetNotionConnectionResponseDto {
+  /**
+   * Notion 연결 상태.
+   * NOT_CONNECTED는 연결 안 됨, CONNECTED는 연결됨,
+   * REAUTH_REQUIRED는 연결은 남아 있지만 연결을 승인한 멤버가 더 이상 OWNER가 아니라 OWNER가 다시 연결해야 하는 상태예요
+   */
+  status: "NOT_CONNECTED" | "CONNECTED" | "REAUTH_REQUIRED";
+
+  constructor(raw: GetNotionConnectionResponseRaw) {
+    this.status = raw.status;
   }
 }

--- a/frontend/src/shared/api/dto/test.ts
+++ b/frontend/src/shared/api/dto/test.ts
@@ -7,7 +7,10 @@ import {
   PostChatSessionRequestDto,
   PostChatSessionResponseDto,
 } from "./chatSession";
-import { PostNotionOAuthAuthorizationResponseDto } from "./notionConnection";
+import {
+  GetNotionConnectionResponseDto,
+  PostNotionOAuthAuthorizationResponseDto,
+} from "./notionConnection";
 import {
   GetWorkspacesResponseDto,
   PostWorkspaceRequestDto,
@@ -129,6 +132,15 @@ describe("DTO 생성자 변환", () => {
       };
 
       expect(new PostNotionOAuthAuthorizationResponseDto(raw)).toEqual(raw);
+    });
+
+    it("연결 상태 응답의 status를 그대로 옮긴다", () => {
+      expect(
+        new GetNotionConnectionResponseDto({ status: "CONNECTED" }),
+      ).toEqual({ status: "CONNECTED" });
+      expect(
+        new GetNotionConnectionResponseDto({ status: "REAUTH_REQUIRED" }),
+      ).toEqual({ status: "REAUTH_REQUIRED" });
     });
   });
 });

--- a/frontend/src/shared/api/fetch/api/v1/workspaces/[workspaceId]/notionConnection/index.ts
+++ b/frontend/src/shared/api/fetch/api/v1/workspaces/[workspaceId]/notionConnection/index.ts
@@ -1,0 +1,24 @@
+import {
+  GetNotionConnectionResponseDto,
+  type GetNotionConnectionResponseRaw,
+} from "@api/dto/notionConnection";
+import { httpClient } from "@api/httpClient";
+
+export const NOTION_CONNECTION_API_PATH = (workspaceId: number) =>
+  `/api/v1/workspaces/${workspaceId}/notion-connection`;
+
+/**
+ * @description 워크스페이스의 Notion 연결 상태를 조회합니다. 연결 안 됨·연결됨·재인증 필요 중 하나를 받아요
+ * @param workspaceId - 워크스페이스 ID
+ * @returns Notion 연결 상태
+ * @example
+ * const { status } = await getNotionConnectionApi(1);
+ */
+export const getNotionConnectionApi = async (workspaceId: number) => {
+  const response = await httpClient<GetNotionConnectionResponseRaw>({
+    method: "get",
+    url: NOTION_CONNECTION_API_PATH(workspaceId),
+  });
+
+  return new GetNotionConnectionResponseDto(response.data);
+};

--- a/frontend/src/shared/api/mock/handlers/api/v1/workspaces/[workspaceId]/notionConnection/index.ts
+++ b/frontend/src/shared/api/mock/handlers/api/v1/workspaces/[workspaceId]/notionConnection/index.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from "msw";
+
+import { notionConnectionResponse } from "@api/mock/responses/notionConnection";
+
+// 경로 파라미터가 있어 fetch 상수 대신 패턴을 직접 적어요. NOT_CONNECTED·REAUTH_REQUIRED·에러는 테스트에서 덮어요
+export const workspaceNotionConnectionHandlers = [
+  http.get("*/api/v1/workspaces/:workspaceId/notion-connection", () =>
+    HttpResponse.json(notionConnectionResponse),
+  ),
+];

--- a/frontend/src/shared/api/mock/handlers/index.ts
+++ b/frontend/src/shared/api/mock/handlers/index.ts
@@ -14,6 +14,7 @@ import { workspaceNotionImportsHandlers } from "./api/v1/workspaces/[workspaceId
 import { workspaceInvitationHandlers } from "./api/v1/workspaces/[workspaceId]/invitation";
 import { workspaceInvitationsHandlers } from "./api/v1/workspaces/[workspaceId]/invitations";
 import { workspaceInvitationReissueHandlers } from "./api/v1/workspaces/[workspaceId]/invitations/reissue";
+import { workspaceNotionConnectionHandlers } from "./api/v1/workspaces/[workspaceId]/notionConnection";
 import { workspaceNotionOAuthAuthorizationsHandlers } from "./api/v1/workspaces/[workspaceId]/notionOauthAuthorizations";
 
 // 리다이렉트 엔드포인트(OAuth 시작·로그아웃)는 XHR 응답이 아니라 두지 않아요
@@ -31,6 +32,7 @@ export const handlers = [
   ...workspaceNotionImportsHandlers,
   ...notionImportStatusHandlers,
   ...workspaceNotionOAuthAuthorizationsHandlers,
+  ...workspaceNotionConnectionHandlers,
   ...invitationAcceptHandlers,
   ...invitationPreviewHandlers,
   ...chatMessagesHandlers,

--- a/frontend/src/shared/api/mock/handlers/test.ts
+++ b/frontend/src/shared/api/mock/handlers/test.ts
@@ -1,6 +1,9 @@
 import { GetCsrfTokenResponseDto, GetMeResponseDto } from "@api/dto/auth";
 import { GetChatMessagesResponseDto } from "@api/dto/chatMessage";
-import { PostNotionOAuthAuthorizationResponseDto } from "@api/dto/notionConnection";
+import {
+  GetNotionConnectionResponseDto,
+  PostNotionOAuthAuthorizationResponseDto,
+} from "@api/dto/notionConnection";
 import {
   GetChatSessionsResponseDto,
   PostChatSessionResponseDto,
@@ -34,11 +37,15 @@ import {
   getChatSessionsApi,
 } from "@api/fetch/api/v1/workspaces/[workspaceId]/conversations";
 import { getWorkspaceInvitationApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/invitation";
+import { getNotionConnectionApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/notionConnection";
 import { startNotionOAuthApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/notionOauthAuthorizations";
 import { issueWorkspaceInvitationApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/invitations";
 import { reissueWorkspaceInvitationApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/invitations/reissue";
 import { csrfTokenResponse, meResponse } from "@api/mock/responses/auth";
-import { notionOAuthAuthorizationResponse } from "@api/mock/responses/notionConnection";
+import {
+  notionConnectionResponse,
+  notionOAuthAuthorizationResponse,
+} from "@api/mock/responses/notionConnection";
 import { chatMessagesResponse } from "@api/mock/responses/chatMessage";
 import {
   chatSessionResponse,
@@ -154,6 +161,12 @@ describe("mock 기본 핸들러와 fetch 요청 함수의 대응", () => {
         new PostNotionOAuthAuthorizationResponseDto(
           notionOAuthAuthorizationResponse,
         ),
+      );
+    });
+
+    it("GET /api/v1/workspaces/:workspaceId/notion-connection은 notionConnectionResponse를 돌려준다", async () => {
+      await expect(getNotionConnectionApi(WORKSPACE_ID)).resolves.toEqual(
+        new GetNotionConnectionResponseDto(notionConnectionResponse),
       );
     });
   });

--- a/frontend/src/shared/api/mock/responses/notionConnection.ts
+++ b/frontend/src/shared/api/mock/responses/notionConnection.ts
@@ -1,4 +1,7 @@
-import type { NotionOAuthAuthorizationResponse } from "@api/mock/types/notionConnection";
+import type {
+  NotionConnectionResponse,
+  NotionOAuthAuthorizationResponse,
+} from "@api/mock/types/notionConnection";
 
 // 노션 연동 카드 테스트가 이 URL로 페이지 이동이 일어나는지 확인해요.
 // 개발 서버(API_MOCKING)에서 실제로 이동하면 Notion이 가짜 client_id를 거절하니 눈으로 확인만 하세요
@@ -6,3 +9,8 @@ export const notionOAuthAuthorizationResponse = {
   authorizationUrl:
     "https://api.notion.com/v1/oauth/authorize?client_id=mock-client-id&response_type=code&owner=user&state=mock-state",
 } satisfies NotionOAuthAuthorizationResponse;
+
+// 기본값은 연결된 상태 하나만 둬요. NOT_CONNECTED·REAUTH_REQUIRED는 테스트에서 mockServer.use로 덮어요
+export const notionConnectionResponse = {
+  status: "CONNECTED",
+} satisfies NotionConnectionResponse;

--- a/frontend/src/shared/api/mock/types/notionConnection.ts
+++ b/frontend/src/shared/api/mock/types/notionConnection.ts
@@ -2,3 +2,9 @@ export interface NotionOAuthAuthorizationResponse {
   /** 사용자를 보낼 Notion 인증 페이지 절대 URL */
   authorizationUrl: string;
 }
+
+/** Notion 연결 상태 조회 응답 */
+export interface NotionConnectionResponse {
+  /** 연결 상태. 연결된 적이 없어도 404가 아니라 NOT_CONNECTED로 와요 */
+  status: "NOT_CONNECTED" | "CONNECTED" | "REAUTH_REQUIRED";
+}

--- a/frontend/src/shared/api/queries/useNotionConnectionQuery/index.ts
+++ b/frontend/src/shared/api/queries/useNotionConnectionQuery/index.ts
@@ -1,0 +1,27 @@
+import { getNotionConnectionApi } from "@api/fetch/api/v1/workspaces/[workspaceId]/notionConnection";
+import { notionConnectionKeys } from "@api/queryKey/notionConnection";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseNotionConnectionQueryParams {
+  workspaceId: number;
+}
+
+/**
+ * 워크스페이스의 Notion 연결 상태를 조회하는 쿼리 훅.
+ *
+ * 홈의 Notion 동기화 카드가 연결 안 됨·연결됨·재인증 필요를 보여주는 데 써요.
+ * 워크스페이스 멤버면 누구나 조회할 수 있고, 연결된 적이 없어도 404가 아니라 NOT_CONNECTED가 와요.
+ *
+ * 라우트 파라미터를 `Number`로 바꾼 값이 정수가 아니면(`/workspace/abc` 같은 잘못된 주소) 요청하지 않아요.
+ */
+const useNotionConnectionQuery = ({
+  workspaceId,
+}: UseNotionConnectionQueryParams) => {
+  return useQuery({
+    queryKey: notionConnectionKeys.detail(workspaceId),
+    queryFn: () => getNotionConnectionApi(workspaceId),
+    enabled: Number.isInteger(workspaceId),
+  });
+};
+
+export default useNotionConnectionQuery;

--- a/frontend/src/shared/api/queryKey/notionConnection.ts
+++ b/frontend/src/shared/api/queryKey/notionConnection.ts
@@ -1,0 +1,5 @@
+export const notionConnectionKeys = {
+  all: ["notionConnection"] as const,
+  detail: (workspaceId: number) =>
+    [...notionConnectionKeys.all, "detail", workspaceId] as const,
+};


### PR DESCRIPTION
## 관련 이슈

- #344

## 작업 내용

홈 화면 Notion 동기화 카드의 기본 문구를 임시 상수(`어제 오후 3:12에 동기화`)에서 서버가 돌려주는 실제 Notion 연결 상태(연결 안 됨 · 연결됨 · 다시 연결 필요)로 교체하였습니다.
이를 위해 연결 상태 조회 API를 DTO → fetch → msw → 쿼리 훅 순으로 새로 연결하였습니다.

> 변경 배경·핵심 아이디어·코드 워크스루·퀴즈를 정리한 [변경 설명 페이지](https://claude.ai/code/artifact/3054c502-a696-4762-b92c-44a88dc3b611)를 함께 참고해 주세요.

### Notion 연결 상태 조회 계층 추가

`GET /api/v1/workspaces/{workspaceId}/notion-connection`을 부르는 코드가 아직 없었으므로, 기존 API 계층 규칙대로 아래 네 층을 추가하였습니다.

- `shared/api/dto/notionConnection.ts`: `GetNotionConnectionResponseDto` 추가. 응답은 `status` 필드 하나이며 `NOT_CONNECTED` · `CONNECTED` · `REAUTH_REQUIRED` 중 하나입니다.
- `shared/api/fetch/api/v1/workspaces/[workspaceId]/notionConnection`: `getNotionConnectionApi`와 경로 상수 `NOTION_CONNECTION_API_PATH` 추가.
- `shared/api/mock`: 기본 응답은 `CONNECTED` 하나만 두고, 나머지 상태와 실패는 테스트에서 `mockServer.use`로 덮도록 하였습니다. mock 타입은 기존 규칙대로 `mock/types/`에 별도로 정의하였습니다.
- `shared/api/queries/useNotionConnectionQuery`와 `queryKey/notionConnection`: 다른 도메인과 같은 `all` · `detail(workspaceId)` 키 모양을 따르고, 라우트 파라미터가 정수가 아니면 요청하지 않도록 `enabled: Number.isInteger(workspaceId)`를 두었습니다.

```ts
const { data: connection, isError: isConnectionStatusError } =
  useNotionConnectionQuery({ workspaceId: Number(workspaceId) });

// connection?.status → "NOT_CONNECTED" | "CONNECTED" | "REAUTH_REQUIRED" | undefined
```

서버는 연결 기록이 없어도 404가 아니라 `NOT_CONNECTED`를 200으로 돌려주므로, 프론트에서는 404를 특별 취급하지 않고 세 상태 값만 다루도록 하였습니다.

### 카드 기본 문구를 연결 상태로 교체

`useNotionSync` model 훅은 연결 상태 값(`connectionStatus`)과 조회 실패 여부(`isConnectionStatusError`)라는 사실만 내보내고, 문구 선택은 `index.tsx`의 `getDescription`이 맡도록 하였습니다.
상수 파일의 임시 문구는 지우고, 서버 `status` 값을 그대로 키로 쓰는 `NOTION_CONNECTION_STATUS_LABEL` 표와 조회 실패 문구를 두었습니다.

**Before**

```tsx
const getDescription = () => {
  if (isSynced) return `문서 ${syncedDocumentCount}개가 새로 들어왔어요`;
  if (isSyncFailed) return failureMessage;
  return LAST_SYNCED_AT_LABEL;
};
```

**After**

```tsx
const getDescription = () => {
  if (isSynced) return `문서 ${syncedDocumentCount}개가 새로 들어왔어요`;
  if (isSyncFailed) return failureMessage;
  if (isConnectionStatusError) return NOTION_CONNECTION_STATUS_UNKNOWN_MESSAGE;
  if (connectionStatus === undefined) return null;
  return NOTION_CONNECTION_STATUS_LABEL[connectionStatus];
};
```

동기화 결과(완료·실패)는 기존처럼 우선 보여주고, 결과가 2초 뒤 걷히면 연결 상태 문구로 돌아옵니다.
응답이 아직 오지 않은 동안에는 잘못된 기본값이 잠깐 보였다가 바뀌는 깜빡임을 피하기 위해 문구를 비워 두고, 조회 자체가 실패한 경우에만 `노션 연결 상태를 확인하지 못했어요`를 보여주도록 구분하였습니다.

### 테스트 갱신

- `NotionSyncCard/test.tsx`: 기존 임시 문구 기대값을 `노션이 연결되어 있어요`로 바꾸고, 첫 문구가 비동기로 오게 되어 `getByText`를 `findByText`로 조정하였습니다. `NOT_CONNECTED` · `REAUTH_REQUIRED` · 조회 실패 세 케이스를 추가하였습니다.
- `dto/test.ts`, `mock/handlers/test.ts`: 새 DTO 변환과 fetch 함수·기본 핸들러 대응 케이스를 추가하였습니다.
- `__test__/workspaceHomePage.test.ts`(Playwright): 홈 진입과 동기화 완료 후 복귀 시점의 기대 문구를 연결 상태 문구로 교체하였습니다.

### 참고 사항

- 이번 PR은 문구만 바꿉니다. `NOT_CONNECTED` · `REAUTH_REQUIRED` 상태에서도 `지금 동기화` 버튼은 눌리며, 서버가 연결 없음 오류를 돌려주면 기존 실패 문구가 보입니다. 상태에 따라 버튼을 잠그거나 재연결 화면으로 안내할지는 별도 이슈로 다루는 것이 좋을지 의견 부탁드립니다.
- 동기화 완료 후 연결 상태 쿼리를 무효화하는 부분은 기존 `TODO`를 그대로 두었습니다.
- 홈 E2E 중 일부 실패는 #333 Dock 개편에 따른 기존 문제로, 이번 변경과 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HWPxsMvCfrrBEKmdTYsiW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notion sync now displays the current connection status: connected, not connected, or reauthentication required.
  - Added clear messaging for unavailable or unknown connection-status information.
  - Connection status is hidden while synchronization is in progress and shown again afterward.

- **Bug Fixes**
  - Invalid workspace identifiers no longer trigger connection-status requests.

- **Tests**
  - Expanded coverage for connection states, status-fetch failures, and synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->