### PR TITLE
[BE] 채팅 답변 출처 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/knot/backend/chat/application/ChatMessageSourceQueryService.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/ChatMessageSourceQueryService.java
@@ -1,0 +1,41 @@
+package com.knot.backend.chat.application;
+
+import com.knot.backend.chat.domain.ChatErrorCode;
+import com.knot.backend.chat.domain.ChatException;
+import com.knot.backend.chat.domain.ChatMessage;
+import com.knot.backend.chat.domain.ChatMessageRepository;
+import com.knot.backend.search.domain.SearchReference;
+import com.knot.backend.search.domain.SearchReferenceRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageSourceQueryService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatSessionAccessPolicy chatSessionAccessPolicy;
+    private final SearchReferenceRepository searchReferenceRepository;
+
+    @Transactional(readOnly = true)
+    public List<SearchReference> findSources(
+            long messageId,
+            long memberId
+    ) {
+        validateMessageId(messageId);
+        ChatMessage chatMessage = chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND));
+        chatSessionAccessPolicy.requireOwner(
+                chatMessage.getSessionId(),
+                memberId
+        );
+        return searchReferenceRepository.findAllByMessageId(messageId);
+    }
+
+    private void validateMessageId(long messageId) {
+        if (messageId <= 0) {
+            throw new ChatException(ChatErrorCode.INVALID_CHAT_MESSAGE_ID);
+        }
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/application/ChatMessageSourceQueryService.java
+++ b/backend/src/main/java/com/knot/backend/chat/application/ChatMessageSourceQueryService.java
@@ -4,6 +4,7 @@ import com.knot.backend.chat.domain.ChatErrorCode;
 import com.knot.backend.chat.domain.ChatException;
 import com.knot.backend.chat.domain.ChatMessage;
 import com.knot.backend.chat.domain.ChatMessageRepository;
+import com.knot.backend.chat.domain.ChatMessageRole;
 import com.knot.backend.search.domain.SearchReference;
 import com.knot.backend.search.domain.SearchReferenceRepository;
 import java.util.List;
@@ -30,12 +31,19 @@ public class ChatMessageSourceQueryService {
                 chatMessage.getSessionId(),
                 memberId
         );
+        requireAssistantMessage(chatMessage);
         return searchReferenceRepository.findAllByMessageId(messageId);
     }
 
     private void validateMessageId(long messageId) {
         if (messageId <= 0) {
             throw new ChatException(ChatErrorCode.INVALID_CHAT_MESSAGE_ID);
+        }
+    }
+
+    private void requireAssistantMessage(ChatMessage chatMessage) {
+        if (chatMessage.getRole() != ChatMessageRole.ASSISTANT) {
+            throw new ChatException(ChatErrorCode.CHAT_MESSAGE_NOT_FOUND);
         }
     }
 }

--- a/backend/src/main/java/com/knot/backend/chat/domain/ChatErrorCode.java
+++ b/backend/src/main/java/com/knot/backend/chat/domain/ChatErrorCode.java
@@ -42,6 +42,12 @@ public enum ChatErrorCode implements ErrorCode {
             "채팅 메시지의 세션 ID가 올바르지 않습니다"
     ),
 
+    INVALID_CHAT_MESSAGE_ID(
+            ErrorCategory.INVALID_INPUT,
+            "INVALID_CHAT_MESSAGE_ID",
+            "채팅 메시지 ID가 올바르지 않습니다"
+    ),
+
     INVALID_CHAT_MESSAGE_ROLE(
             ErrorCategory.INVALID_INPUT,
             "INVALID_CHAT_MESSAGE_ROLE",

--- a/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryApi.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryApi.java
@@ -1,0 +1,77 @@
+package com.knot.backend.chat.presentation;
+
+import static com.knot.backend.global.config.OpenApiConfig.ACCESS_TOKEN_COOKIE;
+
+import com.knot.backend.auth.domain.AuthenticatedMember;
+import com.knot.backend.chat.presentation.dto.response.SearchReferencesResponse;
+import com.knot.backend.global.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Chat Message", description = "AI 답변 메시지의 검색 출처 조회")
+@SecurityRequirement(name = ACCESS_TOKEN_COOKIE)
+public interface ChatMessageSourceQueryApi {
+
+    // @formatter:off
+    @Operation(summary = "AI 답변 출처 조회")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "저장된 검색 출처 조회 성공. 출처가 없으면 빈 배열",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SearchReferencesResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "메시지 ID가 올바르지 않거나 형식이 잘못됨",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 요청",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "메시지가 속한 채팅 세션의 소유자가 아님",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "메시지를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    ResponseEntity<SearchReferencesResponse> findSources(
+            @Parameter(
+                    description = "AI 답변 메시지 ID",
+                    in = ParameterIn.PATH,
+                    example = "102"
+            ) Long messageId,
+            @Parameter(hidden = true) AuthenticatedMember authenticatedMember
+    );
+    // @formatter:on
+}

--- a/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryApi.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryApi.java
@@ -8,12 +8,14 @@ import com.knot.backend.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
@@ -27,6 +29,11 @@ public interface ChatMessageSourceQueryApi {
             @ApiResponse(
                     responseCode = "200",
                     description = "저장된 검색 출처 조회 성공. 출처가 없으면 빈 배열",
+                    headers = @Header(
+                            name = HttpHeaders.CACHE_CONTROL,
+                            description = "사용자별 출처 응답 캐시 방지",
+                            schema = @Schema(type = "string", example = "no-store")
+                    ),
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = SearchReferencesResponse.class)
@@ -58,7 +65,7 @@ public interface ChatMessageSourceQueryApi {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "메시지를 찾을 수 없음",
+                    description = "메시지를 찾을 수 없거나 assistant 메시지가 아님",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ErrorResponse.class)
@@ -69,7 +76,8 @@ public interface ChatMessageSourceQueryApi {
             @Parameter(
                     description = "AI 답변 메시지 ID",
                     in = ParameterIn.PATH,
-                    example = "102"
+                    example = "102",
+                    required = true
             ) Long messageId,
             @Parameter(hidden = true) AuthenticatedMember authenticatedMember
     );

--- a/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryController.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryController.java
@@ -1,0 +1,38 @@
+package com.knot.backend.chat.presentation;
+
+import com.knot.backend.auth.domain.AuthenticatedMember;
+import com.knot.backend.chat.application.ChatMessageSourceQueryService;
+import com.knot.backend.chat.presentation.dto.response.SearchReferencesResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/messages")
+@RequiredArgsConstructor
+public class ChatMessageSourceQueryController implements ChatMessageSourceQueryApi {
+    private final ChatMessageSourceQueryService chatMessageSourceQueryService;
+
+    @Override
+    @GetMapping(value = "/{messageId}/sources", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SearchReferencesResponse> findSources(
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+    ) {
+        SearchReferencesResponse response = SearchReferencesResponse.from(
+                chatMessageSourceQueryService.findSources(
+                        messageId,
+                        authenticatedMember.getMemberId()
+                )
+        );
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .body(response);
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/NotionPageReferenceResponse.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/NotionPageReferenceResponse.java
@@ -1,0 +1,14 @@
+package com.knot.backend.chat.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+
+@Schema(description = "검색 출처 Notion 페이지 메타데이터")
+public record NotionPageReferenceResponse(
+        @Schema(description = "원본 Notion 페이지 ID", example = "14f2a8c1-7e3b-4d6a-9f21-8c5b0a12d934") String id,
+        @Schema(description = "Notion 페이지 제목", example = "기술 스택과 라이브러리 도입") String title,
+        @Schema(description = "원본 Notion 페이지 URL", example = "https://www.notion.so/example") String notionUrl,
+        @Schema(description = "Notion 페이지 생성 시각", example = "2026-08-30T00:00:00Z") Instant createdAt,
+        @Schema(description = "Notion 페이지 수정 시각", example = "2026-09-01T04:12:35Z") Instant updatedAt
+) {
+}

--- a/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/SearchReferenceResponse.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/SearchReferenceResponse.java
@@ -15,7 +15,7 @@ public record SearchReferenceResponse(
 ) {
 
     public static SearchReferenceResponse from(SearchReference reference) {
-        SearchReference.NotionPageReference notionPage = reference.notionPage();
+        SearchReference.ContentPageReference page = reference.page();
         return new SearchReferenceResponse(
                 reference.id(),
                 reference.messageId(),
@@ -23,11 +23,11 @@ public record SearchReferenceResponse(
                 reference.relevanceScore(),
                 reference.source(),
                 new NotionPageReferenceResponse(
-                        notionPage.id(),
-                        notionPage.title(),
-                        notionPage.notionUrl(),
-                        notionPage.createdAt(),
-                        notionPage.updatedAt()
+                        page.externalPageId(),
+                        page.title(),
+                        page.sourceUrl(),
+                        page.createdAt(),
+                        page.updatedAt()
                 )
         );
     }

--- a/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/SearchReferenceResponse.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/SearchReferenceResponse.java
@@ -1,0 +1,34 @@
+package com.knot.backend.chat.presentation.dto.response;
+
+import com.knot.backend.search.domain.SearchReference;
+import com.knot.backend.workspace.domain.ContentSourceProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "AI 답변의 검색 출처")
+public record SearchReferenceResponse(
+        @Schema(description = "검색 출처 ID", example = "1") long id,
+        @Schema(description = "출처가 연결된 메시지 ID", example = "102") long messageId,
+        @Schema(description = "메시지 내 관련도 순위", example = "1") int rank,
+        @Schema(description = "검색 관련도 점수", example = "0.9472") double relevanceScore,
+        @Schema(description = "출처 제공자", example = "NOTION") ContentSourceProvider source,
+        @Schema(description = "원본 출처 문서") NotionPageReferenceResponse notionPage
+) {
+
+    public static SearchReferenceResponse from(SearchReference reference) {
+        SearchReference.NotionPageReference notionPage = reference.notionPage();
+        return new SearchReferenceResponse(
+                reference.id(),
+                reference.messageId(),
+                reference.rank(),
+                reference.relevanceScore(),
+                reference.source(),
+                new NotionPageReferenceResponse(
+                        notionPage.id(),
+                        notionPage.title(),
+                        notionPage.notionUrl(),
+                        notionPage.createdAt(),
+                        notionPage.updatedAt()
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/SearchReferencesResponse.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/dto/response/SearchReferencesResponse.java
@@ -1,0 +1,23 @@
+package com.knot.backend.chat.presentation.dto.response;
+
+import com.knot.backend.search.domain.SearchReference;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "메시지 검색 출처 목록")
+public record SearchReferencesResponse(
+        @Schema(description = "관련도 순으로 정렬된 검색 출처 목록") List<SearchReferenceResponse> searchReferences
+) {
+
+    public SearchReferencesResponse {
+        searchReferences = List.copyOf(searchReferences);
+    }
+
+    public static SearchReferencesResponse from(List<SearchReference> references) {
+        return new SearchReferencesResponse(
+                references.stream()
+                        .map(SearchReferenceResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/knot/backend/search/domain/SearchReference.java
+++ b/backend/src/main/java/com/knot/backend/search/domain/SearchReference.java
@@ -9,13 +9,13 @@ public record SearchReference(
         int rank,
         double relevanceScore,
         ContentSourceProvider source,
-        NotionPageReference notionPage
+        ContentPageReference page
 ) {
 
-    public record NotionPageReference(
-            String id,
+    public record ContentPageReference(
+            String externalPageId,
             String title,
-            String notionUrl,
+            String sourceUrl,
             Instant createdAt,
             Instant updatedAt
     ) {

--- a/backend/src/main/java/com/knot/backend/search/domain/SearchReference.java
+++ b/backend/src/main/java/com/knot/backend/search/domain/SearchReference.java
@@ -1,0 +1,23 @@
+package com.knot.backend.search.domain;
+
+import com.knot.backend.workspace.domain.ContentSourceProvider;
+import java.time.Instant;
+
+public record SearchReference(
+        Long id,
+        Long messageId,
+        int rank,
+        double relevanceScore,
+        ContentSourceProvider source,
+        NotionPageReference notionPage
+) {
+
+    public record NotionPageReference(
+            String id,
+            String title,
+            String notionUrl,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/knot/backend/search/domain/SearchReferenceRepository.java
+++ b/backend/src/main/java/com/knot/backend/search/domain/SearchReferenceRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 public interface SearchReferenceRepository {
 
+    List<SearchReference> findAllByMessageId(Long messageId);
+
     void replace(
             Long messageId,
             List<SearchChunk> references

--- a/backend/src/main/java/com/knot/backend/search/infrastructure/persistence/JdbcSearchReferenceRepository.java
+++ b/backend/src/main/java/com/knot/backend/search/infrastructure/persistence/JdbcSearchReferenceRepository.java
@@ -33,6 +33,11 @@ public class JdbcSearchReferenceRepository implements SearchReferenceRepository 
                     page.created_at,
                     page.updated_at
                 FROM search_references reference
+                JOIN chat_messages message
+                    ON message.id = reference.message_id
+                JOIN chat_sessions session
+                    ON session.id = message.session_id
+                    AND session.workspace_id = reference.workspace_id
                 JOIN imported_pages page
                     ON page.id = reference.imported_page_id
                     AND page.workspace_id = reference.workspace_id
@@ -138,7 +143,7 @@ public class JdbcSearchReferenceRepository implements SearchReferenceRepository 
                 resultSet.getInt("reference_rank"),
                 resultSet.getDouble("relevance_score"),
                 ContentSourceProvider.valueOf(resultSet.getString("source")),
-                new SearchReference.NotionPageReference(
+                new SearchReference.ContentPageReference(
                         resultSet.getString("external_page_id"),
                         resultSet.getString("title"),
                         resultSet.getString("source_url"),

--- a/backend/src/main/java/com/knot/backend/search/infrastructure/persistence/JdbcSearchReferenceRepository.java
+++ b/backend/src/main/java/com/knot/backend/search/infrastructure/persistence/JdbcSearchReferenceRepository.java
@@ -3,7 +3,11 @@ package com.knot.backend.search.infrastructure.persistence;
 import com.knot.backend.search.domain.SearchChunk;
 import com.knot.backend.search.domain.SearchErrorCode;
 import com.knot.backend.search.domain.SearchException;
+import com.knot.backend.search.domain.SearchReference;
 import com.knot.backend.search.domain.SearchReferenceRepository;
+import com.knot.backend.workspace.domain.ContentSourceProvider;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -13,6 +17,42 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class JdbcSearchReferenceRepository implements SearchReferenceRepository {
     private final JdbcClient jdbcClient;
+
+    @Override
+    public List<SearchReference> findAllByMessageId(Long messageId) {
+        return jdbcClient.sql("""
+                SELECT
+                    reference.id AS reference_id,
+                    reference.message_id,
+                    reference.reference_rank,
+                    reference.relevance_score,
+                    connection.provider AS source,
+                    page.external_page_id,
+                    page.title,
+                    page.source_url,
+                    page.created_at,
+                    page.updated_at
+                FROM search_references reference
+                JOIN imported_pages page
+                    ON page.id = reference.imported_page_id
+                    AND page.workspace_id = reference.workspace_id
+                    AND page.import_run_id = reference.import_run_id
+                JOIN content_import_runs import_run
+                    ON import_run.id = reference.import_run_id
+                    AND import_run.workspace_id = reference.workspace_id
+                JOIN content_source_connections connection
+                    ON connection.id = import_run.content_source_connection_id
+                    AND connection.workspace_id = import_run.workspace_id
+                WHERE reference.message_id = :messageId
+                ORDER BY reference.reference_rank ASC
+                """)
+                .param(
+                        "messageId",
+                        messageId
+                )
+                .query(this::mapSearchReference)
+                .list();
+    }
 
     @Override
     public void replace(
@@ -86,5 +126,27 @@ public class JdbcSearchReferenceRepository implements SearchReferenceRepository 
                 throw new SearchException(SearchErrorCode.SEARCH_REFERENCE_FAILED);
             }
         }
+    }
+
+    private SearchReference mapSearchReference(
+            ResultSet resultSet,
+            int rowNumber
+    ) throws SQLException {
+        return new SearchReference(
+                resultSet.getLong("reference_id"),
+                resultSet.getLong("message_id"),
+                resultSet.getInt("reference_rank"),
+                resultSet.getDouble("relevance_score"),
+                ContentSourceProvider.valueOf(resultSet.getString("source")),
+                new SearchReference.NotionPageReference(
+                        resultSet.getString("external_page_id"),
+                        resultSet.getString("title"),
+                        resultSet.getString("source_url"),
+                        resultSet.getTimestamp("created_at")
+                                .toInstant(),
+                        resultSet.getTimestamp("updated_at")
+                                .toInstant()
+                )
+        );
     }
 }

--- a/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryAcceptanceTest.java
@@ -1,0 +1,468 @@
+package com.knot.backend.chat.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.knot.backend.auth.domain.AuthTokenProvider;
+import com.knot.backend.auth.domain.AuthenticatedMember;
+import com.knot.backend.testsupport.TestApplicationProperties;
+import com.knot.backend.testsupport.TestcontainersConfiguration;
+import jakarta.servlet.http.Cookie;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Tag("acceptance")
+@Import(TestcontainersConfiguration.class)
+@TestApplicationProperties
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class ChatMessageSourceQueryAcceptanceTest {
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "KNOT_ACCESS_TOKEN";
+    private static final Instant CREATED_AT = Instant.parse("2026-08-30T00:00:00Z");
+    private static final OffsetDateTime CREATED_AT_OFFSET = CREATED_AT.atOffset(ZoneOffset.UTC);
+
+    private final MockMvc mockMvc;
+    private final AuthTokenProvider authTokenProvider;
+    private final JdbcClient jdbcClient;
+
+    ChatMessageSourceQueryAcceptanceTest(
+            MockMvc mockMvc,
+            AuthTokenProvider authTokenProvider,
+            JdbcClient jdbcClient
+    ) {
+        this.mockMvc = mockMvc;
+        this.authTokenProvider = authTokenProvider;
+        this.jdbcClient = jdbcClient;
+    }
+
+    @BeforeEach
+    void clearTables() {
+        jdbcClient.sql("""
+                TRUNCATE TABLE search_references, chat_feedback, chat_messages, chat_sessions,
+                    imported_page_publications, imported_pages, content_import_runs,
+                    content_source_connections, content_source_authorizations,
+                    workspace_members, workspaces, members RESTART IDENTITY CASCADE
+                """)
+                .update();
+    }
+
+    @Test
+    @DisplayName("assistant 메시지의 저장된 Notion 출처를 rank 순서로 반환한다")
+    void findSources_success() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+        saveSearchReference(fixture);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        fixture.messageId()
+                ).cookie(accessTokenCookie(fixture.ownerId()))
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.searchReferences").isArray())
+                .andExpect(jsonPath("$.searchReferences").isNotEmpty())
+                .andExpect(jsonPath("$.searchReferences[0].id").isNumber())
+                .andExpect(jsonPath("$.searchReferences[0].messageId").value(fixture.messageId()))
+                .andExpect(jsonPath("$.searchReferences[0].rank").value(1))
+                .andExpect(jsonPath("$.searchReferences[0].relevanceScore").value(0.9472))
+                .andExpect(jsonPath("$.searchReferences[0].source").value("NOTION"))
+                .andExpect(jsonPath("$.searchReferences[0].notionPage.id").value("notion-page-1"))
+                .andExpect(jsonPath("$.searchReferences[0].notionPage.title").value("기술 스택과 라이브러리 도입"))
+                .andExpect(
+                        jsonPath("$.searchReferences[0].notionPage.notionUrl")
+                                .value("https://www.notion.so/notion-page-1")
+                )
+                .andExpect(jsonPath("$.searchReferences[0].notionPage.createdAt").value("2026-08-30T00:00:00Z"))
+                .andExpect(jsonPath("$.searchReferences[0].notionPage.updatedAt").value("2026-08-30T01:00:00Z"))
+                .andExpect(jsonPath("$.searchReferences[1].rank").value(2))
+                .andExpect(jsonPath("$.searchReferences[1].relevanceScore").value(0.8))
+                .andExpect(jsonPath("$.searchReferences[1].notionPage.id").value("notion-page-2"));
+    }
+
+    @Test
+    @DisplayName("출처가 없는 메시지는 빈 searchReferences를 반환한다")
+    void findSources_success_empty() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        fixture.messageId()
+                ).cookie(accessTokenCookie(fixture.ownerId()))
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.searchReferences").isArray())
+                .andExpect(jsonPath("$.searchReferences").isEmpty());
+    }
+
+    @Test
+    @DisplayName("다른 멤버는 메시지 출처를 조회할 수 없다")
+    void findSources_failure_accessDenied() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+        saveSearchReference(fixture);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        fixture.messageId()
+                ).cookie(accessTokenCookie(fixture.otherMemberId()))
+        );
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("CHAT_ACCESS_DENIED"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 메시지의 출처를 조회하면 404를 반환한다")
+    void findSources_failure_messageNotFound() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        fixture.messageId() + 1000
+                ).cookie(accessTokenCookie(fixture.ownerId()))
+        );
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CHAT_MESSAGE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("메시지 ID가 양수가 아니면 400을 반환한다")
+    void findSources_failure_invalidMessageId() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        -1L
+                ).cookie(accessTokenCookie(fixture.ownerId()))
+        );
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_CHAT_MESSAGE_ID"));
+    }
+
+    private Fixture saveFixture() {
+        long ownerId = saveMember("source-owner");
+        long otherMemberId = saveMember("source-member");
+        long workspaceId = jdbcClient.sql("""
+                INSERT INTO workspaces (name, created_at)
+                VALUES ('출처 조회 팀', :createdAt)
+                RETURNING id
+                """)
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .query(Long.class)
+                .single();
+        saveWorkspaceMember(
+                workspaceId,
+                ownerId,
+                "OWNER"
+        );
+        saveWorkspaceMember(
+                workspaceId,
+                otherMemberId,
+                "MEMBER"
+        );
+        long sessionId = jdbcClient.sql("""
+                INSERT INTO chat_sessions (workspace_id, member_id, title, created_at, last_message_at)
+                VALUES (:workspaceId, :memberId, '출처 조회', :createdAt, :createdAt)
+                RETURNING id
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "memberId",
+                        ownerId
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .query(Long.class)
+                .single();
+        long messageId = jdbcClient.sql("""
+                INSERT INTO chat_messages (session_id, role, content, created_at)
+                VALUES (:sessionId, 'ASSISTANT', 'PostgreSQL을 사용합니다.', :createdAt)
+                RETURNING id
+                """)
+                .param(
+                        "sessionId",
+                        sessionId
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET.plusSeconds(1)
+                )
+                .query(Long.class)
+                .single();
+        long connectionId = jdbcClient.sql("""
+                INSERT INTO content_source_connections (
+                    workspace_id, provider, access_credential_ciphertext,
+                    external_source_id, provider_connection_id, authorization_owner_type,
+                    authorizing_member_id, created_at, updated_at
+                ) VALUES (
+                    :workspaceId, 'NOTION', 'test-ciphertext',
+                    'notion-workspace', 'notion-connection', 'WORKSPACE',
+                    :memberId, :createdAt, :createdAt
+                )
+                RETURNING id
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "memberId",
+                        ownerId
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .query(Long.class)
+                .single();
+        long importRunId = jdbcClient.sql("""
+                INSERT INTO content_import_runs (
+                    workspace_id, content_source_connection_id, requested_by_member_id,
+                    status, total_page_count, processed_page_count,
+                    started_at, completed_at, created_at
+                ) VALUES (
+                    :workspaceId, :connectionId, :memberId,
+                    'COMPLETED', 1, 1,
+                    :createdAt, :updatedAt, :createdAt
+                )
+                RETURNING id
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "connectionId",
+                        connectionId
+                )
+                .param(
+                        "memberId",
+                        ownerId
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .param(
+                        "updatedAt",
+                        CREATED_AT_OFFSET.plusSeconds(1)
+                )
+                .query(Long.class)
+                .single();
+        long importedPageId = jdbcClient.sql("""
+                INSERT INTO imported_pages (
+                    workspace_id, import_run_id, external_page_id, title,
+                    markdown_content, position, source_url, created_at, updated_at
+                ) VALUES (
+                    :workspaceId, :importRunId, 'notion-page-1', '기술 스택과 라이브러리 도입',
+                    'PostgreSQL을 사용합니다.', 0, 'https://www.notion.so/notion-page-1',
+                    :createdAt, :updatedAt
+                )
+                RETURNING id
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "importRunId",
+                        importRunId
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .param(
+                        "updatedAt",
+                        CREATED_AT_OFFSET.plusSeconds(3600)
+                )
+                .query(Long.class)
+                .single();
+        long secondImportedPageId = jdbcClient.sql("""
+                INSERT INTO imported_pages (
+                    workspace_id, import_run_id, external_page_id, title,
+                    markdown_content, position, source_url, created_at, updated_at
+                ) VALUES (
+                    :workspaceId, :importRunId, 'notion-page-2', '백엔드 회의록',
+                    'PostgreSQL을 사용하기로 결정했습니다.', 1, 'https://www.notion.so/notion-page-2',
+                    :createdAt, :updatedAt
+                )
+                RETURNING id
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "importRunId",
+                        importRunId
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .param(
+                        "updatedAt",
+                        CREATED_AT_OFFSET.plusSeconds(3600)
+                )
+                .query(Long.class)
+                .single();
+        return new Fixture(
+                ownerId,
+                otherMemberId,
+                messageId,
+                workspaceId,
+                importRunId,
+                importedPageId,
+                secondImportedPageId
+        );
+    }
+
+    private void saveSearchReference(Fixture fixture) {
+        jdbcClient.sql("""
+                INSERT INTO search_references (
+                    message_id, workspace_id, import_run_id, imported_page_id,
+                    reference_rank, relevance_score
+                ) VALUES (
+                    :messageId, :workspaceId, :importRunId, :importedPageId, 1, 0.9472
+                ), (
+                    :messageId, :workspaceId, :importRunId, :secondImportedPageId, 2, 0.8
+                )
+                """)
+                .param(
+                        "messageId",
+                        fixture.messageId()
+                )
+                .param(
+                        "workspaceId",
+                        fixture.workspaceId()
+                )
+                .param(
+                        "importRunId",
+                        fixture.importRunId()
+                )
+                .param(
+                        "importedPageId",
+                        fixture.importedPageId()
+                )
+                .param(
+                        "secondImportedPageId",
+                        fixture.secondImportedPageId()
+                )
+                .update();
+    }
+
+    private long saveMember(String nickname) {
+        return jdbcClient.sql("""
+                INSERT INTO members (nickname, profile_image_url)
+                VALUES (:nickname, NULL)
+                RETURNING id
+                """)
+                .param(
+                        "nickname",
+                        nickname
+                )
+                .query(Long.class)
+                .single();
+    }
+
+    private void saveWorkspaceMember(
+            long workspaceId,
+            long memberId,
+            String role
+    ) {
+        jdbcClient.sql("""
+                INSERT INTO workspace_members (workspace_id, member_id, role, joined_at)
+                VALUES (:workspaceId, :memberId, :role, :joinedAt)
+                """)
+                .param(
+                        "workspaceId",
+                        workspaceId
+                )
+                .param(
+                        "memberId",
+                        memberId
+                )
+                .param(
+                        "role",
+                        role
+                )
+                .param(
+                        "joinedAt",
+                        CREATED_AT_OFFSET
+                )
+                .update();
+    }
+
+    private Cookie accessTokenCookie(long memberId) {
+        return new Cookie(
+                ACCESS_TOKEN_COOKIE_NAME,
+                authTokenProvider.issue(
+                        AuthenticatedMember.of(
+                                memberId,
+                                "source-member",
+                                null
+                        )
+                )
+        );
+    }
+
+    private record Fixture(
+            long ownerId,
+            long otherMemberId,
+            long messageId,
+            long workspaceId,
+            long importRunId,
+            long importedPageId,
+            long secondImportedPageId
+    ) {
+    }
+}

--- a/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.knot.backend.chat.presentation;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.test.context.TestConstructor;
@@ -79,6 +81,12 @@ class ChatMessageSourceQueryAcceptanceTest {
 
         // then
         result.andExpect(status().isOk())
+                .andExpect(
+                        header().string(
+                                HttpHeaders.CACHE_CONTROL,
+                                "no-store"
+                        )
+                )
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.searchReferences").isArray())
                 .andExpect(jsonPath("$.searchReferences").isNotEmpty())
@@ -177,6 +185,61 @@ class ChatMessageSourceQueryAcceptanceTest {
         // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_CHAT_MESSAGE_ID"));
+    }
+
+    @Test
+    @DisplayName("메시지와 다른 workspace에 저장된 출처는 반환하지 않는다")
+    void findSources_success_excludesDifferentWorkspaceReference() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+        saveCrossWorkspaceReference(fixture);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        fixture.messageId()
+                ).cookie(accessTokenCookie(fixture.ownerId()))
+        );
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.searchReferences").isArray())
+                .andExpect(jsonPath("$.searchReferences").isEmpty());
+    }
+
+    @Test
+    @DisplayName("사용자 메시지는 출처 조회 대상이 아니다")
+    void findSources_failure_userMessage() throws Exception {
+        // given
+        Fixture fixture = saveFixture();
+        long userMessageId = jdbcClient.sql("""
+                INSERT INTO chat_messages (session_id, role, content, created_at)
+                VALUES (:sessionId, 'USER', 'PostgreSQL을 왜 사용했나요?', :createdAt)
+                RETURNING id
+                """)
+                .param(
+                        "sessionId",
+                        fixture.sessionId()
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET.plusSeconds(2)
+                )
+                .query(Long.class)
+                .single();
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get(
+                        "/api/v1/messages/{messageId}/sources",
+                        userMessageId
+                ).cookie(accessTokenCookie(fixture.ownerId()))
+        );
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CHAT_MESSAGE_NOT_FOUND"));
     }
 
     private Fixture saveFixture() {
@@ -359,6 +422,7 @@ class ChatMessageSourceQueryAcceptanceTest {
                 ownerId,
                 otherMemberId,
                 messageId,
+                sessionId,
                 workspaceId,
                 importRunId,
                 importedPageId,
@@ -396,6 +460,76 @@ class ChatMessageSourceQueryAcceptanceTest {
                 .param(
                         "secondImportedPageId",
                         fixture.secondImportedPageId()
+                )
+                .update();
+    }
+
+    private void saveCrossWorkspaceReference(Fixture fixture) {
+        jdbcClient.sql("""
+                WITH foreign_workspace AS (
+                    INSERT INTO workspaces (name, created_at)
+                    VALUES ('다른 팀', :createdAt)
+                    RETURNING id
+                ), foreign_membership AS (
+                    INSERT INTO workspace_members (workspace_id, member_id, role, joined_at)
+                    SELECT id, :memberId, 'OWNER', :createdAt
+                    FROM foreign_workspace
+                    RETURNING workspace_id, member_id
+                ), foreign_connection AS (
+                    INSERT INTO content_source_connections (
+                        workspace_id, provider, access_credential_ciphertext,
+                        external_source_id, provider_connection_id, authorization_owner_type,
+                        authorizing_member_id, created_at, updated_at
+                    )
+                    SELECT workspace_id, 'NOTION', 'foreign-ciphertext',
+                        'foreign-notion-workspace', 'foreign-notion-connection', 'WORKSPACE',
+                        member_id, :createdAt, :createdAt
+                    FROM foreign_membership
+                    RETURNING id, workspace_id
+                ), foreign_import_run AS (
+                    INSERT INTO content_import_runs (
+                        workspace_id, content_source_connection_id, requested_by_member_id,
+                        status, total_page_count, processed_page_count,
+                        started_at, completed_at, created_at
+                    )
+                    SELECT workspace_id, id, :memberId,
+                        'COMPLETED', 1, 1,
+                        :createdAt, :updatedAt, :createdAt
+                    FROM foreign_connection
+                    RETURNING id, workspace_id
+                ), foreign_page AS (
+                    INSERT INTO imported_pages (
+                        workspace_id, import_run_id, external_page_id, title,
+                        markdown_content, position, source_url, created_at, updated_at
+                    )
+                    SELECT workspace_id, id, 'foreign-page', '다른 팀 문서',
+                        '다른 팀의 문서 내용', 0, 'https://www.notion.so/foreign-page',
+                        :createdAt, :updatedAt
+                    FROM foreign_import_run
+                    RETURNING id, workspace_id, import_run_id
+                )
+                INSERT INTO search_references (
+                    message_id, workspace_id, import_run_id, imported_page_id,
+                    reference_rank, relevance_score
+                )
+                SELECT :messageId, workspace_id, import_run_id, id, 1, 0.99
+                FROM foreign_page
+                """)
+                .param(
+                        "memberId",
+                        fixture.ownerId()
+                )
+                .param(
+                        "messageId",
+                        fixture.messageId()
+                )
+                .param(
+                        "createdAt",
+                        CREATED_AT_OFFSET
+                )
+                .param(
+                        "updatedAt",
+                        CREATED_AT_OFFSET.plusSeconds(1)
                 )
                 .update();
     }
@@ -459,6 +593,7 @@ class ChatMessageSourceQueryAcceptanceTest {
             long ownerId,
             long otherMemberId,
             long messageId,
+            long sessionId,
             long workspaceId,
             long importRunId,
             long importedPageId,

--- a/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryApiDocumentationAcceptanceTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageSourceQueryApiDocumentationAcceptanceTest.java
@@ -1,0 +1,87 @@
+package com.knot.backend.chat.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.knot.backend.testsupport.TestApplicationProperties;
+import com.knot.backend.testsupport.TestcontainersConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Tag("acceptance")
+@ActiveProfiles("dev")
+@Import(TestcontainersConfiguration.class)
+@TestApplicationProperties
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class ChatMessageSourceQueryApiDocumentationAcceptanceTest {
+    private final MockMvc mockMvc;
+
+    ChatMessageSourceQueryApiDocumentationAcceptanceTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Test
+    @DisplayName("OpenAPI JSON에 메시지 출처 조회의 응답·보안·오류 계약을 공개한다")
+    void openApi_success_messageSourcesContract() throws Exception {
+        // given
+        String operationPath = "$.paths['/api/v1/messages/{messageId}/sources'].get";
+        String responseRef = "#/components/schemas/SearchReferencesResponse";
+        String errorResponseRef = "#/components/schemas/ErrorResponse";
+
+        // when
+        ResultActions result = mockMvc.perform(get("/v3/api-docs"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath(operationPath).exists())
+                .andExpect(jsonPath(operationPath + ".summary").value("AI 답변 출처 조회"))
+                .andExpect(jsonPath(operationPath + ".security[0].accessTokenCookie").exists())
+                .andExpect(
+                        jsonPath(operationPath + ".responses['200'].content['application/json'].schema['$ref']")
+                                .value(responseRef)
+                )
+                .andExpect(
+                        jsonPath(operationPath + ".responses['400'].content['application/json'].schema['$ref']")
+                                .value(errorResponseRef)
+                )
+                .andExpect(
+                        jsonPath(operationPath + ".responses['401'].content['application/json'].schema['$ref']")
+                                .value(errorResponseRef)
+                )
+                .andExpect(
+                        jsonPath(operationPath + ".responses['403'].content['application/json'].schema['$ref']")
+                                .value(errorResponseRef)
+                )
+                .andExpect(
+                        jsonPath(operationPath + ".responses['404'].content['application/json'].schema['$ref']")
+                                .value(errorResponseRef)
+                )
+                .andExpect(
+                        jsonPath("$.components.schemas.SearchReferencesResponse.properties.searchReferences").exists()
+                )
+                .andExpect(jsonPath("$.components.schemas.SearchReferenceResponse.properties.id").exists())
+                .andExpect(jsonPath("$.components.schemas.SearchReferenceResponse.properties.messageId").exists())
+                .andExpect(jsonPath("$.components.schemas.SearchReferenceResponse.properties.rank").exists())
+                .andExpect(jsonPath("$.components.schemas.SearchReferenceResponse.properties.relevanceScore").exists())
+                .andExpect(jsonPath("$.components.schemas.SearchReferenceResponse.properties.source").exists())
+                .andExpect(jsonPath("$.components.schemas.SearchReferenceResponse.properties.notionPage").exists())
+                .andExpect(jsonPath("$.components.schemas.NotionPageReferenceResponse.properties.id").exists())
+                .andExpect(jsonPath("$.components.schemas.NotionPageReferenceResponse.properties.title").exists())
+                .andExpect(jsonPath("$.components.schemas.NotionPageReferenceResponse.properties.notionUrl").exists())
+                .andExpect(jsonPath("$.components.schemas.NotionPageReferenceResponse.properties.createdAt").exists())
+                .andExpect(jsonPath("$.components.schemas.NotionPageReferenceResponse.properties.updatedAt").exists());
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #241

## 작업 내용

- 저장된 `search_references`와 `imported_pages`를 메시지·workspace·import run·page 관계로 조회
- `GET /api/v1/messages/{messageId}/sources` 응답을 `searchReferences` 루트와 Notion 페이지 메타데이터 형식으로 제공
- 채팅 세션 소유자와 `ASSISTANT` 메시지만 조회하도록 권한·대상 검증
- 출처가 없으면 빈 배열을 반환하고, rank 오름차순 및 `Cache-Control: no-store`를 보장
- workspace 격리, 잘못된 메시지 대상, OpenAPI 응답 계약을 acceptance 테스트로 검증

### 참고 사항

- Notion API를 다시 호출하거나 RAG를 재실행하지 않고, 이미 저장된 출처만 읽는다.
- domain projection은 provider-neutral로 유지하고, Notion 응답 필드 매핑은 presentation에 둔다.
- 정상 200, 빈 결과, non-owner 403, missing/non-assistant 404, invalid ID 400을 검증했다.
- 검증: `./gradlew spotlessCheck test bootJar` 및 출처 endpoint/API 문서 acceptance 통과
- 검증: `./gradlew integrationTest --tests com.knot.backend.chat.infrastructure.ChatRepositoryIntegrationTest` 통과
- 테스트와 구현을 분리한 atomic commit 흐름으로 구성했다.
- Frontend source 조회 연결은 #301 범위로 남겨두고 이번 PR에는 포함하지 않았다.
