### PR TITLE
[BE] LLM 채팅 SSE 스트림 timeout 경계 수정

### DIFF
--- a/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageController.java
+++ b/backend/src/main/java/com/knot/backend/chat/presentation/ChatMessageController.java
@@ -6,6 +6,7 @@ import com.knot.backend.chat.application.ChatStreamHandle;
 import com.knot.backend.chat.application.ChatStreamListener;
 import com.knot.backend.chat.domain.ChatErrorCode;
 import com.knot.backend.chat.presentation.dto.request.SendChatMessageRequest;
+import com.knot.backend.global.config.ChatStreamingProperties;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -21,9 +22,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/conversations")
 @RequiredArgsConstructor
 public class ChatMessageController {
-    private static final long SSE_TIMEOUT_MILLIS = 30_000L;
-
     private final ChatMessageService chatMessageService;
+    private final ChatStreamingProperties chatStreamingProperties;
 
     @PostMapping(path = "/{sessionId}/messages", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter sendMessage(
@@ -31,7 +31,7 @@ public class ChatMessageController {
             @Valid @RequestBody SendChatMessageRequest request,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
-        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        SseEmitter emitter = new SseEmitter(chatStreamingProperties.timeoutMillis());
         ChatStreamListener listener = new ChatSseStreamListener(emitter);
         ChatStreamHandle handle = chatMessageService.sendMessage(
                 sessionId,

--- a/backend/src/main/java/com/knot/backend/global/config/ChatStreamingConfig.java
+++ b/backend/src/main/java/com/knot/backend/global/config/ChatStreamingConfig.java
@@ -1,11 +1,13 @@
 package com.knot.backend.global.config;
 
 import java.util.concurrent.Executor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
+@EnableConfigurationProperties(ChatStreamingProperties.class)
 public class ChatStreamingConfig {
 
     @Bean(name = "chatStreamExecutor")

--- a/backend/src/main/java/com/knot/backend/global/config/ChatStreamingProperties.java
+++ b/backend/src/main/java/com/knot/backend/global/config/ChatStreamingProperties.java
@@ -1,0 +1,24 @@
+package com.knot.backend.global.config;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "chat.streaming")
+public class ChatStreamingProperties {
+    private Duration timeout = Duration.ofSeconds(150);
+
+    public long timeoutMillis() {
+        if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+            throw new IllegalStateException("chat.streaming.timeout must be positive");
+        }
+        long timeoutMillis = timeout.toMillis();
+        if (timeoutMillis <= 0) {
+            throw new IllegalStateException("chat.streaming.timeout must be at least one millisecond");
+        }
+        return timeoutMillis;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -34,6 +34,7 @@ spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_
 spring.security.oauth2.client.registration.github.scope=read:user
 
 # LLM (fake is the safe local default; enable openai-compatible explicitly)
+chat.streaming.timeout=${CHAT_STREAMING_TIMEOUT:PT150S}
 llm.provider=${LLM_PROVIDER:fake}
 llm.base-uri=${LLM_BASE_URI:http://localhost:1234/v1}
 llm.api-key=${LLM_API_KEY:}

--- a/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageControllerTest.java
+++ b/backend/src/test/java/com/knot/backend/chat/presentation/ChatMessageControllerTest.java
@@ -13,6 +13,8 @@ import com.knot.backend.chat.application.ChatStreamHandle;
 import com.knot.backend.chat.domain.ChatErrorCode;
 import com.knot.backend.chat.domain.ChatException;
 import com.knot.backend.chat.presentation.dto.request.SendChatMessageRequest;
+import com.knot.backend.global.config.ChatStreamingProperties;
+import java.time.Duration;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +27,12 @@ class ChatMessageControllerTest {
     void sendMessage_success() {
         // given
         ChatMessageService service = mock(ChatMessageService.class);
-        ChatMessageController controller = new ChatMessageController(service);
+        ChatStreamingProperties properties = new ChatStreamingProperties();
+        properties.setTimeout(Duration.ofSeconds(90));
+        ChatMessageController controller = new ChatMessageController(
+                service,
+                properties
+        );
         when(
                 service.sendMessage(
                         anyLong(),
@@ -49,6 +56,7 @@ class ChatMessageControllerTest {
 
         // then
         assertThat(result).isNotNull();
+        assertThat(result.getTimeout()).isEqualTo(90_000L);
     }
 
     @Test
@@ -56,7 +64,10 @@ class ChatMessageControllerTest {
     void sendMessage_failure_documentsNotReady() {
         // given
         ChatMessageService service = mock(ChatMessageService.class);
-        ChatMessageController controller = new ChatMessageController(service);
+        ChatMessageController controller = new ChatMessageController(
+                service,
+                new ChatStreamingProperties()
+        );
         when(
                 service.sendMessage(
                         anyLong(),

--- a/backend/src/test/java/com/knot/backend/global/config/ChatStreamingPropertiesTest.java
+++ b/backend/src/test/java/com/knot/backend/global/config/ChatStreamingPropertiesTest.java
@@ -1,0 +1,33 @@
+package com.knot.backend.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ChatStreamingPropertiesTest {
+
+    @Test
+    @DisplayName("양수 timeout을 밀리초로 변환한다")
+    void timeoutMillis_success() {
+        // given
+        ChatStreamingProperties properties = new ChatStreamingProperties();
+        properties.setTimeout(Duration.ofSeconds(90));
+
+        // when & then
+        assertThat(properties.timeoutMillis()).isEqualTo(90_000L);
+    }
+
+    @Test
+    @DisplayName("0 이하 timeout은 거부한다")
+    void timeoutMillis_failure_nonPositive() {
+        // given
+        ChatStreamingProperties properties = new ChatStreamingProperties();
+        properties.setTimeout(Duration.ZERO);
+
+        // when & then
+        assertThatThrownBy(properties::timeoutMillis).isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #336

## 작업 내용

- `SseEmitter`의 30초 하드코딩 timeout을 `chat.streaming.timeout` 설정으로 분리
- 기본 timeout을 150초로 설정하고 `CHAT_STREAMING_TIMEOUT` 환경변수로 조정 가능하도록 구성
- 양수 timeout 검증 및 밀리초 변환 계약 추가
- 기존 timeout/error/completion 및 취소·정리 lifecycle 유지
- controller와 설정 properties 테스트 추가

## 참고 사항

- LLM stream/Future/active registry 정리는 기존 `ChatStreamHandle` lifecycle을 그대로 사용한다.
- Qwen reasoning 응답 처리는 별도 PR #353 / Issue #352 범위다.

## 검증

- `./gradlew check --no-daemon`
- `./gradlew bootJar --no-daemon`
- `./gradlew spotlessCheck`
- `git diff --check origin/develop...HEAD`

## 커밋

- `5c7491d2 test: 채팅 SSE timeout 설정 계약 추가`
- `fb79c560 fix: 채팅 SSE timeout 경계 설정`
